### PR TITLE
Call Monero::Utils::onStartup in main.cpp (requires #2952)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -70,6 +70,7 @@ void messageHandler(QtMsgType type, const QMessageLogContext &context, const QSt
 
 int main(int argc, char *argv[])
 {
+    Monero::Utils::onStartup();
 //    // Enable high DPI scaling on windows & linux
 //#if !defined(Q_OS_ANDROID) && QT_VERSION >= 0x050600
 //    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/monero-project/monero/pull/2860