### PR TITLE
History: Properly label failed transactions

### DIFF
--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -260,6 +260,8 @@ ListView {
                             return blockHeight
                     if (!isOut)
                         return qsTr("UNCONFIRMED") + translationManager.emptyString
+                    if (isFailed)
+                        return qsTr("FAILED") + translationManager.emptyString
                     return qsTr("PENDING") + translationManager.emptyString
 
                 }

--- a/components/HistoryTableMobile.qml
+++ b/components/HistoryTableMobile.qml
@@ -150,6 +150,8 @@ ListView {
                                 return qsTr("(%1/%2 confirmations)").arg(confirmations).arg(confirmationsRequired)
                         if (!isOut)
                             return qsTr("UNCONFIRMED") + translationManager.emptyString
+                        if (isFailed)
+                            return qsTr("FAILED") + translationManager.emptyString
                         return qsTr("PENDING") + translationManager.emptyString
 
                     }


### PR DESCRIPTION
Small change that fixes #898 by showing failed when a transaction in the history has that status. Previously it showed pending in that state.

I was able to reproduce the bug by taking my view only wallet, creating a transaction, signing it on my regular wallet, and then attempting to submit the transaction twice via the view only wallet (if looking to testing it / reproduce the original bug).

![failed-transactions](https://user-images.githubusercontent.com/1319304/33722618-7616718c-db38-11e7-97e7-ef6f6275782d.png)