### PR TITLE
Update error field of payment id text field

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -60,12 +60,18 @@ Rectangle {
 
         if (payment_id.length > 0) {
             integratedAddressLine.text = appWindow.currentWallet.integratedAddress(payment_id)
-            if (integratedAddressLine.text === "")
-              integratedAddressLine.text = qsTr("Invalid payment ID")
+            if (integratedAddressLine.text === "") {
+                integratedAddressLine.text = qsTr("Invalid payment ID")
+                paymentIdLine.error = true
+            }
+            else {
+                paymentIdLine.error = false
+            }
         }
         else {
             paymentIdLine.text = ""
             integratedAddressLine.text = ""
+            paymentIdLine.error = false
         }
 
         update()


### PR DESCRIPTION
Pairs with #1014 by adding a graphical notice to the user of their payment id being invalid. A component to fix #904 
![pidinvalid](https://user-images.githubusercontent.com/17678313/33933371-83798884-dfc3-11e7-9a61-76b50855c504.png)
![pidvalid](https://user-images.githubusercontent.com/17678313/33933382-89d3de0a-dfc3-11e7-8c18-a2270be4b03a.png)




