### PR TITLE
Use wallet2_api isAddressLocal utils method for isDaemonLocal check

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -317,7 +317,7 @@ ApplicationWindow {
         middlePanel.transferView.updatePriorityDropdown();
 
         // If wallet isnt connected and no daemon is running - Ask
-        if(!isMobile && isDaemonLocal() && !walletInitialized && status === Wallet.ConnectionStatus_Disconnected && !daemonManager.running(persistentSettings.testnet)){
+        if(!isMobile && walletManager.isDaemonLocal(appWindow.persistentSettings.daemon_address) && !walletInitialized && status === Wallet.ConnectionStatus_Disconnected && !daemonManager.running(persistentSettings.testnet)){
             daemonManagerDialog.open();
         }
         // initialize transaction history once wallet is initialized first time;
@@ -1630,16 +1630,6 @@ ApplicationWindow {
         id: updatesTimer
         interval: 3600*1000; running: true; repeat: true
         onTriggered: checkUpdates()
-    }
-
-    function isDaemonLocal() {
-        var daemonAddress = appWindow.persistentSettings.daemon_address
-        if (daemonAddress === "")
-            return false
-        var daemonHost = daemonAddress.split(":")[0]
-        if (daemonHost === "127.0.0.1" || daemonHost === "localhost")
-            return true
-        return false
     }
 
     function releaseFocus() {

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -37,15 +37,6 @@ Rectangle {
     color: "#F0EEEE"
     property var currentHashRate: 0
 
-    function isDaemonLocal() {
-        if (appWindow.currentDaemonAddress === "")
-            return false
-        var daemonHost = appWindow.currentDaemonAddress.split(":")[0]
-        if (daemonHost === "127.0.0.1" || daemonHost === "localhost")
-            return true
-        return false
-    }
-
     /* main layout */
     ColumnLayout {
         id: mainLayout
@@ -75,7 +66,7 @@ Rectangle {
                 fontSize: 18
                 color: "#D02020"
                 text: qsTr("(only available for local daemons)")
-                visible: !isDaemonLocal()
+                visible: !walletManager.isDaemonLocal(appWindow.currentDaemonAddress)
             }
 
             Text {
@@ -157,7 +148,7 @@ Rectangle {
                         } else {
                             errorPopup.title  = qsTr("Error starting mining") + translationManager.emptyString;
                             errorPopup.text = qsTr("Couldn't start mining.<br>")
-                            if (!isDaemonLocal())
+                            if (!walletManager.isDaemonLocal(appWindow.currentDaemonAddress))
                                 errorPopup.text += qsTr("Mining is only available on local daemons. Run a local daemon to be able to mine.<br>")
                             errorPopup.icon = StandardIcon.Critical
                             errorPopup.open()
@@ -225,7 +216,7 @@ Rectangle {
         console.log("Mining page loaded");
 
         update()
-        timer.running = isDaemonLocal()
+        timer.running = walletManager.isDaemonLocal(appWindow.currentDaemonAddress)
 
     }
     function onPageClosed() {

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -270,6 +270,11 @@ bool WalletManager::localDaemonSynced() const
     return blockchainHeight() > 1 && blockchainHeight() >= blockchainTargetHeight();
 }
 
+bool WalletManager::isDaemonLocal(const QString &daemon_address) const
+{
+    return Monero::Utils::isAddressLocal(daemon_address.toStdString());
+}
+
 QString WalletManager::resolveOpenAlias(const QString &address) const
 {
     bool dnssec_valid = false;

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -111,6 +111,7 @@ public:
     Q_INVOKABLE quint64 blockchainTargetHeight() const;
     Q_INVOKABLE double miningHashRate() const;
     Q_INVOKABLE bool localDaemonSynced() const;
+    Q_INVOKABLE bool isDaemonLocal(const QString &daemon_address) const;
 
     Q_INVOKABLE bool isMining() const;
     Q_INVOKABLE bool startMining(const QString &address, quint32 threads, bool backgroundMining, bool ignoreBattery);


### PR DESCRIPTION
Fixes #939 by using wallet2_api's `isAddressLocal` method which confirms whether the address passed in is a local address or not. It calls `is_local_address` internally which the associated issue was referencing. 

I tested this by connecting to a remote node and confirmed that I saw the mining warnings that are not visible for local nodes. I also confirmed that when using the remote connect logic pointing to `localhost` or `127.0.0.1` it was still treated as a local node from a warning perspective.

(Note: if testing it looks like if you have a node up in the default port 18081 for mainnet or 28082 for testnet the remote node is ignored so I tested the local nodes treated as remote by running them on different ports)

![local-node](https://user-images.githubusercontent.com/1319304/33855596-61036bfc-de93-11e7-9ae5-fea6260d1bae.png)
![remote-node](https://user-images.githubusercontent.com/1319304/33855597-6118a0b2-de93-11e7-9d8f-7421aba5993a.png)
