### PR TITLE
GUI responsiveness / menu clutter

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -190,6 +190,7 @@ Rectangle {
                             from: 0 - target.width
                             to: 0
                             duration: 300
+                            easing.type: Easing.OutCubic
                         }
                         PropertyAnimation {
                             target: exitItem
@@ -197,6 +198,7 @@ Rectangle {
                             from: 0
                             to: target.width
                             duration: 300
+                            easing.type: Easing.OutCubic
                         }
                     }
                 }

--- a/components/MenuButton.qml
+++ b/components/MenuButton.qml
@@ -57,7 +57,7 @@ Rectangle {
 
     color: checked ? "#FFFFFF" : "#1C1C1C"
     property bool present: !under || under.checked || checked || under.numSelectedChildren > 0
-    height: present ? ((appWindow.height >= 800) ? 64 * scaleRatio  : 52 * scaleRatio ) : 0
+    height: present ? ((appWindow.height >= 800) ? 48 * scaleRatio  : 36 * scaleRatio ) : 0
 
     transform: Scale {
         yScale: button.present ? 1 : 0
@@ -88,13 +88,13 @@ Rectangle {
         Rectangle {
             id: dot
             anchors.centerIn: parent
-            width: 16 * scaleRatio
+            width: 14 * scaleRatio
             height: width
             radius: height / 2
 
             Rectangle {
                 anchors.centerIn: parent
-                width: 12 * scaleRatio
+                width: 10 * scaleRatio
                 height: width
                 radius: height / 2
                 color: "#1C1C1C"
@@ -135,7 +135,7 @@ Rectangle {
         anchors.left: parent.left
         anchors.leftMargin: parent.getOffset() + 50 * scaleRatio
         font.family: "Arial"
-        font.pixelSize: 18 * scaleRatio
+        font.pixelSize: 16 * scaleRatio
         color: parent.checked ? "#000000" : "#FFFFFF"
     }
 

--- a/components/MenuButton.qml
+++ b/components/MenuButton.qml
@@ -63,13 +63,13 @@ Rectangle {
         yScale: button.present ? 1 : 0
 
         Behavior on yScale {
-            NumberAnimation { duration: 500; easing.type: Easing.InOutCubic }
+            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
         }
     }
 
     Behavior on height {
         SequentialAnimation {
-            NumberAnimation { duration: 500; easing.type: Easing.InOutCubic }
+            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
         }
     }
 


### PR DESCRIPTION
Addresses 3 things:

- The menu buttons are quite large in height and font size. I've decreased them to 48px and 16px respectively
- Menu button collapse animation decreased to `200ms` and changed easing to `Easing.OutCubic`
- Added easing to page/panel switching, again `Easing.OutCubic`

Benefits:

- Less height needed to draw the menu
- Less 'in your face' buttons
- Smoother animations for the menu and panel selection

Can provide .gif, but couldnt get `peek` to work
