### PR TITLE
Bugfix with tx proof + update

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -65,8 +65,8 @@ Rectangle {
     signal paymentClicked(string address, string paymentId, string amount, int mixinCount, int priority, string description)
     signal sweepUnmixableClicked()
     signal generatePaymentIdInvoked()
-    signal getTxProofClicked(string txid, string address, string message);
-    signal checkTxProofClicked(string txid, string address, string message, string signature);
+    signal getProofClicked(string txid, string address, string message);
+    signal checkProofClicked(string txid, string address, string message, string signature);
 
     color: "#F0EEEE"
 

--- a/main.qml
+++ b/main.qml
@@ -243,8 +243,8 @@ ApplicationWindow {
             currentWallet.connectionStatusChanged.disconnect(onWalletConnectionStatusChanged)
             middlePanel.paymentClicked.disconnect(handlePayment);
             middlePanel.sweepUnmixableClicked.disconnect(handleSweepUnmixable);
-            middlePanel.getTxProofClicked.disconnect(handleGetTxProof);
-            middlePanel.checkTxProofClicked.disconnect(handleCheckTxProof);
+            middlePanel.getProofClicked.disconnect(handleGetProof);
+            middlePanel.checkProofClicked.disconnect(handleCheckProof);
         }
 
         currentWallet = undefined;
@@ -276,8 +276,8 @@ ApplicationWindow {
         currentWallet.connectionStatusChanged.connect(onWalletConnectionStatusChanged)
         middlePanel.paymentClicked.connect(handlePayment);
         middlePanel.sweepUnmixableClicked.connect(handleSweepUnmixable);
-        middlePanel.getTxProofClicked.connect(handleGetTxProof);
-        middlePanel.checkTxProofClicked.connect(handleCheckTxProof);
+        middlePanel.getProofClicked.connect(handleGetProof);
+        middlePanel.checkProofClicked.connect(handleCheckProof);
 
 
         console.log("Recovering from seed: ", persistentSettings.is_recovering)
@@ -757,8 +757,8 @@ ApplicationWindow {
         currentWallet.store();
     }
 
-    // called on "getTxProof"
-    function handleGetTxProof(txid, address, message) {
+    // called on "getProof"
+    function handleGetProof(txid, address, message) {
         console.log("Getting payment proof: ")
         console.log("\ttxid: ", txid,
                     ", address: ", address,
@@ -778,8 +778,8 @@ ApplicationWindow {
         informationPopup.open()
     }
 
-    // called on "checkTxProof"
-    function handleCheckTxProof(txid, address, message, signature) {
+    // called on "checkProof"
+    function handleCheckProof(txid, address, message, signature) {
         console.log("Checking payment proof: ")
         console.log("\ttxid: ", txid,
                     ", address: ", address,

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -64,8 +64,16 @@ Rectangle {
     }
 
     function checkSignature(signature) {
-        return signature.startsWith("OutProofV") && check256(signature, 142) ||
-               signature.startsWith("InProofV")  && check256(signature, 141)
+        if (signature.startsWith("OutProofV")) {
+            if ((signature.length - 10) % 132 != 0)
+                return false;
+            return check256(signature, signature.length);
+        } else if (signature.startsWith("InProofV")) {
+            if ((signature.length - 9) % 132 != 0)
+                return false;
+            return check256(signature, signature.length);
+        }
+        return false;
     }
 
     /* main layout */

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -506,11 +506,10 @@ QString Wallet::checkTxKey(const QString &txid, const QString &tx_key, const QSt
 
 QString Wallet::getTxProof(const QString &txid, const QString &address, const QString &message) const
 {
-    std::string error_str;
-    QString result = QString::fromStdString(m_walletImpl->getTxProof(txid.toStdString(), address.toStdString(), message.toStdString(), error_str));
-    if (!error_str.empty())
-        result = QString::fromStdString("error|" + error_str);
-    return result;
+    std::string result = m_walletImpl->getTxProof(txid.toStdString(), address.toStdString(), message.toStdString());
+    if (result.empty())
+        result = "error|" + m_walletImpl->errorString();
+    return QString::fromStdString(result);
 }
 
 QString Wallet::checkTxProof(const QString &txid, const QString &address, const QString &message, const QString &signature)


### PR DESCRIPTION
Fixed stupid mistype of function names.
Also `getTxProof` handles failure cases with C++ exception instead of additional string arg.