### PR TITLE
Password input: reset on failed input

### DIFF
--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -62,6 +62,7 @@ Item {
         show()
         root.visible = true;
         passwordInput.focus = true
+        passwordInput.text = ""
     }
 
     function close() {


### PR DESCRIPTION
Password input now resets on failed input. Previously it kept the invalid password on failure.

Simple change that fixes #865 as empties the contents of the password dialog on open. 

When the password is invalid it reopens the dialog https://github.com/monero-project/monero-gui/blob/d9d2050f2924322ff6f2895addcb6961a49132f9/main.qml#L351 which at this point it didn't clear the previous contents but now the logic does so opening starts the dialog off fresh for user input.