### PR TITLE
Left panel: add view only wallet label

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -91,13 +91,25 @@ Rectangle {
         }
 
         Text {
+            id: viewOnlyLabel
+            visible: viewOnly
+            text: qsTr("View Only") + translationManager.emptyString
+            anchors.top: logo.bottom
+            anchors.topMargin: 5
+            anchors.left: parent.left
+            anchors.leftMargin: 50
+            font.bold: true
+            color: "blue"
+        }
+
+        Text {
             id: testnetLabel
             visible: persistentSettings.testnet
             text: qsTr("Testnet") + translationManager.emptyString
             anchors.top: logo.bottom
             anchors.topMargin: 5
-            anchors.left: parent.left
-            anchors.leftMargin: 50
+            anchors.left: viewOnly ? viewOnlyLabel.right : parent.left
+            anchors.leftMargin: viewOnly ? 10 : 50
             font.bold: true
             color: "red"
         }


### PR DESCRIPTION
I took a look at the associated issue #887 where the user did not realize they were on a view only wallet and could not spend money directly.

With view only wallets you can create a transaction which you can then sign on a normal wallet and later submit via the view only wallet. It does this so that you can keep your main wallet offline if you want and just use it for signing transactions generated by the view wallet. 

I think the best call here then is just a label like the testnet one that appears if you're on the testnet under the Monero branding on the top left.

The changes were pretty straightforward to add one. I've included photos of the GUI here for mainnet, mainnet view only, testnet, testnet view only to see the changes more easily.

![mainnet](https://user-images.githubusercontent.com/1319304/33334205-1f49d04a-d437-11e7-9d12-f0785be33c30.png)
![mainnet-view](https://user-images.githubusercontent.com/1319304/33334207-1f62b736-d437-11e7-8445-c845b03c9524.png)
![testnet](https://user-images.githubusercontent.com/1319304/33334208-1f737fee-d437-11e7-8b1f-c9c0fee0dc7c.png)
![testnet-view](https://user-images.githubusercontent.com/1319304/33334209-1f87b8a6-d437-11e7-85f3-aec2a9ddd51c.png)

Note: this branch currently fails to build by itself due to master currently having a broken build. Pulling in the changes from this commit https://github.com/monero-project/monero-gui/pull/966/commits/d8f3a52378ad61ee0d81f156bd2fc15b8a66293c / PR #966 fixes it (which I did locally but stashed those for this PR). I'll rebase once the associated PR for that commit is merged into master.

Ref: #887