### PR TITLE
TextBlock: Fix multi select bug

### DIFF
--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -29,7 +29,7 @@
 import QtQuick 2.0
 import moneroComponents.Clipboard 1.0
 import moneroComponents.AddressBookModel 1.0
-
+import "../components" as MoneroComponents
 
 ListView {
     id: listView
@@ -160,10 +160,8 @@ ListView {
             }
             */
             // -- address (in case outgoing transaction) - N/A in case of incoming
-            TextEdit {
+            MoneroComponents.TextBlock {
                 id: addressText
-                readOnly: true
-                selectByMouse: true
                 anchors.verticalCenter: dot.verticalCenter
                 width: parent.width - x - 12
                 //elide: Text.ElideRight
@@ -195,9 +193,7 @@ ListView {
                 text: paymentId !== "" ? qsTr("Payment ID:")  + translationManager.emptyString : ""
             }
             // -- "PaymentID" value
-            TextEdit {
-                readOnly: true
-                selectByMouse: true
+            MoneroComponents.TextBlock {
                 id: paymentIdValue
                 width: 136
                 anchors.bottom: parent.bottom
@@ -209,9 +205,7 @@ ListView {
 
             }
             // Address book lookup
-            TextEdit {
-                readOnly: true
-                selectByMouse: true
+            MoneroComponents.TextBlock {
                 id: addressBookLookupValue
                 width: 136
                 anchors.bottom: parent.bottom
@@ -243,10 +237,8 @@ ListView {
                 text:  qsTr("BlockHeight:")  + translationManager.emptyString
             }
             // -- "BlockHeight" value
-            TextEdit {
-                readOnly: true
-                selectByMouse: true
-                width: 85
+            MoneroComponents.TextBlock {
+                width: 200
                 anchors.bottom: parent.bottom
                 //elide: Text.ElideRight
                 font.family: "Arial"

--- a/components/TextBlock.qml
+++ b/components/TextBlock.qml
@@ -4,4 +4,9 @@ TextEdit {
     wrapMode: Text.Wrap
     readOnly: true
     selectByMouse: true
+    // Workaround for https://bugreports.qt.io/browse/QTBUG-50587
+    onFocusChanged: {
+        if(focus === false)
+            deselect()
+    }
 }


### PR DESCRIPTION
This branch provides a workaround for the bug that caused #1003. The bug we're experiencing can be found on QT's bug tracker as [QTBUG-50587](https://bugreports.qt.io/browse/QTBUG-50587). 
The [persistentSelection](http://doc.qt.io/qt-5/qml-qtquick-textedit.html#persistentSelection-prop) property (which is defaulted to false in QT5) is supposed to handle deselecting text upon losing focus of the component but this breaks for `readOnly: true` textEdit components allowing multiple to be selected in tandem. 

The temporary fix (until QT5 fixes the bug on their end) is simply to listen to the `onFocusChanged` event and if the focus has been lost deselect  the component. 

We also use readOnly TextEdit components for the history panel. Originally I considered making a `ReadOnlySelectableTextEdit` which those and the `TextBlock` component would inherit from but since the `TextBlock` component's only difference was that it wrapped the text I decided against it in favor of just using the TextBlock component for the history panel. The text on the history panel only wraps when the screen has been shrunk to a pretty small width and even then it seems preferable to be able to select this text without going off the screen.

Let me know if anyone would prefer this be handled in a different way / left for QT to fix their end for the meantime. I was thinking this may be a much cleaner experience for users so opted to go forward with it but it is a minor bug as the associated issue mentioned so we can probably just sit on it for a bit if we'd prefer to avoid working around it directly.

![history](https://user-images.githubusercontent.com/1319304/33786384-f24ad4e2-dc36-11e7-85a4-9db087c7d577.png)
![history-wrapping](https://user-images.githubusercontent.com/1319304/33786385-f25c4114-dc36-11e7-9ac6-3b5083688d88.png)
