### PR TITLE
Receive page: QR code bug fix for invalid payment ids

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -80,8 +80,8 @@ Rectangle {
           s += (nfields++ ? "&" : "?")
           s += "tx_amount=" + amount
         }
-        var pid = paymentIdLine.text.trim()
-        if (pid !== "") {
+        var pid = paymentIdLine.text.trim().toLowerCase()
+        if (pid !== "" && walletManager.paymentIdValid(pid)) {
           s += (nfields++ ? "&" : "?")
           s += "tx_payment_id=" + pid
         }


### PR DESCRIPTION
Simple change to fix #904 where the QR code was incorrectly updating for invalid payment IDs. Logic just checks whether or not the payment ID is valid prior to including it as part of the QR code now. 

I've attached a few screenshots which show that the QR code only updates now when there is a valid payment id as well.

![no-payment-id](https://user-images.githubusercontent.com/1319304/33847738-9054e120-de79-11e7-8f4c-970abb65da35.png)
![invalid-payment-id](https://user-images.githubusercontent.com/1319304/33847737-903a900e-de79-11e7-83fc-81e8c3cccc73.png)
![valid-payment-id](https://user-images.githubusercontent.com/1319304/33847729-8a1e2d98-de79-11e7-8d68-d0c9174d0a76.png)

