### PR TITLE
Left Panel Hotkeys: Fix Seed & Keys

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -64,6 +64,7 @@ Rectangle {
         else if(pos === "Sign") menuColumn.previousButton = signButton
         else if(pos === "Settings") menuColumn.previousButton = settingsButton
         else if(pos === "Advanced") menuColumn.previousButton = advancedButton
+        else if(pos === "Keys") menuColumn.previousButton = keysButton
 
         menuColumn.previousButton.checked = true
     }

--- a/main.qml
+++ b/main.qml
@@ -104,6 +104,11 @@ ApplicationWindow {
         else if(seq === "Ctrl+I") middlePanel.state = "Sign"
         else if(seq === "Ctrl+E") middlePanel.state = "Settings"
         else if(seq === "Ctrl+D") middlePanel.state = "Advanced"
+        else if(seq === "Ctrl+Y") {
+            leftPanel.selectItem("Keys")
+            settingsPasswordDialog.open()
+            return
+        }
         else if(seq === "Ctrl+Tab" || seq === "Alt+Tab") {
             /*
             if(middlePanel.state === "Dashboard") middlePanel.state = "Transfer"


### PR DESCRIPTION
This issue fixes #1011 by adding a hotkey for the "Seed & Keys" section which behaves the same way as the leftPanel clicking by triggering the popup to confirm the user's password prior to entry.

Note: until #1005 has been merged typing a password will revert the leftPanel selection and show you an incorrect left tab. You can bypass the bug #1005 is fixing by using a password-less test wallet and clicking the enter button for the password when the dialog pops (the hotkey logic runs currently even when the leftPanel has been disabled and sets the value to match the current open tab which can cause issues during the password prompt flow to switch to a new tab).

![image showing current hotkey](https://user-images.githubusercontent.com/1319304/33844202-94d535c6-de6d-11e7-9b8c-763a8ad24bff.png)
