### PR TITLE
Left Panel: seeds and keys not selected when open

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -86,7 +86,7 @@ ApplicationWindow {
     }
 
     function sequencePressed(obj, seq) {
-        if(seq === undefined)
+        if(seq === undefined || !leftPanel.enabled)
             return
         if(seq === "Ctrl") {
             ctrlPressed = true


### PR DESCRIPTION
This pull request fixes an issue (fixes #1002) where the left panel incorrectly had the "Settings" section selected when the "Seeds & Keys" section was open.

This issue was caused by the logic that looks for hotkeys for selection of the left panel. During password dialog keydown events it was causing the left panel to select the "Settings" section as the `middlePanel.state` was set to "Settings" while we wait for a password input.

I've adjusted the left panel hotkey logic to ignore input when the leftPanel is disabled as it doesn't make sense to look for hotkeys then which fixes this issue.

This [logic](https://github.com/Timo614/monero-gui/blob/9cdfad35120fd0ae43f2fccf10bc43835c79eceb/main.qml#L88) shows the method in question which is used to handle hot keys for adjusting which left panel item has been selected.