### PR TITLE
add wallet name to left panel

### DIFF
--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -567,6 +567,10 @@ Rectangle {
         }
         TextBlock {
             Layout.fillWidth: true
+            text: qsTr("Wallet Name: ") + walletName + translationManager.emptyString
+        }
+        TextBlock {
+            Layout.fillWidth: true
             text:  (typeof currentWallet == "undefined") ? "" : qsTr("Daemon log path: ") + currentWallet.daemonLogPath + translationManager.emptyString
         }
     }


### PR DESCRIPTION
Resolves #655  by adding the wallet name to the top of the left panel like so.
![walletname](https://user-images.githubusercontent.com/17678313/33955659-4b023f68-e00a-11e7-8ad3-64d895a66065.png)
