### PR TITLE
Store wallet log in ~/Library/Logs/ in MacOS

### DIFF
--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -658,7 +658,13 @@ QString Wallet::getDaemonLogPath() const
 
 QString Wallet::getWalletLogPath() const
 {
-    return QCoreApplication::applicationDirPath() + "/monero-wallet-gui.log";
+    const QString filename("monero-wallet-gui.log");
+
+#ifdef Q_OS_MACOS
+    return QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0) + "/Library/Logs/" + filename;
+#else
+    return QCoreApplication::applicationDirPath() + "/" + filename;
+#endif
 }
 
 Wallet::Wallet(Monero::Wallet *w, QObject *parent)


### PR DESCRIPTION
In MacOS it is not usual to modify anything inside an application. If the user that runs the application doesn't have writing permissions the log will not be saved.

This modifies the path to store them in MacOS' standard location for application logs.