### PR TITLE
Switch Core with GUI in README.md, fix headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Copyright (c) 2014-2017, The Monero Project
 - Web: [getmonero.org](https://getmonero.org)
 - Forum: [forum.getmonero.org](https://forum.getmonero.org)
 - Mail: [dev@getmonero.org](mailto:dev@getmonero.org)
-- Github: [https://github.com/monero-project/monero-core](https://github.com/monero-project/monero-core)
+- Github: [https://github.com/monero-project/monero-gui](https://github.com/monero-project/monero-gui)
 - IRC: [#monero-dev on Freenode](irc://chat.freenode.net/#monero-dev)
 
-## Vulnerability Response
+## Vulnerability response
 
 - Our [Vulnerability Response Process](https://github.com/monero-project/meta/blob/master/VULNERABILITY_RESPONSE_PROCESS.md) encourages responsible disclosure
 - We are also available via [HackerOne](https://hackerone.com/monero)
@@ -25,23 +25,23 @@ Monero is a private, secure, untraceable, decentralised digital currency. You ar
 
 **Untraceability:** By taking advantage of ring signatures, a special property of a certain type of cryptography, Monero is able to ensure that transactions are not only untraceable, but have an optional measure of ambiguity that ensures that transactions cannot easily be tied back to an individual user or computer.
 
-## About this Project
+## About this project
 
 This is the GUI for the [core Monero implementation](https://github.com/monero-project/monero). It is open source and completely free to use without restrictions, except for those specified in the license agreement below. There are no restrictions on anyone creating an alternative implementation of Monero that uses the protocol and network in a compatible manner.
 
 As with many development projects, the repository on Github is considered to be the "staging" area for the latest changes. Before changes are merged into that branch on the main repository, they are tested by individual developers in their own branches, submitted as a pull request, and then subsequently tested by contributors who focus on testing and code reviews. That having been said, the repository should be carefully considered before using it in a production environment, unless there is a patch in the repository for a particular show-stopping issue you are experiencing. It is generally a better idea to use a tagged release for stability.
 
-## Supporting the Project
+## Supporting the project
 
 Monero development can be supported directly through donations.
 
-Both Monero and Bitcoin donations can be made to donate.getmonero.org if using a client that supports the [OpenAlias](https://openalias.org) standard
+Both Monero and Bitcoin donations can be made to **donate.getmonero.org** if using a client that supports the [OpenAlias](https://openalias.org) standard.
 
 The Monero donation address is: `44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A` (viewkey: `f359631075708155cc3d92a32b75a7d02a5dcf27756707b47a2b31b21c389501`)
 
 The Bitcoin donation address is: `1KTexdemPdxSBcG55heUuTjDRYqbC5ZL8H`
 
-Core development funding and/or some supporting services are also graciously provided by sponsors:
+GUI development funding and/or some supporting services are also graciously provided by sponsors:
 
 [<img width="80" src="https://static.getmonero.org/images/sponsors/mymonero.png"/>](https://mymonero.com)
 [<img width="150" src="https://static.getmonero.org/images/sponsors/kitware.png?1"/>](http://kitware.com)
@@ -57,7 +57,7 @@ There are also several mining pools that kindly donate a portion of their fees, 
 
 See [LICENSE](LICENSE).
 
-## Installing Monero Core from a Package
+## Installing the Monero GUI from a package
 
 Packages are available for
 
@@ -66,7 +66,7 @@ Packages are available for
 
 Packaging for your favorite distribution would be a welcome contribution!
 
-## Compiling Monero Core from Source
+## Compiling the Monero GUI from source
 
 ### On Linux:
 
@@ -82,13 +82,13 @@ Packaging for your favorite distribution would be a welcome contribution!
 
 	`sudo emerge app-arch/xz-utils app-doc/doxygen dev-cpp/gtest dev-libs/boost dev-libs/expat dev-libs/openssl dev-util/cmake media-gfx/graphviz net-dns/unbound net-libs/ldns net-libs/miniupnpc sys-libs/libunwind`
 
-2. Grab an up-to-date copy of the monero-core repository
+2. Grab an up-to-date copy of the monero-gui repository
 
-	`git clone https://github.com/monero-project/monero-core.git`
+	`git clone https://github.com/monero-project/monero-gui.git`
 
 3. Go into the repository
 
-	`cd monero-core`
+	`cd monero-gui`
 
 4. Install the GUI dependencies
 
@@ -158,13 +158,13 @@ The executable can be found in the build/release/bin folder.
 
     This is the directory where Qt 5.x is installed on **your** system
 
-6. Grab an up-to-date copy of the monero-core repository
+6. Grab an up-to-date copy of the monero-gui repository
 
-  `git clone https://github.com/monero-project/monero-core.git`
+  `git clone https://github.com/monero-project/monero-gui.git`
 
 7. Go into the repository
 
-  `cd monero-core`
+  `cd monero-gui`
 
 8. Start the build
 
@@ -189,7 +189,7 @@ More info: http://stackoverflow.com/a/35098040/1683164
 
 1. Install [msys2](http://msys2.github.io/), follow the instructions on that page on how to update packages to the latest versions
 
-2. Install monero dependencies as described in [monero documentation](https://github.com/monero-project/monero) into msys2 environment
+2. Install Monero dependencies as described in [monero documentation](https://github.com/monero-project/monero) into msys2 environment
    **As we only build application for x86, install only dependencies for x86 architecture (i686 in package name)**
    ```
    pacman -S mingw-w64-i686-toolchain make mingw-w64-i686-cmake mingw-w64-i686-boost
@@ -215,7 +215,7 @@ More info: http://stackoverflow.com/a/35098040/1683164
    Where ```%MSYS_ROOT%``` will be ```c:\msys32``` if your host OS is x86-based or ```c:\msys64``` if your host OS
    is x64-based
 
-6. Install the latest version of boost, specificly the required static libraries
+6. Install the latest version of boost, specifically the required static libraries
     ```
     cd
     wget http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.bz2
@@ -228,12 +228,12 @@ More info: http://stackoverflow.com/a/35098040/1683164
 7. Clone repository
     ```
     cd
-    git clone https://github.com/monero-project/monero-core.git
+    git clone https://github.com/monero-project/monero-gui.git
     ```
 
 8. Build the GUI
     ```
-    cd monero-core
+    cd monero-gui
     export PATH=$(ls -rd /c/Qt/5.[6,7,8]/mingw53_32/bin | head -1):$PATH
     ./build.sh
     cd build


### PR DESCRIPTION
Recently the GUI repo had its name changed from monero-core to monero-gui. This PR updates the build instructions and elsewhere with the new repo name and link.

This PR also seeks to put the heading capitalization policy inline with the main Monero readme. Capitalizing every single word in a heading begins to feel redundant and cumbersome when headings become long (and many are indeed quite long). A much better practice is capitalizing just the initial word. See: https://github.com/monero-project/monero/pull/2881