### PR TITLE
Esperanto fixes

### DIFF
--- a/translations/monero-core_eo.ts
+++ b/translations/monero-core_eo.ts
@@ -4,67 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Aldoni novan kontakton</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QR kodo</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation>Qr Kodo</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>paga-ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="105"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation>&lt;b&gt;Paga-ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Unika uzantnomo uzita en&lt;br/&gt;via adresaro. Tiu informo ne sendiĝos a&lt;br/&gt;kun la transakcio</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Algluu 64 deksesumajn signojn</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Priskribo &lt;font size=&apos;2&apos;&gt;(Opcia)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Donu nomon aŭ priskribon al ĉi tiu enigo</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Aldoni</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Nevalida adreso</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Ne sukcesas krei enigon</translation>
     </message>
@@ -80,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Paga-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -122,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Komenco de la demono post %1 sekundoj</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -135,9 +135,6 @@
         <source>Use custom settings</source>
         <translation>Uzi proprajn agordojn</translation>
     </message>
-</context>
-<context>
-    <name>DaemonProgress</name>
 </context>
 <context>
     <name>Dashboard</name>
@@ -193,43 +190,38 @@
         <translation> selektita: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="147"/>
-        <source>&lt;b&gt;Total amount of selected payments&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Totala kvanto de selektitaj pagoj&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtri</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Tajpu por inkrementa serĉo...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Dato: de la...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>ĝis la...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Sperta filtrado</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Transakcia tipo</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Kvanto: de...</translation>
     </message>
@@ -243,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Paga-ID:</translation>
     </message>
@@ -255,7 +247,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx key:</source>
-        <translation>Tr ŝlosilo</translation>
+        <translation>Tr ŝlosilo:</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="51"/>
@@ -268,150 +260,279 @@
         <translation>Destinoj:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Detaloj</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
-        <translation>Blokalteco</translation>
+        <translation>Blokalteco:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 konfirmoj)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation>(%1/%2 konfirmoj)</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NEKONFIRMITA</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="263"/>
         <source>PENDING</source>
         <translation>OKAZONTE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="292"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="384"/>
         <source>Fee</source>
         <translation>Kosto</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="349"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation>Tr ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation>Paga-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation>Tr ŝlosilo:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation>Tr noto:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation>Destinoj:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation>Ne plu da rezultoj</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation>(%1/%2 konfirmoj)</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation>NEKONFIRMITA</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="153"/>
+        <source>PENDING</source>
+        <translation>OKAZONTE</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation>Mnemonikan semon</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation>Ŝlosiloj</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation>Sekreta vidŝlosilo</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation>Publika vidŝlosilo</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation>Sekreta elspezŝlosilo</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation>Publika elspezŝlosilo</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="135"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="180"/>
         <source>Unlocked balance</source>
         <translation>Disponebla saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="283"/>
         <source>Send</source>
         <translation>Sendu</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="333"/>
         <source>Receive</source>
         <translation>Ricevi</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="334"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="427"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="428"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="357"/>
         <source>History</source>
         <translation>Historio</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
         <source>Testnet</source>
         <translation>Testreto</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="308"/>
         <source>Address book</source>
         <translation>Adresaro</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="309"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="358"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="380"/>
         <source>Advanced</source>
         <translation>Spertaĵoj</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="381"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="403"/>
         <source>Mining</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="404"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Kontrolu pagon</translation>
+        <location filename="../LeftPanel.qml" line="496"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="497"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="451"/>
         <source>Sign/verify</source>
         <translation>Subskribi/kontroli</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="452"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="474"/>
         <source>Settings</source>
         <translation>Agordoj</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="475"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="284"/>
         <source>S</source>
         <translation>A</translation>
     </message>
@@ -419,12 +540,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Disponebla saldo</translation>
     </message>
@@ -432,87 +553,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Memstara minado</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(nur disponeblas por lokaj demonoj)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Mini per via komputilo helpas plisekurigi la Monero-reton. Ju pli da homoj minas, des mapli atakebla iĝas la reto, kaj ĉiu malgranda helpo utilas. &lt;br&gt; &lt;br&gt;La minado ankaŭ donas al vi etan ŝancon ricevi rekompencon je Moneroj. Via komputilo kreos haketojn, serĉante bloksolvojn. Se vi trovas blokon, vi ricevos la asociitan rekompencon. Bonŝancon!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>Minaj procezfadenoj</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(opcia)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Fona minado (eksperimenta)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Ebligi la minadon eĉ kiam uzante la baterion</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Adminitri la minilon</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Komenci la minadon</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Eraro dum la ekminado</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Neeblis komenci la minadon</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>La minado nur disponeblas ĉe lokaj demonoj. Lanĉu lokan demonon por ebligi la minadon</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Haltigi la minadon</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Stato: ne minante</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Minante je %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Ne minante</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Stato: </translation>
     </message>
@@ -520,7 +641,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Disponebla Saldo:</translation>
     </message>
@@ -528,12 +649,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Retstatuso</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Konektita</translation>
     </message>
@@ -543,17 +664,22 @@
         <translation>Sinkroniĝante</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Malĝusta versio</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Malkonektita</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Malĝusta retstatuso</translation>
     </message>
@@ -561,24 +687,24 @@
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="87"/>
         <source>Please enter wallet password</source>
         <translation>Bonvolu entajpi monujpasvorton</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="87"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Bonvolu entajpi monujpasvorton por:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="156"/>
+        <location filename="../components/PasswordDialog.qml" line="155"/>
         <source>Cancel</source>
         <translation>Nuligi</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Bone</translation>
+        <location filename="../components/PasswordDialog.qml" line="168"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -602,19 +728,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Starigante konekton...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Restantaj blokoj: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Sinkronigante blokojn</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -632,7 +766,7 @@
     <message>
         <location filename="../pages/Receive.qml" line="129"/>
         <source>in the txpool: %1</source>
-        <translation>En la transakciujo</translation>
+        <translation>En la transakciujo: %1</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="136"/>
@@ -662,116 +796,120 @@
     <message>
         <location filename="../pages/Receive.qml" line="156"/>
         <source> with more money (%1)</source>
-        <translation>kun pli da mono (1%)</translation>
+        <translation>kun pli da mono (%1)</translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="158"/>
         <source> with not enough money (%1)</source>
-        <translation>kun nesufiĉe da mono (1%)</translation>
+        <translation>kun nesufiĉe da mono (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="189"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="196"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Nurlegebla monujadreso montrata ĉi tie</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="208"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="229"/>
         <source>16 hexadecimal characters</source>
         <translation>16 deksesumaj signoj</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="241"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="264"/>
         <source>Clear</source>
         <translation>Vakigi</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="273"/>
         <source>Integrated address</source>
         <translation>Integrita adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="282"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generi pagan ID-on por integrita adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="294"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="384"/>
         <source>Save QrCode</source>
         <translation>Konservi la QR-kodon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="385"/>
         <source>Failed to save QrCode to </source>
         <translation>Malsukcesis konservi la QR-kodon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="396"/>
         <source>Save As</source>
         <translation>Konservi Kiel</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="221"/>
         <source>Payment ID</source>
         <translation>Paga-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="306"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="314"/>
         <source>Amount to receive</source>
         <translation>Ricevenda kvanto</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
+        <location filename="../pages/Receive.qml" line="334"/>
         <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
         <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Sekvi &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;helpo&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="339"/>
         <source>Tracking payments</source>
         <translation>Sekvado de pagoj</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="340"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
-
-        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Jen simpla pago-sekvilo:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Alklaku "Generi" por krei hazardan pago-IDon por nova kliento.&lt;/p&gt; &lt;p&gt;Lasu vian klienton skani tiun QR-kodon por plenumi la pagon (se tiu kliento havas QR-taŭgan aparaton aŭ programon).&lt;/p&gt;&lt;p&gt;Ĉi-paĝo aŭtomate skanos la blokĉenon kaj transakciaron je transakcioj kiuj uzas tiun QR-kodon. Se vi enigas kvanton, la pago-sekvilo ankaŭ kontrolos ke la sumo de la envenantaj transakcioj atingas tiun kvanton.&lt;/p&gt;Vi povas laŭplaĉe akcepti nekonfirmitajn transakciojn aŭ ne. Ili verŝajne konfirmiĝos pli malpli rapide, sed ekzistas ebleco ke ne, do se temas pri grandaj valoroj vi prefere atendu unu konfirmon aŭ pli.&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Jen simpla pago-sekvilo:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Alklaku &quot;Generi&quot; por krei hazardan pago-IDon por nova kliento.&lt;/p&gt; &lt;p&gt;Lasu vian klienton skani tiun QR-kodon por plenumi la pagon (se tiu kliento havas QR-taŭgan aparaton aŭ programon).&lt;/p&gt;&lt;p&gt;Ĉi-paĝo aŭtomate skanos la blokĉenon kaj transakciaron je transakcioj kiuj uzas tiun QR-kodon. Se vi enigas kvanton, la pago-sekvilo ankaŭ kontrolos ke la sumo de la envenantaj transakcioj atingas tiun kvanton.&lt;/p&gt;Vi povas laŭplaĉe akcepti nekonfirmitajn transakciojn aŭ ne. Ili verŝajne konfirmiĝos pli malpli rapide, sed ekzistas ebleco ke ne, do se temas pri grandaj valoroj vi prefere atendu unu konfirmon aŭ pli.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="253"/>
         <source>Generate</source>
         <translation>Generi</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Novaĵoj</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Helpo</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Pri</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation>Pordo</translation>
     </message>
 </context>
 <context>
@@ -790,228 +928,236 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished">Monujsemo &amp; ŝlosiloj</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished">Sekreta vidŝlosilo</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished">Publika vidŝlosilo</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished">Sekreta elspezŝlosilo</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished">Publika elspezŝlosilo</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
-        <source>Wrong password</source>
-        <translation>Malĝusta pasvorto</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Demonadreso</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Administri monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Fermi la monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Krei nurlegeblan monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Administri la demonon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Enŝalti la demonon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Haltigi la demonon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="579"/>
         <source>Daemon log</source>
         <translation>Demontaglibro</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Gastignomo / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="259"/>
         <source>Show status</source>
         <translation>Montri statuson</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Demonaj startflagoj</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="284"/>
+        <location filename="../pages/Settings.qml" line="314"/>
         <source>(optional)</source>
         <translation>(opcia)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Montri la semon &amp; ŝlosilojn</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Reskanu la monujsaldon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Eraro: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Informo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Sukcese reskanis la elspezitajn eligojn</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="277"/>
         <source>Blockchain location</source>
         <translation>Pozicio de la blokĉeno</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Pordo</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Ensaluti (opcie)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="337"/>
         <source>Username</source>
         <translation>Uzantnomo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="346"/>
         <source>Password</source>
         <translation>Pasvorto</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="371"/>
         <source>Connect</source>
         <translation>Konekti</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="472"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="497"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="537"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="538"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="566"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="570"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="588"/>
         <source>Please choose a folder</source>
         <translation>Bonvolu elekti dosierujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="597"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="600"/>
         <source>Error: Filesystem is read only</source>
         <translation>Eraro: dosiersistemo estas nurlegebla</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="604"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
-        <translation>Averto: estas nur 1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
+        <translation>Averto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="606"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
-        <translation>Noto: estas nur 1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
+        <translation>Noto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="610"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
-        <translation>Noto : lmdb-dosierujo ne troviĝis. Nova dosierujo kreiĝos.</translation>
+        <translation>Noto: lmdb-dosierujo ne troviĝis. Nova dosierujo kreiĝos.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="546"/>
+        <location filename="../pages/Settings.qml" line="614"/>
         <source>Cancel</source>
         <translation>Nuligi</translation>
     </message>
     <message>
+        <location filename="../pages/Settings.qml" line="524"/>
         <source>Save</source>
         <translation>Konservi</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="395"/>
         <source>Layout settings</source>
         <translation>Aspektagordoj</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="175"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="189"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="207"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="213"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="231"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="246"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="307"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="325"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="356"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="413"/>
         <source>Custom decorations</source>
         <translation>Propraj dekoracioj</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="424"/>
         <source>Log level</source>
         <translation>Taglibro-nivelo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="456"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Versio</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="486"/>
         <source>GUI version: </source>
         <translation>GUI versio: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="491"/>
         <source>Embedded Monero version: </source>
         <translation>Enkorpigita Monera versio: </translation>
     </message>
@@ -1019,105 +1165,105 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Bona subskribo</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Tio ĉi estas bona subskribo</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Malbona subskribo</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Tiu ĉi subskribo ne validiĝis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Subskribu mesaĝon aŭ dosierenhavojn per via adreso:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Mesaĝo:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Subskribenda mesaĝo</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Subskribi</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Bonvolu elekti subskribendan dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Selekti</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Kontroli</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Bonvolu elekti kontrolendan dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Subskribenda adreso &lt;font size=&apos;2&apos;&gt;  (Algluu ĝin ĉi tien, aŭ selektu ĝin en la &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresaro&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="386"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: %1px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;%2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;%3&apos;&gt; )&lt;/font&gt;</source>
+        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: %1px;}&lt;/style&gt;                            Subskribenda adreso &lt;font size=&apos;%2&apos;&gt;  (Algluu ĝin ĉi tien, aŭ selektu ĝin en la &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresaro&lt;/a&gt;&lt;font size=&apos;%3&apos;&gt; )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Aŭ dosiero:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Dosiernomo kun subskribenda mesaĝo</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="412"/>
+        <location filename="../pages/Sign.qml" line="417"/>
         <source>Signature</source>
         <translation>Subskribo</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Kontroli subskribon de mesaĝo aŭ dosiero el adreso:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Kontrolenda mesaĝo</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Dosiernomo kun kontrolenda mesaĝo</translation>
     </message>
@@ -1125,65 +1271,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Bone</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Nuligi</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation>BONE</translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Malalta (x1 kosto)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Meza (x20 kosto)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Alta (x166 kosto)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Malrapida (x0.25 kosto)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Antaŭsupoza (x1 kosto)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Rapida (x5 kosto)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
-        <translation type="unfinished"></translation>
+        <translation>Plej rapida (x41.5 fee)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>ĈIUJ</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Sendita</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Ricevita</translation>
     </message>
@@ -1238,16 +1394,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normala</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Meza</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Alta</translation>
     </message>
@@ -1262,7 +1413,7 @@
     <message>
         <location filename="../pages/Transfer.qml" line="78"/>
         <source>Privacy level (ringsize %1)</source>
-        <translation>Nivelo de privateco</translation>
+        <translation>Nivelo de privateco (ringsize %1)</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="44"/>
@@ -1270,219 +1421,224 @@
         <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Enŝalti la demonon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="126"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="178"/>
         <source>Transaction priority</source>
         <translation>Prioritato de transakcio</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="161"/>
         <source>All</source>
         <translation>Ĉiuj</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
+        <location filename="../pages/Transfer.qml" line="191"/>
         <source>Low (x1 fee)</source>
         <translation>Malalta (x1 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
+        <location filename="../pages/Transfer.qml" line="192"/>
         <source>Medium (x20 fee)</source>
         <translation>Meza (x20 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
+        <location filename="../pages/Transfer.qml" line="193"/>
         <source>High (x166 fee)</source>
         <translation>Alta (x166 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="200"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Malrapida (x0.25 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="201"/>
         <source>Default (x1 fee)</source>
         <translation>Antaŭsupoza (x1 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="202"/>
         <source>Fast (x5 fee)</source>
         <translation>Rapida (x5 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="203"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Plej rapida (x41.5 fee)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adreso &lt;font size=&apos;2&apos;&gt;  (Algluu ĉi tie aŭ selektu el la &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresaro&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="239"/>
         <source>QR Code</source>
-        <translation>QR kodo</translation>
+        <translation>QR Kodo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="263"/>
         <source>Resolve</source>
         <translation>Solvi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="281"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Neniu valida Adreso troviĝis je ĉi tiu OpenAlias adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="286"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>La adreso troviĝis, sed la DNSSEC-subskriboj ne povis esti kontrolitaj, do la adreso eble estas mistifikita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="288"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Neniu valida Adreso troviĝis je ĉi tiu OpenAlias adreso, sed la DNSSEC subskriboj ne povis esti kontrolitaj, do la adreso eble estas mistifikita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="291"/>
+        <location filename="../pages/Transfer.qml" line="294"/>
         <source>Internal error</source>
         <translation>Interna eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="297"/>
         <source>No address found</source>
         <translation>Neniu adreso trovita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="316"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Priskribo &lt;font size=&apos;2&apos;&gt;( Opcia )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="322"/>
         <source>Saved to local wallet history</source>
         <translation>Konservita en la loka monujhistorio</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="330"/>
         <source>Send</source>
         <translation>Sendi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="395"/>
         <source>Show advanced options</source>
         <translation>Montru spertajn agordojn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="423"/>
         <source>Transaction cost</source>
         <translation>Transakcia kosto</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="458"/>
         <source>Sweep Unmixable</source>
         <translation>Balai Nemikseblaĵojn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="472"/>
         <source>Create tx file</source>
         <translation>Kreu=i tr dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="494"/>
         <source>Sign tx file</source>
         <translation>Subskribi tr dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="508"/>
         <source>Submit tx file</source>
         <translation>Sendi tr dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="541"/>
+        <location filename="../pages/Transfer.qml" line="597"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
+        <source>
+Number of transactions: </source>
+        <translation>Kvanto de transakcioj: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="551"/>
+        <source>
+Transaction #%1</source>
+        <translation>
+Transakcion #%1</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="552"/>
+        <source>
+Recipient: </source>
+        <translation>
+Ricevanto: </translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="603"/>
         <source>Information</source>
         <translation>Informo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="530"/>
+        <location filename="../pages/Transfer.qml" line="591"/>
         <source>Please choose a file</source>
         <translation>Bonvolu elekti dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="225"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                          Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adreso &lt;font size=&apos;2&apos;&gt;  (Algluu ĉi tie aŭ selektu el la &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresaro&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="542"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Ne eblas ŝargi nesubskribitan transakcion: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
-        <source>Number of transactions: </source>
-        <translation>Kvanto de transakcioj: </translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
-        <source>Transaction #%1</source>
-        <translation>Transakcio #%1</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
-        <source>Recipient: </source>
-        <translation>Ricevanto: </translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="553"/>
         <source>
 payment ID: </source>
         <translation>Paga ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="554"/>
         <source>
 Amount: </source>
         <translation>Kvanto: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="555"/>
         <source>
 Fee: </source>
         <translation>Kosto: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>
 Ringsize: </source>
         <translation>Ringgrandeco: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="570"/>
         <source>Confirmation</source>
         <translation>Konfirmo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="598"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Ne eblas sendi transakcion: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="604"/>
         <source>Money sent successfully</source>
         <translation>Mono sukcese sendita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="673"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>La konektita demono ne kongruas kun la GUI.
@@ -1494,23 +1650,23 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
+        <location filename="../pages/Transfer.qml" line="670"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>La monujo ne estas konektita kun la demono</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="678"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Atendante la finon de demonsinkroniĝado</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="305"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Paga-ID &lt;font size=&apos;2&apos;&gt;( Opcia )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="311"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 aŭ 64 deksesuma karaktroj</translation>
     </message>
@@ -1518,64 +1674,75 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Kontroli ke tria partio faris pagon provizante:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - ricevantadreson</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - la transakcio-IDon</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - la sekretan transakcio-ŝlosilon provizitan de la sendinto</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="343"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Se pago havis plurajn transakciojn, ĉiu devas esti kontrolita kaj la rezultoj kombinitaj.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="128"/>
+        <location filename="../pages/TxKey.qml" line="239"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="93"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="135"/>
+        <location filename="../pages/TxKey.qml" line="246"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Monujadreso de ricevanto</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="154"/>
+        <location filename="../pages/TxKey.qml" line="265"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="272"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="181"/>
+        <source>Generate</source>
+        <translation>Generi</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="204"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="291"/>
+        <source>Signature</source>
+        <translation>Subskribo</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="299"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="101"/>
+        <location filename="../pages/TxKey.qml" line="212"/>
         <source>Transaction ID</source>
         <translation>Transakcio-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="108"/>
+        <location filename="../pages/TxKey.qml" line="219"/>
         <source>Paste tx ID</source>
         <translation>Algluu Tr ID-on</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Alglui Tr ŝlosilon</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="320"/>
         <source>Check</source>
         <translation>Kontroli</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Transakcia ŝlosilo</translation>
     </message>
 </context>
 <context>
@@ -1630,6 +1797,39 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Krei novan monujon</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation>Pozicio de la blokĉeno</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation>(opcia)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1735,43 +1935,43 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Monujo kun la sama nomo jam ekzistas. Bonvolu ŝangi la monujnomon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Ne-askiaj karaktroj ne permesiĝas en la vojnomo aŭ kontonomo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>UZU MONERON</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Krei monujon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Sukcese</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>La nurlegebla monujo kreiĝis. Vi povas malfermi ĝin se vi fermas la aktualan monujon kaj klakas la &quot;Malfermu monujon el dosiero&quot; opcion, kaj elektas la nurlegeblan monujon en: %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Aborti</translation>
     </message>
@@ -1779,47 +1979,52 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Monujnomo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Restaŭri per semo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Restaŭri per ŝlosiloj</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Monujadreso (publika)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Vidŝlosilo (privata)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Elspezŝlosilo (privata)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Restaŭralteco (malnepra)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Via monujo estas konservita en</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Bonvolu elekti dosierujon</translation>
     </message>
@@ -1832,7 +2037,12 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
         <translation>Entajpu vian 25-vortan mnemonikan semon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Estas &lt;b&gt;gravege&lt;/b&gt; noti vian semon kaj konservi ĝin sekretan. Estas la unusola bakupo por restaŭri vian monujon.</translation>
     </message>
@@ -1840,37 +2050,32 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Bonvenon al Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Bonvolu elekti unu el la sekvaj opcioj:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Krei novan monujon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Restaŭri monujon de ŝlosilojn aŭ mnemonikan semon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Malfermi monujon el dosiero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Propra demonadreso (opcia)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testreto</translation>
     </message>
@@ -1884,7 +2089,7 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
         <translation>Donu pasvorton al via monujo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation>&lt;br&gt;Sciu ke tiu pasvorto nerestaŭreblas, kaj se vi forgesas ĝin, vi devos restaŭri vian monujon el la 25-vorta mnemoniksemo.&lt;br/&gt;&lt;br/&gt;
@@ -1894,12 +2099,12 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Pasvorto</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Konfirmu pasvorton</translation>
     </message>
@@ -1907,7 +2112,7 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Restaŭri monujon</translation>
     </message>
@@ -1915,12 +2120,12 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Bonvenon al Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Bonvolu elekti lingvon kaj regionan formaton</translation>
     </message>
@@ -1928,233 +2133,296 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="344"/>
+        <location filename="../main.qml" line="555"/>
+        <location filename="../main.qml" line="567"/>
+        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="671"/>
+        <location filename="../main.qml" line="680"/>
+        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="816"/>
+        <location filename="../main.qml" line="1005"/>
+        <location filename="../main.qml" line="1164"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="345"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Ne sukcesis malfermi monujon: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="557"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Ne sukcesas krei transakcion: Malĝusta demonversio</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="568"/>
+        <location filename="../main.qml" line="681"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Ne malmikseblaj eligoj por balai</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="618"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Kvanto malĝustas: oni postulas nombron de %1 al %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="742"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Mono sendiĝis sukcese: %1 transakcio(j)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Pagkontrolo</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="805"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Tiu ĉi adreso ricevis %1 moneron; sed la transakcio ankoraŭ ne estas minata</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="812"/>
         <source>This address received nothing</source>
         <translation>Tiu ĉi adreso ricevis nenion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="559"/>
+        <location filename="../main.qml" line="672"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Ne sukcesas krei transakcion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="376"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Disponebla saldo (atendante blokon)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="376"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Disponebla saldo (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="376"/>
         <source>Unlocked balance</source>
         <translation>Disponebla saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="429"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="469"/>
         <source>Waiting for daemon to start...</source>
         <translation>Atendante komencon de la demono</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Atendante halton de la demono</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="500"/>
         <source>Daemon failed to start</source>
         <translation>Demono malsukcesis starti</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="501"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Bonvolu kontroli la taglibrojn de viaj monujo kaj demonlogo por eraroj. Vi ankaŭ povas provi komenci %1 permane.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="580"/>
+        <location filename="../main.qml" line="693"/>
         <source>Confirmation</source>
         <translation>Konfirmo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="581"/>
+        <location filename="../main.qml" line="694"/>
         <source>Please confirm transaction:
 </source>
         <translation>Bonvolu konfirmi transakcion: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="582"/>
         <source>
 Address: </source>
         <translation>Adreso: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="583"/>
         <source>
 Payment ID: </source>
         <translation>Paga ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="584"/>
+        <location filename="../main.qml" line="695"/>
         <source>
 
 Amount: </source>
         <translation>Kvanto: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="585"/>
+        <location filename="../main.qml" line="696"/>
         <source>
 Fee: </source>
         <translation>Kosto: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="586"/>
         <source>
 
 Ringsize: </source>
         <translation>Ringgrandeco: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="587"/>
         <source>
 Number of transactions: </source>
         <translation>Kvanto de transakcioj: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 
 Description: </source>
         <translation>Priskribo: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="768"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="771"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="797"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="800"/>
+        <source>Bad signature</source>
+        <translation>Malbona subskribo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1006"/>
+        <location filename="../main.qml" line="1165"/>
+        <source>Wrong password</source>
+        <translation>Malĝusta pasvorto</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1076"/>
+        <source>Warning</source>
+        <translation>Averto</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1079"/>
+        <source>Error: Filesystem is read only</source>
+        <translation>Eraro: dosiersistemo estas nurlegebla</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1081"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation>Averto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1083"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation>Noto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1085"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation>Noto: lmdb-dosierujo ne troviĝis. Nova dosierujo kreiĝos.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1089"/>
+        <source>Cancel</source>
+        <translation>Nuligi</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1566"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1579"/>
         <source>Daemon is running</source>
         <translation>Demono funkcias</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1580"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>La demono funkciantos en la fono kiam vi fermos la GUI.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1582"/>
         <source>Stop daemon</source>
         <translation>Haltigi demonon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1617"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Nova versio de monero-wallet-gui disponeblas:  %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="630"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Nesufiĉe da mono. Disponebla saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="733"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Mono ne sendeblas</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="736"/>
         <source>Information</source>
         <translation>Informo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="742"/>
         <source>Transaction saved to file: %1</source>
         <translation>La transakcio estas konservita en la dosiero %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="808"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Tiu adreso ricevis %1 monerojn, kun %2 konfirmo(j)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="825"/>
         <source>Balance (syncing)</source>
         <translation>Saldo (Sinkroniĝante)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="825"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1194"/>
         <source>Please wait...</source>
         <translation>Bonvolu atendi...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1218"/>
         <source>Program setup wizard</source>
         <translation>Programagordilo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1234"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1284"/>
         <source>send to the same destination</source>
         <translation>Sendu al la sama celo</translation>
     </message>


### PR DESCRIPTION
This PR follows up on #794
I ran the following command to update line numbers and remove obsolete translations:

    lupdate -no-obsolete -pro monero-wallet-gui.pro -ts translations/monero-core_eo.ts

Then I manually fixed a number of placeholder issues, translations marked as `type="unfinished"`, etc.