### PR TITLE
Refresh translations

### DIFF
--- a/translations/monero-core.ts
+++ b/translations/monero-core.ts
@@ -280,22 +280,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="263"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="292"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="349"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="384"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,7 +348,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="153"/>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
         <source>PENDING</source>
         <translation type="unfinished"></translation>
     </message>
@@ -422,117 +432,122 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="135"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="180"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="283"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="333"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="334"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="427"/>
+        <location filename="../LeftPanel.qml" line="439"/>
         <source>Prove/check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="428"/>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="357"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="308"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="309"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="358"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="380"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="381"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="403"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="404"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="496"/>
+        <location filename="../LeftPanel.qml" line="508"/>
         <source>Seed &amp; Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="497"/>
+        <location filename="../LeftPanel.qml" line="509"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="451"/>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="475"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="284"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="452"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="474"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -685,24 +700,47 @@
     </message>
 </context>
 <context>
-    <name>PasswordDialog</name>
+    <name>NewPasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="87"/>
-        <source>Please enter wallet password</source>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="87"/>
-        <source>Please enter wallet password for:&lt;br&gt;</source>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="155"/>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="168"/>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PasswordDialog</name>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
+        <source>Please enter wallet password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
+        <source>Please enter wallet password for:&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="156"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -759,147 +797,147 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="189"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="196"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="208"/>
+        <location filename="../pages/Receive.qml" line="214"/>
         <source>Address copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="229"/>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="241"/>
+        <location filename="../pages/Receive.qml" line="247"/>
         <source>Payment ID copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="264"/>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="273"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="294"/>
+        <location filename="../pages/Receive.qml" line="300"/>
         <source>Integrated address copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="314"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="335"/>
+        <location filename="../pages/Receive.qml" line="341"/>
         <source>Tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="337"/>
+        <location filename="../pages/Receive.qml" line="343"/>
         <source>help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="342"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="387"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="399"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="221"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="253"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="282"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="306"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -938,13 +976,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="259"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="284"/>
-        <location filename="../pages/Settings.qml" line="314"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -964,42 +1002,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="277"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="337"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="346"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="371"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="395"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="413"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1009,87 +1047,97 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="181"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
         <source>Local Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="189"/>
+        <location filename="../pages/Settings.qml" line="215"/>
         <source>Remote Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="207"/>
+        <location filename="../pages/Settings.qml" line="233"/>
         <source>Manage Daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="213"/>
+        <location filename="../pages/Settings.qml" line="239"/>
         <source>Show advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="231"/>
+        <location filename="../pages/Settings.qml" line="257"/>
         <source>Start Local Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="246"/>
+        <location filename="../pages/Settings.qml" line="272"/>
         <source>Stop Local Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="307"/>
+        <location filename="../pages/Settings.qml" line="333"/>
         <source>Local daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="325"/>
+        <location filename="../pages/Settings.qml" line="351"/>
         <source>Node login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="356"/>
+        <location filename="../pages/Settings.qml" line="382"/>
         <source>Remote node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="472"/>
+        <location filename="../pages/Settings.qml" line="498"/>
         <source>Debug info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="486"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="491"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="497"/>
+        <location filename="../pages/Settings.qml" line="523"/>
         <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="498"/>
+        <location filename="../pages/Settings.qml" line="524"/>
         <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="524"/>
+        <location filename="../pages/Settings.qml" line="550"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="537"/>
+        <location filename="../pages/Settings.qml" line="563"/>
         <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="538"/>
+        <location filename="../pages/Settings.qml" line="564"/>
         <source>Are you sure you want to rebuild the wallet cache?
 The following information will be deleted
 - Recipient addresses
@@ -1101,58 +1149,64 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="566"/>
+        <location filename="../pages/Settings.qml" line="592"/>
         <source>Wallet log path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="570"/>
-        <source>Daemon log path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="579"/>
-        <source>Daemon log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="588"/>
-        <source>Please choose a folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="597"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
+        <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="604"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="606"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="610"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="546"/>
-        <location filename="../pages/Settings.qml" line="614"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1446,199 +1500,184 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="194"/>
-        <source>Low (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
-        <source>Medium (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="196"/>
-        <source>High (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="229"/>
+        <location filename="../pages/Transfer.qml" line="220"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="231"/>
+        <location filename="../pages/Transfer.qml" line="222"/>
         <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="244"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="268"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="286"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="291"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="293"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="296"/>
-        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="302"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="321"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="327"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="335"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="400"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="463"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="477"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="546"/>
-        <location filename="../pages/Transfer.qml" line="602"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="608"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="547"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="557"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="558"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="559"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="560"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="561"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="575"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="609"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="663"/>
-        <location filename="../pages/Transfer.qml" line="675"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="678"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="683"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1648,37 +1687,37 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="428"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="203"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="204"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="205"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1686,73 +1725,75 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="343"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="128"/>
-        <location filename="../pages/TxKey.qml" line="239"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="93"/>
-        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="135"/>
-        <location filename="../pages/TxKey.qml" line="246"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="154"/>
-        <location filename="../pages/TxKey.qml" line="265"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
-        <location filename="../pages/TxKey.qml" line="272"/>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
         <source>Optional message against which the signature is signed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="181"/>
+        <location filename="../pages/TxKey.qml" line="186"/>
         <source>Generate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="204"/>
-        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="291"/>
+        <location filename="../pages/TxKey.qml" line="297"/>
         <source>Signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="299"/>
+        <location filename="../pages/TxKey.qml" line="305"/>
         <source>Paste tx proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="101"/>
-        <location filename="../pages/TxKey.qml" line="212"/>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="108"/>
-        <location filename="../pages/TxKey.qml" line="219"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="320"/>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2144,296 +2185,321 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="344"/>
-        <location filename="../main.qml" line="555"/>
-        <location filename="../main.qml" line="567"/>
-        <location filename="../main.qml" line="617"/>
-        <location filename="../main.qml" line="629"/>
-        <location filename="../main.qml" line="671"/>
-        <location filename="../main.qml" line="680"/>
-        <location filename="../main.qml" line="732"/>
-        <location filename="../main.qml" line="816"/>
-        <location filename="../main.qml" line="1005"/>
-        <location filename="../main.qml" line="1164"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="345"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="429"/>
+        <location filename="../main.qml" line="435"/>
         <source>Remaining blocks (local node):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="500"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="557"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="559"/>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="568"/>
-        <location filename="../main.qml" line="681"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="580"/>
-        <location filename="../main.qml" line="693"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="581"/>
-        <location filename="../main.qml" line="694"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="582"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="583"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="584"/>
-        <location filename="../main.qml" line="695"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="585"/>
-        <location filename="../main.qml" line="696"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="768"/>
+        <location filename="../main.qml" line="778"/>
         <source>Payment proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="771"/>
+        <location filename="../main.qml" line="781"/>
         <source>Couldn&apos;t generate a proof because of the following reason: 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="797"/>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
         <source>Payment proof check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="800"/>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="808"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1006"/>
-        <location filename="../main.qml" line="1165"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1076"/>
+        <location filename="../main.qml" line="1108"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1079"/>
+        <location filename="../main.qml" line="1111"/>
         <source>Error: Filesystem is read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1081"/>
+        <location filename="../main.qml" line="1113"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1083"/>
+        <location filename="../main.qml" line="1115"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1085"/>
+        <location filename="../main.qml" line="1117"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1089"/>
+        <location filename="../main.qml" line="1121"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1566"/>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
         <source>Tap again to close...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1579"/>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1580"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1582"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1617"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="588"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="618"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="733"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="805"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="812"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1194"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1218"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1234"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1284"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_ar.ts
+++ b/translations/monero-core_ar.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>ضيف بيانات جديده</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>العنوان</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>هويه المعامله &lt;font size=&apos;2&apos;&gt;(اختياري)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>الوصف &lt;font size=&apos;2&apos;&gt;(اختياري)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>خصص لهذه البيانات اسم او وصف</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>ضيف</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>عنوان غير صحيح</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Can&apos;t ينشا مدخلات</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>هويه المعامله</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>يبدأ تشغيل خادم مونيرو في خلال %1 ثواني</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation> صفي تاريخ المعاملات</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>نوع البحث التدريجي..</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>صفي</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>التاريخ من</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>إلي</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>تصفيه متقدمه</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>نوع المعامله</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>الكميه من</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>هويه المعامله</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>لا يوجد نتائج اخري</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>تفاصيل</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%/10 تأكيدات)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%/10 تأكيدات) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>غير مؤكده</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>قيد الانتظار</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>الكميه</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>الرسوم</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">هويه المعامله</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%/10 تأكيدات) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">غير مؤكده</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">قيد الانتظار</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">مفتاح الرؤيه السري</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">مفتاح الرؤيه العام</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">مفتاح الصرف السري</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">مفتاح الصرف العام</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>الرصيد</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>الرصيد المتاح</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>إرسل</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>إستقبل</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>التاريخ</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>دليل العناوين</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>متطور</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>التعدين</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>إفحص معامله</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>إمضي/إتأكد</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>الرصيد</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>الرصيد المتاح</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>تعدين فردي</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(متاح بس للخادم المحلي)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>التعدين بجهازك بيساعد في تقويه شبكه مونيرو. كل ما ناس ازيد بتعدن  كل ما كان اصعب مهاجمه الشبكه,  وكل مساهمه صغيره بتفرق ,. التعدين الفردي بيديك فرصه تكسب شويه مونيرو ,جهازك هيحاول يحل معادلات البلوك . لو لقيت بلوك والجايزه راحت ليك , مبروك عليك يا ابن المحظوظه </translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>اختياري</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>التعدين في الخلفيه (تجريبي) </translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>تشغيل التعدين لو الجهاز علي البطاريه</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>إتحكم في التعدين</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>إبدأ التعدين</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>مشكله في تشغيل التعدين</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>التعدين متاح فقط علي الخوادم المحليه . شغل خادم مونيرو علي جهازك عشان تعرف تشغل التعدين بالمحفظه</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>إبدأ تعدين</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>الحاله: لا يُعدن</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>بيعدن بسرعه %1 هاش/ث</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>مش بيعدن</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>الحاله</translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>الرصيد المتاح</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>مزامنة:</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>مُتصل</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>نسخه خطأ</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>ليس متصل</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
-        <source>حاله التوصيل باطله</source>
-        <translation></translation>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
+        <source>Invalid connection status</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>حاله الشبكه</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>إدخل كلمه سر المحفظه</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>إدخل كلمه سر المحفظه التاليه :&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>موافق</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>جاري الإتصال...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>الكتل المتبقيه: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>مزامنه الكتل</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>هويه المعامله باطله</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>خطأ: ليس هناك اتصال بخادم</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 تأكيدات: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 تاكيدات: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>لم يتم العثور علي معامله بعد..</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>تم العثور علي معامله</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 معامله وجدت</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>مع اموال اكثر (%1)  </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>مع اموال غير كافيه (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>العنوان</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>عنوان محفظه القراءه فقط معروض هنا</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>تنظيف</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>هويه المعامله</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>كميه الاستلام</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>تتبع المعاملات</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
-        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;إضغط هنا حتي تنشأ هويه معامله جديده لزبون جديد&lt;/p&gt; &lt;p&gt;خلي الزبون يفحص الكود ويدفعلك (لو الزبون عنده جهاز يفحص بيه الكود الظاهر امامك).&lt;/p&gt;&lt;p&gt;الصفحه دي هتبحث عن المعامله دي في سلسله الكتل بشكل تلقائي . لو ضيفت كميه, هتبحث برضه عن الكميه في المعامله القادمه وتقارنها بيها.&lt;/p&gt;It&apos;s الموضوع بيرجع ليك تقبل انك تاخد معامله غير مؤكده او لا . غالبا هيتاكدوا بشكل سريع  they&apos;بس في احتماليه انهم ميتاكدوش  عشان كده لو بتتعامل بفلوس كتيره استني تاكيد او اتنين علي الاقل .&lt;/p&gt;</translation>    
+        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;إضغط هنا حتي تنشأ هويه معامله جديده لزبون جديد&lt;/p&gt; &lt;p&gt;خلي الزبون يفحص الكود ويدفعلك (لو الزبون عنده جهاز يفحص بيه الكود الظاهر امامك).&lt;/p&gt;&lt;p&gt;الصفحه دي هتبحث عن المعامله دي في سلسله الكتل بشكل تلقائي . لو ضيفت كميه, هتبحث برضه عن الكميه في المعامله القادمه وتقارنها بيها.&lt;/p&gt;It&apos;s الموضوع بيرجع ليك تقبل انك تاخد معامله غير مؤكده او لا . غالبا هيتاكدوا بشكل سريع  they&apos;بس في احتماليه انهم ميتاكدوش  عشان كده لو بتتعامل بفلوس كتيره استني تاكيد او اتنين علي الاقل .&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>فشل حفظ الكود في</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>إحفظ علي هيئه</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>هويه المعامله</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>إنشاء</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>إنشاء هويه معامله في عنوان مدموج</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>الكميه</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>أخبار</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>مساعده</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>عن</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">رقم المنفذ</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>إنشاء محفظه رؤيه فقط</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>التحكم في الخادم</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>إبدأ الخادم</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>وقَف الخادم</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>إظهر الحاله</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>شعارات بدأ الخادم</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(إختياري)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>إظهر المفاتيح السريه وبيانات الاسترجاع</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>إفحص رصيد المحفظه مجددا</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>حطأ:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>معلومات</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>تم فحص نتاج الصرف مجددا بنجاح</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>مكان سلسله الكتل</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>عنوان الخادم</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>اسم المضف / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>رقم المنفذ</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>تسجيل الدخول (اختياري)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>اسم المستخدم</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>كلمه السر</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>إتصال</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>اعدادات التصميم</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>زخرفه خاصه</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>مستوي التاريخ</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>النسخه</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>نسخه الواجهه الرسوميه</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>نسخه مونيرو المضمنة</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>تسجيلات الخادم</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>من فضلك اختر مجلد</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>تحذير</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>حطأ : نظام الملفات فراءة فقط</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>تحذير : هناك فقط %1 مساحه خاليه علي الجهاز. سلسله الكتل تحتاج علي الاقل ّ%2 جيجا من البيانات</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>تحذير : هناك فقط %1 مساحه خاليه علي الجهاز. سلسله الكتل تحتاج علي الاقل ّ%2 جيجا من البيانات</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>ملاحظه : lmdb  مجلد  الخاصه بسلسله الكتل غير موجود سيتم انشاء مجلد جديد</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>كلمات الاسترجاع والمفاتيح السريه</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>مفتاح الرؤيه السري</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>مفتاح الرؤيه العام</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>مفتاح الصرف السري</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>مفتاح الصرف العام</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>كلمه السر خاطئه</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>تحكم في المحفظه</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>إغلاق المحفظه</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>توقيع جيد</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>هناك توقيع جيد</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>توقيع سيء</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>هذا التوقيع لم يوثق</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>وقع رساله او ملف بعنوانك</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>أي رساله:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>الرساله لتوقيعها</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>وقَع</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>من فضلك اختر ملف لتوقيعه</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>إختر</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>تأكد</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>من فضلك اختر ملف للتاكد منه</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation></translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>أو ملف:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>الملف مع الرساله لتوقيعهما</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>التوقيع</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>تأكد من توقيع رساله او ملف من عنوان معين</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>الرساله للتاكد منها</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>الملف مع الرساله للتاكد منهما</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>حسناًً</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>منخفض ( ب1 الرسوم) </translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>متوسط ( ب20 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>عالي (ب166 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>بطيء (ب0.25 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>عادي (ب1 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>سريع (ب5 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>الأسرع (ب41.5 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>جميعاً</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>أُرسل</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>مُستَلَم</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>عادي</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>متوسط</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>مرتفع</translation>
     </message>
@@ -1237,225 +1470,215 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>الكميه</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>اهميه المعامله</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>جميعاً</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>قليل (ب1 رسوم)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>متوسط (ب20 الرسوم)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>عالي (ب166 الرسوم)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>حل</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>لا يوجد عنوان صحيح لهذا العنوان المدموج</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>العنوان موجود, لكن توقيع ال DNSSEC لا يمكن التاكد منه, هذا العنوان ربما يكون مغشوش</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>العنوان موجود, لكن توقيع ال DNSSEC لا يمكن التاكد منه, هذا العنوان ربما يكون مغشوش</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>خطأ داخلي</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>لا يوجد عنوان</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>الوصف &lt;font size=&apos;2&apos;&gt;( اختياري )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>حفظ علي تاريخ المحفظه المحلي</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>أرسل</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>إظهر الإعدادات المتقدمه</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>إنشاء ملف معامله</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>توقيع ملف معامله</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>تسليم ملف معامله</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>معلومات</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>إختر ملف من فضلك</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
-        <source>Can&apos;t load unsigned transaction: </source>
-        <translation type=""></translation>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">إبدأ الخادم</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">العنوان</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
+        <source>Can&apos;t load unsigned transaction: </source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>-عدد المعاملات:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>-معامله #1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>-المتلقي:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>-هويه المعامله:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>-الكميه:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>-الرسوم:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>التاكيدات:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>تم إرسال المال بنجاح</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>المحفظه غير متصله بخادم</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>الخادم المتصل بيه غير متوافق مع الواجهه الرسوميه.
 - من فضلك رقي او إتصل بخادم آخر</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>بإنتظار إتمام التزامن مع الخادم</translation>
     </message>
@@ -1465,37 +1688,37 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>تكلفه المعامله</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>هويه المعامله &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>بطيء (ب0.25 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>عادي (ب1 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>سريع (ب5 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>الأسرع (ب41.5 الرسوم)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1503,64 +1726,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>تأكد من ان طرف تالت أتم معامله عن طريق تزويد</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation>- عنوان المتلقي</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation>- هويه المعامله</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation>- الرقم السري للمعامله المزود من المُرسل</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>اذا كان عمليه الدفع لها اكثر من معامله وجب التاكد من كل علي حدا وجمع النتائج</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>العنوان</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>المستلم&apos;s عنوان المحفظه</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">إنشاء</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">التوقيع</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>هويه المعامله</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>إستعلم</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>مفتاح المعامله</translation>
     </message>
 </context>
 <context>
@@ -1615,6 +1851,39 @@ Please upgrade or connect to another daemon</source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>إنشاء محفظه جديده</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">مكان سلسله الكتل</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1720,43 +1989,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>موجود محفظه بنفس الإسم بالفعل. من فضلك إختر غيّّر اسم المحفظه</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>إستخدم مونيرو</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>إنشاء محفظه</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>نجاح</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>تم إنشاء محفظه الرؤيه فقط. يمكنك فتحها بعد غلق المحفظه الحاليه, بالضغط علي &quot; اختيار فتح محفظه من ملف &quot; وإختيار مكان محفظه الرؤيه فقط: %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>إغلق</translation>
     </message>
@@ -1764,47 +2033,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>إسم المحفظه</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>إسترجاع بواسطه كلمات الاسترجاع</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>إسترجاع بواسطه المفاتيح</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>عنوان الحساب (العام)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>مفتاح الرؤيه (الخاص)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>مفتاح الصرف (الخاص)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>طول الإسترجاع (إختياري)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>محفظتك مخزنه في</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>من فضلك إختر مجلد</translation>
     </message>
@@ -1817,7 +2091,12 @@ Please upgrade or connect to another daemon</source>
         <translation>إكتب ال 25 كلمه الخاصه بإسترجاع محفظتك</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>هذه هي بيانات الاسترجاع الخاصه بك. مهم جدا تخزينها أمناً. هي كل ما تحتاجه لإسترجاع محفتظك في أي وقت . </translation>
     </message>
@@ -1825,37 +2104,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>أهلا بيك في مونيرو</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>من فضلك إختار أحد الإختيارات التاليه</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>إنشاء محفظه جديده</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>إسترجاع محفظه من المفاتيح او الكلمات السريه</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>إفتح محفظه من ملف</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>عنوان خادم خاص  (إختياري)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>شبكه التجارب</translation>
     </message>
@@ -1869,7 +2143,7 @@ Please upgrade or connect to another daemon</source>
         <translation>أكتب كلمه مرور المحفظه الخاصه بك</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation>تذكره : كلمه السر هذه لا يمكن استرجاعها . إذا نسيتها يجب إسترجاع المحفظه من ال25 كلمه السريه . إختار كلمه سر قويه بإستخدام ( الحروف . والأرقام و الرموز) :</translation>
@@ -1878,12 +2152,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>كلمه السر</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>تأكيد كلمه السر</translation>
     </message>
@@ -1891,7 +2165,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>إسترجاع محفظه</translation>
     </message>
@@ -1899,12 +2173,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>أهلا بيك في مونيرو!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>من فضلك إختار لغه ونظام محلي.</translation>
     </message>
@@ -1912,107 +2186,114 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">خطأ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>لا يمكن فتح المحفظه:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>الرصيد المتاح (بإنتظار كتله)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>الرصيد المتاح (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>الرصيد المتاح</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>بإنتظار أن يبدأ الخادم..</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>بإنتظار أن يتوقف الخادم..</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>فشل أن يبدأ الخادم</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>من فضلك تأكد من تسجيلات محفظتك وتسجيلات الخادم وابحث عن الخطأ. ممكن ايضا ان تبدأ %1 يدوياً</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>لا يمكن إنشاء معامله: نسخه الخادم خاطئه</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>لا يمكن إنشاء معامله</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>التأكيدات</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>من فضلك أكد المعامله:
  </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
  العنوان:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
  هويه المعامله:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2020,15 +2301,15 @@ Amount: </source>
 الكميه:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
  الرسوم:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2036,117 +2317,198 @@ Ringsize: </source>
  حجم الحلق:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">توقيع سيء</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>هذا العنوان استلم %1 مونيرو , مع %2 تأكيدات</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">توقيع جيد</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">كلمه السر خاطئه</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">تحذير</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">حطأ : نظام الملفات فراءة فقط</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">تحذير : هناك فقط %1 مساحه خاليه علي الجهاز. سلسله الكتل تحتاج علي الاقل ّ%2 جيجا من البيانات</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">تحذير : هناك فقط %1 مساحه خاليه علي الجهاز. سلسله الكتل تحتاج علي الاقل ّ%2 جيجا من البيانات</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">ملاحظه : lmdb  مجلد  الخاصه بسلسله الكتل غير موجود سيتم انشاء مجلد جديد</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">حطأ:</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>الخادم يعمل</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>الخادم سوف يبدأ في العمل في الخلفيه حينما يتم غلق الواجهه الرسوميه</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>وقف الخادم</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>إصدار جديد من واجهه مونيرو الرسويه متاح: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
  عدد المعاملات:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
-        <translation >
+        <translation>
  الوصف:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>الكميه خطأ: الرقم المتوقع من %1 إلي %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>لا يوجد اموال كافيه. الرصيد المتاح: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>لم يمكن ارسال الاموال:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>معلومات</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>تم إرسال المال بنجاح: %1 معاملات</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>تم حفظ المعاملات إلي ملف : %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>فحص معامله</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>هذا العنوان استلم %1 مونيرو, لكن المعامله لم يتم تعدينها بعد</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>هذا العنوان لم يستلم شيء</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>الرصيد (مزامنه)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>الرصيد</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>من فضلك إنتظر..</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>نافذه تثبيت البرنامج</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>مونيرو</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>إرسل إلي نفس المكان </translation>
     </message>

--- a/translations/monero-core_ar.ts
+++ b/translations/monero-core_ar.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%/10 تأكيدات) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 تأكيدات)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%/10 تأكيدات) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 تأكيدات)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_cs.ts
+++ b/translations/monero-core_cs.ts
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="cs_CZ">
+<TS version="2.1" language="cs_CZ">
 <context>
     <name>AddressBook</name>
-    <message>
-        <source>Add new entry</source>
-        <translation type="obsolete">Přidat záznam</translation>
-    </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adresa</translation>
-    </message>
-    <message>
-        <source>QRCODE</source>
-        <translation type="obsolete">QR kód</translation>
     </message>
     <message>
         <location filename="../pages/AddressBook.qml" line="56"/>
@@ -128,10 +120,6 @@
 </context>
 <context>
     <name>DaemonManagerDialog</name>
-    <message>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation type="obsolete">Startuji Monero démóna za %1 sec</translation>
-    </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
         <source>Starting local node in %1 seconds</source>
@@ -287,31 +275,32 @@
         <translation>(%1/%2 potvrzení)</translation>
     </message>
     <message>
-        <source>(%1/10 confirmations)</source>
-        <translation type="obsolete">(%1/10 potvrzení)</translation>
-    </message>
-    <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NEPOTVRZENÉ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="263"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>ČEKAJÍCÍ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="292"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="349"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="384"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Poplatek</translation>
     </message>
@@ -359,7 +348,12 @@
         <translation>NEPOTVRZENÉ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="153"/>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
         <source>PENDING</source>
         <translation>ČEKAJÍCÍ</translation>
     </message>
@@ -438,121 +432,122 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="135"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Zůstatek</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="180"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Neblokovaný zůstatek</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="283"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Odeslat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="333"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Přijmout</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="334"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="427"/>
+        <location filename="../LeftPanel.qml" line="439"/>
         <source>Prove/check</source>
         <translation>Prokázat/zkontrolovat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="428"/>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="357"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Historie</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>testovací síť</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="308"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Adresář</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="309"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="358"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="380"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Pokročilé</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="381"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="403"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Těžení</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="404"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="496"/>
+        <location filename="../LeftPanel.qml" line="508"/>
         <source>Seed &amp; Keys</source>
         <translation>Seed &amp; klíče</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="497"/>
+        <location filename="../LeftPanel.qml" line="509"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <source>Check payment</source>
-        <translation type="obsolete">Kontrola platby</translation>
-    </message>
-    <message>
-        <location filename="../LeftPanel.qml" line="451"/>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Podepsat/Ověřit</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="475"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="284"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="452"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="474"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
@@ -667,397 +662,6 @@
     </message>
 </context>
 <context>
-    <name>Monero::AddressBookImpl</name>
-    <message>
-        <location filename="../monero/src/wallet/api/address_book.cpp" line="53"/>
-        <source>Invalid destination address</source>
-        <translation>Neplatná cílová adresa</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/address_book.cpp" line="63"/>
-        <source>Invalid payment ID. Short payment ID should only be used in an integrated address</source>
-        <translation>Neplatné ID platby. Zkrácené ID platby může být použito pouze jako integrovaná adresa</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/address_book.cpp" line="70"/>
-        <source>Invalid payment ID</source>
-        <translation>Neplatné ID platby</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/address_book.cpp" line="77"/>
-        <source>Integrated address and long payment id can&apos;t be used at the same time</source>
-        <translation>Integrovaná adresa a dlouhé ID platby nemůže být použito zároveň</translation>
-    </message>
-</context>
-<context>
-    <name>Monero::PendingTransactionImpl</name>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="90"/>
-        <source>Attempting to save transaction to file, but specified file(s) exist. Exiting to not risk overwriting. File:</source>
-        <translation>Pokoušíte se uložit transakci do souboru, ale zadaný soubor existuje. Ukončuji, aby nedošlo k přepsání. Soubor:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="97"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation>Nepodařilo se zapsat transakce do souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="115"/>
-        <source>daemon is busy. Please try again later.</source>
-        <translation>Démon je zaneprázdněn. Prosím, zkuste to znovu později.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="118"/>
-        <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation>Žádné spojení s démonem. Ujistěte se, že démon běží.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="122"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation>transakce %s byla démonem odmítnuta ve stavu:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="127"/>
-        <source>. Reason: </source>
-        <translation>. Důvod: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="129"/>
-        <source>Unknown exception: </source>
-        <translation>Neznámá vyjímka: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/pending_transaction.cpp" line="132"/>
-        <source>Unhandled exception</source>
-        <translation>Neošetřená výjimka</translation>
-    </message>
-</context>
-<context>
-    <name>Monero::UnsignedTransactionImpl</name>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="75"/>
-        <source>This is a watch only wallet</source>
-        <translation>Toto je peněženka je pouze pro prohlížení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="85"/>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="92"/>
-        <source>Failed to sign transaction</source>
-        <translation>Nepodařilo se podepsat transakci</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="168"/>
-        <source>Claimed change does not go to a paid address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="174"/>
-        <source>Claimed change is larger than payment to the change address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="184"/>
-        <source>Change goes to more than one address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="197"/>
-        <source>sending %s to %s</source>
-        <translation>zasílám %s na %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="203"/>
-        <source>with no destinations</source>
-        <translation>žádné cíle</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="209"/>
-        <source>%s change to %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="212"/>
-        <source>no change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/unsigned_transaction.cpp" line="214"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu. %s</source>
-        <translation>Načteno %lu transakcí, pro %s, poplatek %s, %s, %s, s minimální ring size %lu. %s</translation>
-    </message>
-</context>
-<context>
-    <name>Monero::Wallet</name>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="246"/>
-        <source>Failed to parse address</source>
-        <translation>Chyba parsování adresy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="253"/>
-        <source>Failed to parse key</source>
-        <translation>Chyba parsování klíče</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="261"/>
-        <source>failed to verify key</source>
-        <translation>Chyba ověření klíče</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="271"/>
-        <source>key does not match address</source>
-        <translation>Klíč neodpovídá adrese</translation>
-    </message>
-</context>
-<context>
-    <name>Monero::WalletImpl</name>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="464"/>
-        <source>failed to parse address</source>
-        <translation>Chyba parsování adresy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="476"/>
-        <source>failed to parse secret spend key</source>
-        <translation>Nepodařilo se zparsovat tajný klíč pro útratu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="486"/>
-        <source>No view key supplied, cancelled</source>
-        <translation>Žádný klíč pro zobrazení, zrušeno</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="493"/>
-        <source>failed to parse secret view key</source>
-        <translation>Nepodařilo se zparsovat tajný klíč pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="503"/>
-        <source>failed to verify secret spend key</source>
-        <translation>Nepodařilo se ověřit tajný klíč pro útratu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="508"/>
-        <source>spend key does not match address</source>
-        <translation>Klíč pro útratu neodpovídá adrese</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="514"/>
-        <source>failed to verify secret view key</source>
-        <translation>Nepodařilo se ověřit tajný klíč pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="519"/>
-        <source>view key does not match address</source>
-        <translation>Klíč pro zobrazení neodpovídá adrese</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="538"/>
-        <source>failed to generate new wallet: </source>
-        <translation>Nepodařilo se vygenerovat novou peněženku: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="758"/>
-        <source>Failed to send import wallet request</source>
-        <translation>Nepodařilo se odeslat požadavek na import peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="904"/>
-        <source>Failed to load unsigned transactions</source>
-        <translation>Nepodařilo se načíst nepodepsané transakce</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="925"/>
-        <source>Failed to load transaction from file</source>
-        <translation>Nepodařilo se načíst transakci ze souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="943"/>
-        <source>Wallet is view only</source>
-        <translation>Peněženka pouze pro prohlížení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="952"/>
-        <source>failed to save file </source>
-        <translation>Nepodařilo se uložit soubor</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="971"/>
-        <source>Key images can only be imported with a trusted daemon</source>
-        <translation>Potvrzení o utracení lze importovat pouze s důvěryhodným démonem</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="984"/>
-        <source>Failed to import key images: </source>
-        <translation>Nepodařilo se importovat potvrzení o utracení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1017"/>
-        <source>Failed to get subaddress label: </source>
-        <translation>Nepodařilo se získat popis podadresy:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1031"/>
-        <source>Failed to set subaddress label: </source>
-        <translation>Nepodařilo se nastavit popis podadresy:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1094"/>
-        <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
-        <translation>ID platby má neplatný formát, očekává se 16 nebo 64 znaků hex řetězec: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1104"/>
-        <source>Failed to add short payment id: </source>
-        <translation>Nepodařilo se přidat krátké ID platby: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1137"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1240"/>
-        <source>daemon is busy. Please try again later.</source>
-        <translation>Démon je zaneprázdněn. Prosím zkuste to znovu později.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1140"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1243"/>
-        <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation>Žádné spojení s démonem. Ujistěte se, že démon běží.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1143"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1246"/>
-        <source>RPC error: </source>
-        <translation>Chyba RPC: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1146"/>
-        <source>failed to get random outputs to mix: %s</source>
-        <translation>Selhalo získání náhodných výstupů pro zamixování: %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1153"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1256"/>
-        <source>not enough money to transfer, available only %s, sent amount %s</source>
-        <translation>Nedostatek peněz k převodu, dostupných pouze %s, odeslaná částka %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1162"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1265"/>
-        <source>not enough money to transfer, overall balance only %s, sent amount %s</source>
-        <translation>Nedostatek peněz k převodu, celkový zůstatek pouze %s, poslaná částka %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1171"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1274"/>
-        <source>not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)</source>
-        <translation>Nedostatek peněz k převodu, dostupných pouze %s, objem transakce %s = %s + %s (poplatek)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1180"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1283"/>
-        <source>not enough outputs for specified ring size</source>
-        <translation>Nedostatečný počet výstupů pro konkrétní velikost ring size</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1182"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1285"/>
-        <source>output amount</source>
-        <translation>Výstupní částka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1182"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1285"/>
-        <source>found outputs to use</source>
-        <translation>Nalezeny použitelné výstupy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1187"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1290"/>
-        <source>transaction was not constructed</source>
-        <translation>Transakce nebyla vytvořena</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1191"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1294"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation>Transakce %s byla odmítnuta démonem se stavem: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1198"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1301"/>
-        <source>one of destinations is zero</source>
-        <translation>Jedna z destinací je nulová</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1201"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1304"/>
-        <source>failed to find a suitable way to split transactions</source>
-        <translation>Nepodařilo najít vhodný způsob, jak rozdělit transakce</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1204"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1307"/>
-        <source>unknown transfer error: </source>
-        <translation>Neznámá chyba při přenosu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1207"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1310"/>
-        <source>internal error: </source>
-        <translation>Interní chyba: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1210"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1313"/>
-        <source>unexpected error: </source>
-        <translation>Neočekávaná chyba: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1213"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1316"/>
-        <source>unknown error</source>
-        <translation>Neznámá chyba</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1249"/>
-        <source>failed to get random outputs to mix</source>
-        <translation>Selhalo získání náhodných výstupů pro mixování</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1394"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1423"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1476"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1507"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1538"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1561"/>
-        <source>Failed to parse txid</source>
-        <translation>Nepodařilo se zparsovat txid</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1412"/>
-        <source>no tx keys found for this txid</source>
-        <translation>Nenalezen tx klíč pro toto txid</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1432"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1442"/>
-        <source>Failed to parse tx key</source>
-        <translation>Nepodařilo se zparsovat tx klíč</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1452"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1484"/>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1515"/>
-        <source>Failed to parse address</source>
-        <translation>Nepodařilo se zparsovat adresu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/api/wallet.cpp" line="1782"/>
-        <source>Rescan spent can only be used with a trusted daemon</source>
-        <translation>Přeskenování útrat může být použito pouze s důvěryhodným démonem</translation>
-    </message>
-</context>
-<context>
     <name>NetworkStatusItem</name>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="53"/>
@@ -1096,30 +700,49 @@
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušit</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished">Pokračovat</translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="87"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Prosím, vložte heslo peněženky</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="87"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Prosím, vložte heslo peněženky pro:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="155"/>
+        <location filename="../components/PasswordDialog.qml" line="156"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="168"/>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
         <source>Continue</source>
         <translation>Pokračovat</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation type="obsolete">OK</translation>
     </message>
 </context>
 <context>
@@ -1174,142 +797,147 @@
         <translation>Neplatné ID platby</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>VAROVÁNÍ: žádné spojení s démonem</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>v txpoolu: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 potvrzení: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 potvrzení: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Zatím žádná nalezená transakce</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transakce nalezena</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 nalezených transakcí</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>s více penězi (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>s nedostatkem peněz (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="189"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="196"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Adresa peněženky zobrazená zde pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="208"/>
+        <location filename="../pages/Receive.qml" line="214"/>
         <source>Address copied to clipboard</source>
         <translation>Adresa zkopírována do schránky</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="229"/>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 hexadecimálních znaků</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="241"/>
+        <location filename="../pages/Receive.qml" line="247"/>
         <source>Payment ID copied to clipboard</source>
         <translation>ID platby zkopírované do schránky</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="264"/>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Vyčistit</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="273"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Integrované adresy</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="294"/>
+        <location filename="../pages/Receive.qml" line="300"/>
         <source>Integrated address copied to clipboard</source>
         <translation>Integrovaná adresa zkopírována do schránky</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="314"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Částka k přijetí</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="334"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Sledování &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="339"/>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Sledování plateb</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="340"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Jedná se o jednoduchý tracker prodeje:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Kliknutím na tlačítko Generovat vytvořte identifikátor náhodných plateb pro nového zákazníka&lt;/p&gt; &lt;p&gt;Zašlete vašemu zákazníkovi tento kód QR, aby provedl platbu (pokud má zákazník software, který podporuje skenování QR kódu).&lt;/p&gt;&lt;p&gt;Tato stránka automaticky vyhledává příchozí transakci v blockchain databázi a tx poolu. Zadáte-li částku, bude také kontrolovat, zda příchozí transakce dosahují až této výše.&lt;/p&gt;Je na vás, zda vám postačí nepotvrzené transakce nebo ne. Je pravděpodobné, že budou následně v krátkém čase potvrzeny, ale stále existuje možnost, že nebudou, takže u větších hodnot možná budete chtít počkat na jedno nebo více potvrzení.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="384"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Uložit QR kód</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="385"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Chyba uložení QR kód do</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="396"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Uložit jako</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="221"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ID platby</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="253"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generovat</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="282"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generovat ID platby pro integrovanou adresu</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="306"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
@@ -1325,25 +953,6 @@
         <location filename="../components/RemoteNodeEdit.qml" line="57"/>
         <source>Port</source>
         <translation>Port</translation>
-    </message>
-</context>
-<context>
-    <name>RightPanel</name>
-    <message>
-        <source>Twitter</source>
-        <translation type="obsolete">Twitter</translation>
-    </message>
-    <message>
-        <source>News</source>
-        <translation type="obsolete">Novinky</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="obsolete">Pomoc</translation>
-    </message>
-    <message>
-        <source>About</source>
-        <translation type="obsolete">O</translation>
     </message>
 </context>
 <context>
@@ -1367,35 +976,15 @@
         <translation>Vytvořit peněženku pouze pro čtení</translation>
     </message>
     <message>
-        <source>Manage daemon</source>
-        <translation type="obsolete">Spravovat démona</translation>
-    </message>
-    <message>
-        <source>Start daemon</source>
-        <translation type="obsolete">Spustit démona</translation>
-    </message>
-    <message>
-        <source>Stop daemon</source>
-        <translation type="obsolete">Zastavit démona</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="259"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Zobrazit stav</translation>
     </message>
     <message>
-        <source>Daemon startup flags</source>
-        <translation type="obsolete">Spouštěcí parametry démona</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="284"/>
-        <location filename="../pages/Settings.qml" line="314"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(nepovinné)</translation>
-    </message>
-    <message>
-        <source>Show seed &amp; keys</source>
-        <translation type="obsolete">Zobrazit seed &amp; klíče</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="145"/>
@@ -1413,68 +1002,44 @@
         <translation>Informace</translation>
     </message>
     <message>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="obsolete">Úspěšně přeskenované odchozí výstupy</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="277"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Umístění blockchainu</translation>
     </message>
     <message>
-        <source>Daemon address</source>
-        <translation type="obsolete">Adresa démona</translation>
-    </message>
-    <message>
-        <source>Hostname / IP</source>
-        <translation type="obsolete">Hostname / IP</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="obsolete">Port</translation>
-    </message>
-    <message>
-        <source>Login (optional)</source>
-        <translation type="obsolete">Přihlášení (nepovinné)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="337"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Uživatelské jméno</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="346"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Heslo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="371"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Připojit</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="395"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Nastavení zobrazení</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="413"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Vlastní dekorace</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Úroveň logování</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(např. *:WARNING,net.p2p:DEBUG)</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="obsolete">Verze</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="160"/>
@@ -1482,87 +1047,92 @@
         <translation>Úspěšně přeskenované utracené výstupy.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
         <source>Local Node</source>
         <translation>Lokální uzel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="189"/>
+        <location filename="../pages/Settings.qml" line="215"/>
         <source>Remote Node</source>
         <translation>Vzdálený uzel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="207"/>
+        <location filename="../pages/Settings.qml" line="233"/>
         <source>Manage Daemon</source>
         <translation>Spravovat démona</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="213"/>
+        <location filename="../pages/Settings.qml" line="239"/>
         <source>Show advanced</source>
         <translation>Zobrazit rozšířené</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="231"/>
+        <location filename="../pages/Settings.qml" line="257"/>
         <source>Start Local Node</source>
         <translation>Nastartovat lokální uzel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="246"/>
+        <location filename="../pages/Settings.qml" line="272"/>
         <source>Stop Local Node</source>
         <translation>Zastavit lokální uzel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="307"/>
+        <location filename="../pages/Settings.qml" line="333"/>
         <source>Local daemon startup flags</source>
         <translation>Příznaky pro start lokálního démona</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="325"/>
+        <location filename="../pages/Settings.qml" line="351"/>
         <source>Node login (optional)</source>
         <translation>Přihlášení k uzlu (nepovinné)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="356"/>
+        <location filename="../pages/Settings.qml" line="382"/>
         <source>Remote node</source>
         <translation>Vzdálený uzel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="472"/>
+        <location filename="../pages/Settings.qml" line="498"/>
         <source>Debug info</source>
         <translation>Ladicí informace</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="486"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Verze grafického rozhraní</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="491"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Vestavěná verze Monero: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="497"/>
+        <location filename="../pages/Settings.qml" line="523"/>
         <source>Wallet creation height: </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="498"/>
+        <location filename="../pages/Settings.qml" line="524"/>
         <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="524"/>
+        <location filename="../pages/Settings.qml" line="550"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="537"/>
+        <location filename="../pages/Settings.qml" line="563"/>
         <source>Rescan wallet cache</source>
         <translation>Přeskenovat mezipaměť peněženky</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="538"/>
+        <location filename="../pages/Settings.qml" line="564"/>
         <source>Are you sure you want to rebuild the wallet cache?
 The following information will be deleted
 - Recipient addresses
@@ -1581,84 +1151,71 @@ Starší soubor mezipaměti peněženky bude přejmenován a později jej lze ob
 </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="566"/>
+        <location filename="../pages/Settings.qml" line="592"/>
         <source>Wallet log path: </source>
         <translation>Cesta k logu peněženky: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="570"/>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
         <source>Daemon log path: </source>
         <translation>Cesta k logu démona: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="579"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Log démona</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="588"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Prosím vyberte adresář</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="597"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Chyba: Souborový systém je v módu pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="604"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Varování: na diskovém oddílu zbývá pouze %1 GB místa. Blockchain potřebuje ~%2 GB místa.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="606"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Poznámka: na diskovém oddílu zbývá pouze %1 GB místa. Blockchain potřebuje ~%2 GB místa.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="610"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Poznánka: lmdb adresář nenalezen. Vytvořím nový.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="546"/>
-        <location filename="../pages/Settings.qml" line="614"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="obsolete">Zobrazit seed &amp; klíče</translation>
-    </message>
-    <message>
-        <source>Secret view key</source>
-        <translation type="obsolete">Prohlížení tajného klíče</translation>
-    </message>
-    <message>
-        <source>Public view key</source>
-        <translation type="obsolete">Prohlížení veřejného klíče</translation>
-    </message>
-    <message>
-        <source>Secret spend key</source>
-        <translation type="obsolete">Tajný klíč pro výdaj</translation>
-    </message>
-    <message>
-        <source>Public spend key</source>
-        <translation type="obsolete">Veřejný klíč pro výdaj</translation>
-    </message>
-    <message>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
-        <translation type="obsolete">Špatné heslo</translation>
+        <translation type="unfinished">Špatné heslo</translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="66"/>
@@ -1738,9 +1295,14 @@ Starší soubor mezipaměti peněženky bude přejmenován a později jej lze ob
         <translation>Prosím zvolte soubor k ověření</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="386"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: %1px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;%2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;%3&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: %1px;}&lt;/style&gt;                            Podpisová adresa &lt;font size=&apos;%2&apos;&gt;  ( Vložte nebo zvolte z &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresáře&lt;/a&gt;&lt;font size=&apos;%3&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="160"/>
@@ -1756,8 +1318,8 @@ Starší soubor mezipaměti peněženky bude přejmenován a později jej lze ob
     <message>
         <location filename="../pages/Sign.qml" line="234"/>
         <location filename="../pages/Sign.qml" line="239"/>
-        <location filename="../pages/Sign.qml" line="412"/>
-        <location filename="../pages/Sign.qml" line="417"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
@@ -1779,10 +1341,6 @@ Starší soubor mezipaměti peněženky bude přejmenován a později jej lze ob
 </context>
 <context>
     <name>StandardDialog</name>
-    <message>
-        <source>Ok</source>
-        <translation type="obsolete">OK</translation>
-    </message>
     <message>
         <location filename="../components/StandardDialog.qml" line="122"/>
         <source>Double tap to copy</source>
@@ -1906,14 +1464,6 @@ Starší soubor mezipaměti peněženky bude přejmenován a později jej lze ob
 <context>
     <name>TickDelegate</name>
     <message>
-        <source>Normal</source>
-        <translation type="obsolete">Normální</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation type="obsolete">Střední</translation>
-    </message>
-    <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
         <source>Default</source>
         <translation>Výchozí</translation>
@@ -1927,236 +1477,207 @@ Starší soubor mezipaměti peněženky bude přejmenován a později jej lze ob
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start démona&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Chyba OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Úroveň soukromí (počet podpisovatelů %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="126"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="178"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Priorita transakce</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="161"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Vše</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="191"/>
-        <source>Low (x1 fee)</source>
-        <translation>Nízký (x1 poplatek)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="192"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Střední (x20 poplatek)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="193"/>
-        <source>High (x166 fee)</source>
-        <translation>Vysoký (x166 poplatek)</translation>
-    </message>
-    <message>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="obsolete">&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adresu &lt;font size=&apos;2&apos;&gt;  ( vložte nebo zvolte z &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresáře&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="239"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="263"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Vyřešit</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="281"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Nenalezena validní adresa na odpovídající OpenAlias adrese</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="286"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adresa nalezena, avšak DNSSEC podpis nesouhlasí, což může znamenat, že adresa je povržená</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="288"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Nenalezena validní adresa na odpovídající OpenAlias adrese, ani nebyl ověřen DNSSEC podpis, což může znamenat, že adresa je povržená</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="291"/>
-        <location filename="../pages/Transfer.qml" line="294"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Interní chyba</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="297"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Adresa nenalezena</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Popis &lt;font size=&apos;2&apos;&gt;( nepovinné )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="322"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Uloženo v historii lokální peněženky</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="330"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Odeslat</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="395"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Zobrazit rozšířené možnosti</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="458"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Nemixovatelné výstupy</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="472"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Vytvořit tx soubor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="494"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Podepsat tx soubor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="508"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Odeslat tx soubor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informace</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="530"/>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Prosím vyberte soubor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="225"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                          Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                          Adresa &lt;font size=&apos;2&apos;&gt;  ( Vložte nebo zvolte z &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresáře&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="542"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Nelze nahrát nepodepsanou transakci</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Počet transakcí: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transakce #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="552"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Adresát: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="553"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 ID platby: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Částka: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Poplatek: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Počet podpisovatelů: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="570"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Potvrzení</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Nelze odeslat transakci</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="604"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Částka úspěšně odeslaná</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
-        <location filename="../pages/Transfer.qml" line="670"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Peněženka není připojená k démonovi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="673"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Démon ke kterému jsme připojeni není kompatibilní s grafickým rozhraním.
 Prosím, aktualizujte jej nebo se připojte k jinému démonovi.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="678"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Čekám na dokončení synchronizace démona</translation>
     </message>
@@ -2166,37 +1687,52 @@ Prosím, aktualizujte jej nebo se připojte k jinému démonovi.</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="423"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Náklady transakce</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="305"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID platby &lt;font size=&apos;2&apos;&gt;( nepovinné )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="200"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Spustit démona</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Pomalý (x0.25 poplatek)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="201"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Výchozí (x1 poplatek)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="202"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Rychlý (x5 poplatek)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="203"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Nejrychlejší (x41.5 poplatek)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="311"/>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresa</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 nebo 64 hexadecimálních znaků</translation>
     </message>
@@ -2204,107 +1740,77 @@ Prosím, aktualizujte jej nebo se připojte k jinému démonovi.</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation type="obsolete">Ověřte, že třetí osoba provedla platbu dodáním:</translation>
-    </message>
-    <message>
-        <source> - the recipient address</source>
-        <translation type="obsolete"> - adresa příjemce</translation>
-    </message>
-    <message>
-        <source> - the transaction ID</source>
-        <translation type="obsolete"> - ID transakce</translation>
-    </message>
-    <message>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation type="obsolete"> - klíč tajné transakce dodaný odesílatelem</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="343"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Pokud má platba několik transakcí, musí být každá transakce zkontrolována a výsledky zkombinovány.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="128"/>
-        <location filename="../pages/TxKey.qml" line="239"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="93"/>
-        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message:</source>
-        <translation>Vytvořte potvrzení o příchozí/odchozí platbě uvedením ID transakce, adresy příjemce a volitelné zprávy:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="135"/>
-        <location filename="../pages/TxKey.qml" line="246"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Příjemce</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="154"/>
-        <location filename="../pages/TxKey.qml" line="265"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
         <source>Message</source>
         <translation>Zpráva</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
-        <location filename="../pages/TxKey.qml" line="272"/>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
         <source>Optional message against which the signature is signed</source>
         <translation>Volitelná zpráva, proti které je podpis podepsán</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="181"/>
+        <location filename="../pages/TxKey.qml" line="186"/>
         <source>Generate</source>
         <translation>Generovat</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="204"/>
-        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature:</source>
-        <translation>Ověřte, zda byly na adresu zaslány finanční prostředky, a to zadáním ID transakce, adresy příjemce, zprávy a podpisu:</translation>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="291"/>
+        <location filename="../pages/TxKey.qml" line="297"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="299"/>
+        <location filename="../pages/TxKey.qml" line="305"/>
         <source>Paste tx proof</source>
         <translation>Vložte důkaz tx</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="101"/>
-        <location filename="../pages/TxKey.qml" line="212"/>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>ID transakce</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="108"/>
-        <location filename="../pages/TxKey.qml" line="219"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Vložte tx ID</translation>
     </message>
     <message>
-        <source>Paste tx key</source>
-        <translation type="obsolete">Vložte tx klíč</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="320"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Zkontrolovat</translation>
-    </message>
-    <message>
-        <source>Transaction key</source>
-        <translation type="obsolete">Transakční klíč</translation>
-    </message>
-</context>
-<context>
-    <name>WalletManager</name>
-    <message>
-        <location filename="../src/libwalletqt/WalletManager.cpp" line="153"/>
-        <source>Unknown error</source>
-        <translation>Neznámá chyba</translation>
     </message>
 </context>
 <context>
@@ -2637,10 +2143,6 @@ Prosím, aktualizujte jej nebo se připojte k jinému démonovi.</translation>
         <translation>Otevřít peněženku ze souboru</translation>
     </message>
     <message>
-        <source>Custom daemon address (optional)</source>
-        <translation type="obsolete">Vlastní adresa démona (nepovinné)</translation>
-    </message>
-    <message>
         <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testovací síť</translation>
@@ -2697,2815 +2199,116 @@ Prosím, aktualizujte jej nebo se připojte k jinému démonovi.</translation>
     </message>
 </context>
 <context>
-    <name>command_line</name>
-    <message>
-        <location filename="../monero/src/common/command_line.cpp" line="57"/>
-        <source>yes</source>
-        <translation>ano</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/common/command_line.cpp" line="71"/>
-        <source>no</source>
-        <translation>ne</translation>
-    </message>
-</context>
-<context>
-    <name>cryptonote::rpc_args</name>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="39"/>
-        <source>Specify ip to bind rpc server</source>
-        <translation>Zadejte IP pro připojení k RPC serveru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="40"/>
-        <source>Specify username[:password] required for RPC server</source>
-        <translation>Zadejte uzivatel[:heslo] nutné pro RPC server</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="41"/>
-        <source>Confirm rpc-bind-ip value is NOT a loopback (local) IP</source>
-        <translation>Potvrďte, že hodnota rpc-bind-ip NENÍ loopback (lokální) IP</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="42"/>
-        <source>Specify a comma separated list of origins to allow cross origin resource sharing</source>
-        <translation>Zadejte seznam zdrojů oddělených čárkami pro umožnění sdílení zdrojů</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="69"/>
-        <source>Invalid IP address given for --</source>
-        <translation>Neplatná IP adresa pro --</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="77"/>
-        <source> permits inbound unencrypted external connections. Consider SSH tunnel or SSL proxy instead. Override with --</source>
-        <translation> umožňuje příchozí nezašifrované externí připojení. Zvažte raději použití SSH tunelu nebo SSL proxy. Přepsat s --</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="94"/>
-        <source>Username specified with --</source>
-        <translation>Uživatelské jmnéno specifikované s --</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="94"/>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="104"/>
-        <source> cannot be empty</source>
-        <translation> nemůže být prázdné</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/rpc/rpc_args.cpp" line="104"/>
-        <source> requires RFC server password --</source>
-        <translation> vyžaduje RFC heslo serveru --</translation>
-    </message>
-</context>
-<context>
-    <name>cryptonote::simple_wallet</name>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="211"/>
-        <source>true</source>
-        <translation>ano</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="216"/>
-        <source>false</source>
-        <translation>ne</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="264"/>
-        <source>failed to parse refresh type</source>
-        <translation>Nepodařilo se zparsovat typ obnovení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="360"/>
-        <source>Commands: </source>
-        <translation>Příkazy: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="374"/>
-        <source>Unknown command: </source>
-        <translation>Neznámý příkaz: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="381"/>
-        <source>Command usage: </source>
-        <translation>Použití příkazu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="384"/>
-        <source>Command description: </source>
-        <translation>Popis příkazu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="403"/>
-        <source>wallet is watch-only and has no spend key</source>
-        <translation>Peněženka je pouze pro čtení a neobsahuje žádný klíč pro utracení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="421"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="472"/>
-        <source>wallet is watch-only and has no seed</source>
-        <translation>Peněženka je pouze pro čtení a neobsahuje žádný seed</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="438"/>
-        <source>Enter optional seed encryption passphrase, empty to see raw seed</source>
-        <translation>Zadejte volitelnou přístupovou frázi pro šifrování seed, prázdné pro nešifrovaný seed</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="453"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="477"/>
-        <source>wallet is non-deterministic and has no seed</source>
-        <translation>Peněženka je nedeterministická a neobsahuje seed</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="500"/>
-        <source>Your original password was incorrect.</source>
-        <translation>Vaše původní heslo nebylo zadáno správně.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="514"/>
-        <source>Error with wallet rewrite: </source>
-        <translation>Chyba přepsání peněženky: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="526"/>
-        <source>usage: payment_id</source>
-        <translation>použijte: payment_id</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="530"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5096"/>
-        <source>Random payment ID: </source>
-        <translation>Náhodné ID platby: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="538"/>
-        <source>Cannot connect to daemon</source>
-        <translation>Nelze se připojit k démonovi</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="543"/>
-        <source>Current fee is %s monero per kB</source>
-        <translation>Aktuální poplatek je %s monero za kB</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="559"/>
-        <source>Error: failed to estimate backlog array size: </source>
-        <translation>Chyba: nepodařilo se odhadnout velikost backlog pole: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="564"/>
-        <source>Error: bad estimated backlog array size</source>
-        <translation>Chyba: chybný odhad velikosti backlog pole: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="576"/>
-        <source> (current)</source>
-        <translation> (nepovinné)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="579"/>
-        <source>%u block (%u minutes) backlog at priority %u%s</source>
-        <translation>%u blok (%u minut) backlog s prioritou %u%s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="581"/>
-        <source>%u to %u block (%u to %u minutes) backlog at priority %u</source>
-        <translation>%u k %u bloku (%u do %u minut) backlog s prioritou %u</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="584"/>
-        <source>No backlog at priority </source>
-        <translation>Žádný backlog s prioritou </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="619"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="638"/>
-        <source>wallet is watch-only and cannot transfer</source>
-        <translation>Peněženka je pouze pro čtení a neumožňuje platby</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="645"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="651"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="665"/>
-        <source>ring size must be an integer &gt;= </source>
-        <translation>ring size musí být celé číslo &gt;= </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="670"/>
-        <source>could not change default ring size</source>
-        <translation>Nelyze změnit výchozí ring size</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="682"/>
-        <source>priority must be 0, 1, 2, 3, or 4 </source>
-        <translation>priorita musí být 0, 1, 2, 3, nebo 4 </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="694"/>
-        <source>priority must be 0, 1, 2, 3,or 4</source>
-        <translation>priorita musí být 0, 1, 2, 3,nebo 4 </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="709"/>
-        <source>priority must be 0, 1, 2 3,or 4</source>
-        <translation>priorita musí být 0, 1, 2 3,nebo 4 </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="714"/>
-        <source>could not change default priority</source>
-        <translation>Nelze změnit výchozí prioritu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="797"/>
-        <source>invalid unit</source>
-        <translation>Nesprávná jednotka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="815"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="877"/>
-        <source>invalid count: must be an unsigned integer</source>
-        <translation>Neplatný počet: musí být celé číslo bez znaménka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="833"/>
-        <source>invalid value</source>
-        <translation>Neplatný počet</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="898"/>
-        <source>Invalid height</source>
-        <translation>Nesprávná délka blockchain</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="931"/>
-        <source>start_mining [&lt;number_of_threads&gt;] [bg_mining] [ignore_battery]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="932"/>
-        <source>Start mining in the daemon (bg_mining and ignore_battery are optional booleans).</source>
-        <translation>Započít těžení prostřednictvím démona (bg_mining a ignore_battery jsou nepovinné boolean hodnoty).</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="935"/>
-        <source>Stop mining in the daemon.</source>
-        <translation>Zastavit těžení prostřednictvím démona.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="938"/>
-        <source>Save the current blockchain data.</source>
-        <translation>Uložit aktuální data z blokchainu.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="941"/>
-        <source>Synchronize the transactions and balance.</source>
-        <translation>Synchronizovat transakce a zůstatky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="944"/>
-        <source>balance [detail]</source>
-        <translation>Zůstatek [detail]</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="945"/>
-        <source>Show the wallet&apos;s balance of the currently selected account.</source>
-        <translation>Zobrazit zůstatek v peněžence u aktuálné zvoleného účtu.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="948"/>
-        <source>incoming_transfers [available|unavailable] [verbose] [index=&lt;N1&gt;[,&lt;N2&gt;[,...]]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="949"/>
-        <source>Show the incoming transfers, all or filtered by availability and address index.</source>
-        <translation>Zobrazit příchozí převody, všechny nebo filtrované dle dostupnosti a indexu adres.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="952"/>
-        <source>payments &lt;PID_1&gt; [&lt;PID_2&gt; ... &lt;PID_N&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="953"/>
-        <source>Show the payments for the given payment IDs.</source>
-        <translation>Zobrazit platby vztažené k poskytnutému ID platby.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="956"/>
-        <source>Show the blockchain height.</source>
-        <translation>Zobrazit délku blockchain.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="959"/>
-        <source>transfer_original [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="960"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt; using an older transaction building algorithm. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the fee of the transaction. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>Převeďte &lt;množství&gt; na &lt;adresu&gt; pomocí staršího algoritmu budování transakcí. Pokud parametr &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...] je zadán, peněžka použije výstupy přijaté těmito adresami. Pokud je vynechán, peněženka je vybere náhodně. V každém případě se pokouší nejlépe kombinovat výstupy na více adres. &lt;priority&gt; je prioritou transakce. Čím vyšší je priorita, tím vyšší je poplatek za transakci. Platné hodnoty priorit jsou v tomto pořadí (od nejnižšího po nejvyšší): nedůležité, normální, zvýšené, prioritní. Pokud je vynechána, použije se výchozí hodnota (viz příkaz "set priority"). &lt;ring_size&gt; je počet vstupů, které mají být zahrnuty pro nedohledatelnost. Vícenásobné platby lze provést najednou přidáním &lt;address_2&gt; &lt;amount_2&gt; atd. (před ID platby, pokud je uvedeno)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="962"/>
-        <source>transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; &lt;amount&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="963"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt;. If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the fee of the transaction. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>Převeďte &lt;množství&gt; na &lt;adresu&gt;Pokud parametr &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...] je zadán, peněžka použije výstupy přijaté těmito adresami. Pokud je vynechán, peněženka je vybere náhodně. V každém případě se pokouší nejlépe kombinovat výstupy na více adres. &lt;priority&gt; je prioritou transakce. Čím vyšší je priorita, tím vyšší je poplatek za transakci. Platné hodnoty priorit jsou v tomto pořadí (od nejnižšího po nejvyšší): nedůležité, normální, zvýšené, prioritní. Pokud je vynechána, použije se výchozí hodnota (viz příkaz "set priority"). &lt;ring_size&gt; je počet vstupů, které mají být zahrnuty pro nedohledatelnost. Vícenásobné platby lze provést najednou přidáním &lt;address_2&gt; &lt;amount_2&gt; atd. (před ID platby, pokud je uvedeno)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="966"/>
-        <source>locked_transfer [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;addr&gt; &lt;amount&gt; &lt;lockblocks&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="967"/>
-        <source>Transfer &lt;amount&gt; to &lt;address&gt; and lock it for &lt;lockblocks&gt; (max. 1000000). If the parameter &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet uses outputs received by addresses of those indices. If omitted, the wallet randomly chooses address indices to be used. In any case, it tries its best not to combine outputs across multiple addresses. &lt;priority&gt; is the priority of the transaction. The higher the priority, the higher the fee of the transaction. Valid values in priority order (from lowest to highest) are: unimportant, normal, elevated, priority. If omitted, the default value (see the command &quot;set priority&quot;) is used. &lt;ring_size&gt; is the number of inputs to include for untraceability. Multiple payments can be made at once by adding &lt;address_2&gt; &lt;amount_2&gt; etcetera (before the payment ID, if it&apos;s included)</source>
-        <translation>Převeďte &lt;množství&gt; na &lt;adresu&gt; a zamkněte je pro počet bloků. Pokud parametr &quot;index=&lt;N1&gt;[,&lt;N2&gt;,...] je zadán, peněžka použije výstupy přijaté těmito adresami. Pokud je vynechán, peněženka je vybere náhodně. V každém případě se pokouší nejlépe kombinovat výstupy na více adres. &lt;priority&gt; je prioritou transakce. Čím vyšší je priorita, tím vyšší je poplatek za transakci. Platné hodnoty priorit jsou v tomto pořadí (od nejnižšího po nejvyšší): nedůležité, normální, zvýšené, prioritní. Pokud je vynechána, použije se výchozí hodnota (viz příkaz "set priority"). &lt;ring_size&gt; je počet vstupů, které mají být zahrnuty pro nedohledatelnost. Vícenásobné platby lze provést najednou přidáním &lt;address_2&gt; &lt;amount_2&gt; atd. (před ID platby, pokud je uvedeno)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="970"/>
-        <source>Send all unmixable outputs to yourself with ring_size 1</source>
-        <translation>Odeslání všech nezměnitelných výstupů sám sobě pomocí ring_size 1</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="972"/>
-        <source>sweep_all [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="973"/>
-        <source>Send all unlocked balance to an address. If the parameter &quot;index&lt;N1&gt;[,&lt;N2&gt;,...]&quot; is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used.</source>
-        <translation>Odeslání veškerého odblokovaného zůstatku na adresu. Pokud parametr "index" N1> [, N2>, ...] je upřesněno, peněženka zaměňuje výstupy přijaté těmito adresovými indexy. Pokud je vynechána, náhodně vybere index peněz, který má být použit.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="976"/>
-        <source>sweep_below &lt;amount_threshold&gt; [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;address&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="977"/>
-        <source>Send all unlocked outputs below the threshold to an address.</source>
-        <translation>Odeslat všechny odemčené výstupy pod prahovou hodnotou na adresu.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="980"/>
-        <source>sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="981"/>
-        <source>Send a single output of the given key image to an address without change.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="984"/>
-        <source>donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="985"/>
-        <source>Donate &lt;amount&gt; to the development team (donate.getmonero.org).</source>
-        <translation>Darujte &lt;částku&gt; vývojovému týmu (donate.getmonero.org).</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="988"/>
-        <source>sign_transfer &lt;file&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="989"/>
-        <source>Sign a transaction from a &lt;file&gt;.</source>
-        <translation>Podepsat transakci ze &lt;souboru&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="992"/>
-        <source>Submit a signed transaction from a file.</source>
-        <translation>Odeslat podepsanou transakci ze souboru.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="995"/>
-        <source>set_log &lt;level&gt;|{+,-,}&lt;categories&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="996"/>
-        <source>Change the current log detail (level must be &lt;0-4&gt;).</source>
-        <translation>Změnit aktuální úroveň logování (musí být &lt;0-4&gt;)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="999"/>
-        <source>account [new &lt;label text with white spaces allowed&gt; | switch &lt;index&gt; | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1000"/>
-        <source>If no arguments are specified, the wallet shows all the existing accounts along with their balances. If the &quot;new&quot; argument is specified, the wallet creates a new account with its label initialized by the provided label text (which can be empty). If the &quot;switch&quot; argument is specified, the wallet switches to the account specified by &lt;index&gt;. If the &quot;label&quot; argument is specified, the wallet sets the label of the account specified by &lt;index&gt; to the provided label text.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1003"/>
-        <source>address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1004"/>
-        <source>If no arguments are specified or &lt;index&gt; is specified, the wallet shows the default or specified address. If &quot;all&quot; is specified, the walllet shows all the existing addresses in the currently selected account. If &quot;new &quot; is specified, the wallet creates a new address with the provided label text (which can be empty). If &quot;label&quot; is specified, the wallet sets the label of the address specified by &lt;index&gt; to the provided label text.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1007"/>
-        <source>integrated_address [&lt;payment_id&gt; | &lt;address&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1008"/>
-        <source>Encode a payment ID into an integrated address for the current wallet public address (no argument uses a random payment ID), or decode an integrated address to standard address and payment ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1011"/>
-        <source>address_book [(add ((&lt;address&gt; [pid &lt;id&gt;])|&lt;integrated address&gt;) [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1012"/>
-        <source>Print all entries in the address book, optionally adding/deleting an entry to/from it.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1015"/>
-        <source>Save the wallet data.</source>
-        <translation>Uložit data z peněženky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1018"/>
-        <source>Save a watch-only keys file.</source>
-        <translation>Uložit soubor s klíči pouze pro čtení.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1021"/>
-        <source>Display the private view key.</source>
-        <translation>Zobrazit privátni klíč pro zobrazení.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1024"/>
-        <source>Display the private spend key.</source>
-        <translation>Zobrazit privátni klíč pro utracení.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1027"/>
-        <source>Display the Electrum-style mnemonic seed</source>
-        <translation>Zobrazit mnemonický seed v Electrum stylu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1030"/>
-        <source>set &lt;option&gt; [&lt;value&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1031"/>
-        <source>Available options:
- seed language
-   Set the wallet&apos;s seed language.
- always-confirm-transfers &lt;1|0&gt;
-   Whether to confirm unsplit txes.
- print-ring-members &lt;1|0&gt;
-   Whether to print detailed information about ring members during confirmation.
- store-tx-info &lt;1|0&gt;
-   Whether to store outgoing tx info (destination address, payment ID, tx secret key) for future reference.
- default-ring-size &lt;n&gt;
-   Set the default ring size (default and minimum is 5).
- auto-refresh &lt;1|0&gt;
-   Whether to automatically synchronize new blocks from the daemon.
- refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt;
-   Set the wallet&apos;s refresh behaviour.
- priority [0|1|2|3|4]
-   Set the fee too default/unimportant/normal/elevated/priority.
- confirm-missing-payment-id &lt;1|0&gt;
- ask-password &lt;1|0&gt;
- unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
-   Set the default monero (sub-)unit.
- min-outputs-count [n]
-   Try to keep at least that many outputs of value at least min-outputs-value.
- min-outputs-value [n]
-   Try to keep at least min-outputs-count outputs of at least that value.
- merge-destinations &lt;1|0&gt;
-   Whether to merge multiple payments to the same destination address.
- confirm-backlog &lt;1|0&gt;
-   Whether to warn if there is transaction backlog.
- confirm-backlog-threshold [n]
-   Set a threshold for confirm-backlog to only warn if the transaction backlog is greater than n blocks.
- refresh-from-block-height [n]
-   Set the height before which to ignore blocks.</source>
-        <translation>Dostupné možnosti:
- seed language
-   Nastavte jazyk seedu
- always-confirm-transfers &lt;1|0&gt;
-   Potvrzovat nesplněné transakce.
- print-ring-members &lt;1|0&gt;
-   Zda se při potvrzení vytisknou podrobné informace o členství v ringu.
- store-tx-info &lt;1|0&gt;
-   Informace o uložení odchozích informací tx (cílová adresa, ID platby, tajný klíč tx) pro budoucí použití.
- default-ring-size &lt;n&gt;
-   Nastavte výchozí velikost ring (výchozí a minimálně 5).
- auto-refresh &lt;1|0&gt;
-   Zda se automaticky mají synchronizovat nové bloky od démona.
- refresh-type &lt;full|optimize-coinbase|no-coinbase|default&gt;
-   Nastavte chování obnovení peněženky.
- priority [0|1|2|3|4]
-   Nastavte poplatek příliš neplatný / nedůležitý / normální / zvýšený / prioritní.
- confirm-missing-payment-id &lt;1|0&gt;
- ask-password &lt;1|0&gt;
- unit &lt;monero|millinero|micronero|nanonero|piconero&gt;
-   Nastavte výchozí jednotku monero (nebo zlomek).
- min-outputs-count [n]
-   Snažte se udržet alespoň tolik výstupů s hodnotou alespoň min-outputs-value.
- min-outputs-value [n]
-   Pokuste se udržet minimálně min-outputs-count výstupů.
- merge-destinations &lt;1|0&gt;
-   Zda se sloučí více plateb do stejné cílové adresy.
- confirm-backlog &lt;1|0&gt;
-   O tom, zda chcete upozornit na případné nevyřízené transakce.
- confirm-backlog-threshold [n]
-   Nastavte prahovou hodnotu pro confirm-backlog, aby se varovala pouze v případě, že je nevyřízený počet transakcí větší než n bloků.
- refresh-from-block-height [n]
-   Nastavte délku blockchain, před kterou chcete bloky ignorovat.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1066"/>
-        <source>Display the encrypted Electrum-style mnemonic seed.</source>
-        <translation>Zobrazit šifrovaný mnemonický seed v Electrum stylu.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1069"/>
-        <source>Rescan the blockchain for spent outputs.</source>
-        <translation>Přeskenovat blockchain na utracené výstupy.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1072"/>
-        <source>get_tx_key &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1073"/>
-        <source>Get the transaction key (r) for a given &lt;txid&gt;.</source>
-        <translation>Získat transakční klíč (r) pro poskytnuté &lt;txid&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1076"/>
-        <source>check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1077"/>
-        <source>Check the amount going to &lt;address&gt; in &lt;txid&gt;.</source>
-        <translation>Zkontrolovat částku odcházející na &lt;adresu&gt; v &lt;txid&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1080"/>
-        <source>get_tx_proof_out &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1081"/>
-        <source>Generate a signature proving funds sent to &lt;address&gt; in &lt;txid&gt;, optionally with a challenge string &lt;message&gt;, using either the transaction secret key (when &lt;address&gt; is not your wallet&apos;s address) or the view secret key (otherwise), which does not disclose the secret key.</source>
-        <translation>Generovat podpis prokazující částky zaslané na &lt;adresu&gt; v &lt;txid&gt;, volitelně s &lt;výzvou&gt;, použitím buď tajného transakčního klíče (pokud &lt;adresa&gt; není addresa vaší peněženky) nebo tajný klíč pro zobrazení, který neprozrazuje tajný klíč.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1084"/>
-        <source>check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1085"/>
-        <source>Check the proof for funds going to &lt;address&gt; in &lt;txid&gt; with the challenge string &lt;message&gt; if any.</source>
-        <translation>Zkontrolujte důkaz, zda peněžní prostředky odchází na &lt;adresu&gt; v &lt;txid&gt; s případnou výzvou.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1088"/>
-        <source>get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1089"/>
-        <source>Generate a signature proving that you generated &lt;txid&gt; using the spend secret key, optionally with a challenge string &lt;message&gt;.</source>
-        <translation>Generovat podpis prokazující, že jste vygenerovali &lt;txid&gt; použitím tajného klíče pro utracení, volitelně s &lt;výzvou&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1092"/>
-        <source>check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1093"/>
-        <source>Check a signature proving that the signer generated &lt;txid&gt;, optionally with a challenge string &lt;message&gt;.</source>
-        <translation>Zkontrolujte podpis prokazující podepisující vygeneroval &lt;txid&gt;, volitelně s &lt;výzvou&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1096"/>
-        <source>show_transfers [in|out|pending|failed|pool] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1097"/>
-        <source>Show the incoming/outgoing transfers within an optional height range.</source>
-        <translation>Zobrazit příchozí/odchozí převody, volitelně ve specifikovaném rozsahu blockchain řetězce.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1100"/>
-        <source>unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1101"/>
-        <source>Show the unspent outputs of a specified address within an optional amount range.</source>
-        <translation>Zobrazit neutracené výstupy ze specifikované adresy, volitelně v rozsahu specifikované částky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1104"/>
-        <source>Rescan the blockchain from scratch.</source>
-        <translation>Znovu přeskenujte blockchain od začátku.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1107"/>
-        <source>set_tx_note &lt;txid&gt; [free text note]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1108"/>
-        <source>Set an arbitrary string note for a &lt;txid&gt;.</source>
-        <translation>Nastavit libovolnou hodnotu řetězce pro značku &lt;txid&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1111"/>
-        <source>get_tx_note &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1112"/>
-        <source>Get a string note for a txid.</source>
-        <translation>Získat hodnotu řetězce pro značku txid.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1115"/>
-        <source>set_description [free text note]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1116"/>
-        <source>Set an arbitrary description for the wallet.</source>
-        <translation>Nastavte libovolný popis peněženky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1119"/>
-        <source>Get the description of the wallet.</source>
-        <translation>Zobrazit popis peněženky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1122"/>
-        <source>Show the wallet&apos;s status.</source>
-        <translation>Zobrazit stav peněženky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1125"/>
-        <source>Show the wallet&apos;s information.</source>
-        <translation>Zobrazit informace o peněžence.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1128"/>
-        <source>sign &lt;file&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1129"/>
-        <source>Sign the contents of a file.</source>
-        <translation>Podepsat obsah souboru.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1132"/>
-        <source>verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1133"/>
-        <source>Verify a signature on the contents of a file.</source>
-        <translation>Ověřit podpis obsahu souboru.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1136"/>
-        <source>export_key_images &lt;file&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1137"/>
-        <source>Export a signed set of key images to a &lt;file&gt;.</source>
-        <translation>Exportovat podepsaný set potvrzení o utracení do &lt;souboru&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1140"/>
-        <source>import_key_images &lt;file&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1141"/>
-        <source>Import a signed key images list and verify their spent status.</source>
-        <translation>Importovat podepsaný seznam potvrzení o utracení a ověřit stav utracení.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1144"/>
-        <source>export_outputs &lt;file&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1145"/>
-        <source>Export a set of outputs owned by this wallet.</source>
-        <translation>Exportovat seznam výstupů vlastněných touto peněženkou.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1148"/>
-        <source>import_outputs &lt;file&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1149"/>
-        <source>Import a set of outputs owned by this wallet.</source>
-        <translation>Importovat seznam výstupů vlastněných touto peněženkou.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1152"/>
-        <source>show_transfer &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1153"/>
-        <source>Show information about a transfer to/from this address.</source>
-        <translation>Zobrazit informace o převodech do/z této adresy.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1156"/>
-        <source>Change the wallet&apos;s password.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1159"/>
-        <source>Generate a new random full size payment id. These will be unencrypted on the blockchain, see integrated_address for encrypted short payment ids.</source>
-        <translation>Vygenerujte nové, náhodné, plné ID platby. Ty budou nezašifrované v blockchainu, viz integrovaná adresa pro šifrované krátké ID platby.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1162"/>
-        <source>Print the information about the current fee and transaction backlog.</source>
-        <translation>Vytisknout informace o aktuálním poplatku a transakčním backlogu.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1165"/>
-        <source>help [&lt;command&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1166"/>
-        <source>Show the help section or the documentation about a &lt;command&gt;.</source>
-        <translation>Zobrazit sekci nápovědy nebo dokumentace o &lt;příkazu&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1199"/>
-        <source>needs an argument</source>
-        <translation>vyžaduje argument</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1213"/>
-        <source>set seed: needs an argument. available options: language</source>
-        <translation>nastavení seed: vyžaduje argument. dostupné volby: jazyk</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1222"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1223"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1224"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1226"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1229"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1230"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1234"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1235"/>
-        <source>0 or 1</source>
-        <translation>0 nebo 1</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1225"/>
-        <source>integer &gt;= </source>
-        <translation>celé číslo &gt;= </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1227"/>
-        <source>full (slowest, no assumptions); optimize-coinbase (fast, assumes the whole coinbase is paid to a single address); no-coinbase (fastest, assumes we receive no coinbase transaction), default (same as optimize-coinbase)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1228"/>
-        <source>0, 1, 2, 3, or 4</source>
-        <translation>0, 1, 2, 3, nebo 4</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1231"/>
-        <source>monero, millinero, micronero, nanonero, piconero</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1232"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1236"/>
-        <source>unsigned integer</source>
-        <translation>celé číslo bez znaménka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1233"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2551"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2602"/>
-        <source>amount</source>
-        <translation>částka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1237"/>
-        <source>block height</source>
-        <translation>délka blockchainu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1239"/>
-        <source>set: unrecognized argument(s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1248"/>
-        <source>usage: set_log &lt;log_level_number_0-4&gt; | &lt;categories&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1281"/>
-        <source>Wallet name not valid. Please try again or use Ctrl-C to quit.</source>
-        <translation>Název peněženky není validní. Prosím zkuste zadat znovu nebo použijte Ctrl+C pro přerušení.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1293"/>
-        <source>Attempting to generate or restore wallet, but specified file(s) exist.  Exiting to not risk overwriting.</source>
-        <translation>Pokoušíte se generovat nebo obnovit peněženku, ale odpovídající soubory již existují. Ukončuji, aby nedošlo k přepsání.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1298"/>
-        <source>Wallet and key files found, loading...</source>
-        <translation>Nalezena peněženka a soubory s klíči, načítám...</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1304"/>
-        <source>Key file found but not wallet file. Regenerating...</source>
-        <translation>Nalezen soubor s klíči, nikoli však soubor s peněženkou. Přegenerovávám...</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1310"/>
-        <source>Key file not found. Failed to open wallet: </source>
-        <translation>Soubor s klíči nenalezen. Selhalo otevírání peněženky: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1318"/>
-        <source>No wallet found with that name. Confirm creation of new wallet named: </source>
-        <translation>Nenalezena peněženka s tímto názvem. Potvrďte vytvoření nové peněženky: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1319"/>
-        <source>(Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1329"/>
-        <source>Generating new wallet...</source>
-        <translation>Generuji novou peněženku...</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1347"/>
-        <source>PLEASE NOTE: the following 25 words can be used to recover access to your wallet. Please write them down and store them somewhere safe and secure. Please do not store them in your email or on file storage services outside of your immediate control.
-</source>
-        <translation>UPOZORNĚNÍ: Následující 25 slov může být použito k obnovení přístupu k peněženkám. Napište je a uložte je někde bezpečně. Neskladujte je ve vašem e-mailu nebo ve veřejných službách pro ukládání souborů nebo na místech kde k nim mají možnost přístupu jiní.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1372"/>
-        <source>can&apos;t specify more than one of --generate-new-wallet=&quot;wallet_name&quot;, --wallet-file=&quot;wallet_name&quot;, --generate-from-view-key=&quot;wallet_name&quot;, --generate-from-spend-key=&quot;wallet_name&quot;, --generate-from-keys=&quot;wallet_name&quot;, --generate-from-multisig-keys=&quot;wallet_name&quot; and --generate-from-json=&quot;jsonfilename&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1388"/>
-        <source>can&apos;t specify both --restore-deterministic-wallet and --non-deterministic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1393"/>
-        <source>--restore-deterministic-wallet uses --generate-new-wallet, not --wallet-file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1408"/>
-        <source>specify a recovery parameter with the --electrum-seed=&quot;words list here&quot;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1417"/>
-        <source>Electrum-style word list failed verification</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1421"/>
-        <source>Enter seed encryption passphrase, empty if none</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1436"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1456"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1491"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1510"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1530"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1546"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1594"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1619"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1635"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1675"/>
-        <source>No data supplied, cancelled</source>
-        <translation>Žádná poskytnutá data, přerušuji.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1442"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1516"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1625"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3035"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3461"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3669"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4184"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4252"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4316"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5145"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5377"/>
-        <source>failed to parse address</source>
-        <translation>Nepodařilo se zanalyzovat adresu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1447"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1521"/>
-        <source>This address is a subaddress which cannot be used here.</source>
-        <translation>Tato adresa je podadresa, kterou zde nelze použít.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1462"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1552"/>
-        <source>failed to parse view key secret key</source>
-        <translation>Nepodařilo se zanalyzovat tajný klíč pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1472"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1570"/>
-        <source>failed to verify view key secret key</source>
-        <translation>Nepodařilo se ověřit tajný klíč pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1476"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1574"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1655"/>
-        <source>view key does not match standard address</source>
-        <translation>klíč pro zobrazení neodpovídá standartní adrese</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1481"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1500"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1578"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1712"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1738"/>
-        <source>account creation failed</source>
-        <translation>vytvoření účtu selhalo</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1496"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1536"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1680"/>
-        <source>failed to parse spend key secret key</source>
-        <translation>Nepodařilo se zanalyzovat tajný klíč pro utracení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1562"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1701"/>
-        <source>failed to verify spend key secret key</source>
-        <translation>Nepodařilo se ověřit tajný klíč pro utracení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1566"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1706"/>
-        <source>spend key does not match standard address</source>
-        <translation>klíč pro utracení neodpovídá standartní adrese</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1599"/>
-        <source>Error: expected M/N, but got: </source>
-        <translation>Chyba: očekáváno M/N, zadáno: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1604"/>
-        <source>Error: expected N &gt; 1 and N &lt;= M, but got: </source>
-        <translation>Chyba: očekáváno N &gt; 1 a N &lt;= M, zadáno: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1609"/>
-        <source>Error: M/N is currently unsupported. </source>
-        <translation>Chyba: M/N je aktuálně nepodporované. </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1612"/>
-        <source>Generating master wallet from %u of %u multisig wallet keys</source>
-        <translation>Generuji master peněženku %u z %u multisig klíčů peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1641"/>
-        <source>failed to parse secret view key</source>
-        <translation>Selhalo parsování tajného klíče pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1650"/>
-        <source>failed to verify secret view key</source>
-        <translation>Selhalo ověření tajného klíče pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1670"/>
-        <source>Secret spend key (%u of %u):</source>
-        <translation>Tajný klíč pro utracení (%u z %u):</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1694"/>
-        <source>Error: M/N is currently unsupported</source>
-        <translation>Chyba: M/N aktuálně není podporovaný</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1733"/>
-        <source>specify a wallet path with --generate-new-wallet (not --wallet-file)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1767"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1794"/>
-        <source>bad m_restore_height parameter: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1772"/>
-        <source>date format must be YYYY-MM-DD</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1785"/>
-        <source>Restore height is: </source>
-        <translation>Obnovená délka blockchainu je:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1786"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3227"/>
-        <source>Is this okay?  (Y/Yes/N/No): </source>
-        <translation>JE to OK?  (Y/Yes/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1808"/>
-        <source>Restore height </source>
-        <translation>Obnovit délku blockchainu </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1809"/>
-        <source>Still apply restore height?  (Y/Yes/N/No): </source>
-        <translation>Opravdu obnovit délku blockchainu?  (Y/Yes/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1820"/>
-        <source>failed to open account</source>
-        <translation>Selhalo otevření účtu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1824"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2229"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2284"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2305"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4220"/>
-        <source>wallet is null</source>
-        <translation>Peněženka je prázdná</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1833"/>
-        <source>Daemon is local, assuming trusted</source>
-        <translation>Démon je lokální, považuji za důvěryhodného</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1840"/>
-        <source>Warning: using an untrusted daemon at %s, privacy will be lessened</source>
-        <translation>Varování: používám nedůvěryhodného démona na %s, úroveň soukromí může být ponížena.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1891"/>
-        <source>wallet failed to connect to daemon: </source>
-        <translation>Selhalo připojení peněženky k démonovi: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1892"/>
-        <source>Daemon either is not started or wrong port was passed. Please make sure daemon is running or restart the wallet with the correct daemon address.</source>
-        <translation>Démon buď není spuštěn, nebo byl předán špatný port. Ujistěte se, že démon běží nebo restartujte peněženku se správnou adresou démona.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1899"/>
-        <source>Daemon uses a different RPC major version (%u) than the wallet (%u): %s. Either update one of them, or use --allow-mismatched-daemon-version.</source>
-        <translation>Daemon používá jinou hlavní verzi RPC (%u) než peněženka (%u): %s. Buď aktualizujte jednu z nich nebo použijte --allow-mismatched-daemon-version.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1918"/>
-        <source>List of available languages for your wallet&apos;s seed:</source>
-        <translation>Seznam dostupných jazyků pro seed vaší peněženky:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1927"/>
-        <source>Enter the number corresponding to the language of your choice: </source>
-        <translation>Zadejte číslo odpovídající požadovanému jazyku: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1936"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1941"/>
-        <source>invalid language choice passed. Please try again.
-</source>
-        <translation>Zvolena neplatná volba jazyka. Prosím zkuste to znovu.
-        </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1955"/>
-        <source>invalid password</source>
-        <translation>neplatné heslo</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="1993"/>
-        <source>You had been using a deprecated version of the wallet. Please use the new seed that we provide.
-</source>
-        <translation>Použili jste zastaralou verzi peněženky. Použijte prosím nový seed.
-</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2007"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2065"/>
-        <source>Generated new wallet: </source>
-        <translation>Vygenerovaná nová peněženka: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2009"/>
-        <source>View key: </source>
-        <translation>Klíč pro prohlížení: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2013"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2070"/>
-        <source>failed to generate new wallet: </source>
-        <translation>selhalo generování nové peněženky: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2024"/>
-        <source>Your wallet has been generated!
-To start synchronizing with the daemon, use &quot;refresh&quot; command.
-Use &quot;help&quot; command to see the list of available commands.
-Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-Always use &quot;exit&quot; command when closing monero-wallet-cli to save your
-current session&apos;s state. Otherwise, you might need to synchronize 
-your wallet again (your wallet keys are NOT at risk in any case).
-</source>
-        <translation>Vaše peněženka byla vygenerována!
-Chcete-li spustit synchronizaci s démonem, použijte funkci &quot;refresh&quot;.
-Použijte &quot;help&quot; příkaz pro zobrazení seznamu dostupných příkazů.
-Použijte příkaz &quot;help &lt;command&gt;&quot; pro zobrazení dokumentace příkazu.
-Vždy používejte výraz &quot;exit&quot; při zavírání monero-wallet-cli pro uložení vašeho
-stavu aktuální relace. V opačném případě budete možná muset synchronizovat
-znova (peněženky nejsou v žádném případě vystaveny riziku).
-</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2082"/>
-        <source>wallet file path not valid: </source>
-        <translation>Cesta k souboru s peněženkou není validní: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2097"/>
-        <source>Opened watch-only wallet</source>
-        <translation>Otevřena peněženka pouze pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2097"/>
-        <source>Opened wallet</source>
-        <translation>Otevřená peněženka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2106"/>
-        <source>You had been using a deprecated version of the wallet. Please proceed to upgrade your wallet.
-</source>
-        <translation>Použili jste zastaralou verzi peněženky. Pokračujte v upgrade peněženky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2121"/>
-        <source>You had been using a deprecated version of the wallet. Your wallet file format is being upgraded now.
-</source>
-        <translation>Použili jste zastaralou verzi peněženky. Formát souboru peněženky je nyní aktualizován.
-</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2129"/>
-        <source>failed to load wallet: </source>
-        <translation>Selhalo nahrání peněženky: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2140"/>
-        <source>You may want to remove the file &quot;%s&quot; and try again</source>
-        <translation>Odstraňte soubor &quot;%s&quot; a zkuste to znovu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2146"/>
-        <source>Use &quot;help&quot; command to see the list of available commands.
-</source>
-        <translation>Použijte příkaz &quot;help&quot; pro zobrazení seznamu dostupných příkazů.
-</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2147"/>
-        <source>Use &quot;help &lt;command&gt;&quot; to see a command&apos;s documentation.
-</source>
-        <translation>Použijte příkaz &quot;help &lt;command&gt;&quot; pro zobrazení nápovědy k jednotlivým příkazům.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2168"/>
-        <source>failed to deinitialize wallet</source>
-        <translation>Selhala inicializace peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2191"/>
-        <source>Wallet data saved</source>
-        <translation>Data peněženky uložena</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2203"/>
-        <source>Password for new watch-only wallet</source>
-        <translation>Heslo pro novou peněženku pouze pro prohlížení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2207"/>
-        <source>failed to read wallet password</source>
-        <translation>Selhalo přečtení hesla k peněžence</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2220"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2675"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5431"/>
-        <source>this command requires a trusted daemon. Enable with --trusted-daemon</source>
-        <translation>Tento příkaz vyžaduje důvěryhodného démona. Povolíte pomocí --trusted-daemon</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2262"/>
-        <source>invalid arguments. Please use start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt; should be from 1 to </source>
-        <translation>neplatné parametry. Prosím použijte start_mining [&lt;number_of_threads&gt;] [do_bg_mining] [ignore_battery], &lt;number_of_threads&gt;, jež by mělo být od 1 do </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2271"/>
-        <source>Mining started in daemon</source>
-        <translation>V démonu byla spuštěna těžba</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2273"/>
-        <source>mining has NOT been started: </source>
-        <translation>Těžba nebyla započata: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2292"/>
-        <source>Mining stopped in daemon</source>
-        <translation>Těžna byla zastavena</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2294"/>
-        <source>mining has NOT been stopped: </source>
-        <translation>Těžba nebyla zastavena: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2313"/>
-        <source>Blockchain saved</source>
-        <translation>Blockchain uložen</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2315"/>
-        <source>blockchain can&apos;t be saved: </source>
-        <translation>Blockchain nemohl být uložen: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2328"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2346"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2359"/>
-        <location filename="../monero/src/simplewallet/simplewallet.h" line="255"/>
-        <source>Height </source>
-        <translation>Délka blockchain </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2329"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2347"/>
-        <source>txid </source>
-        <translation>txid </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2331"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2349"/>
-        <source>idx </source>
-        <translation>idx </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2348"/>
-        <source>spent </source>
-        <translation>utraceno </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2360"/>
-        <source>transaction </source>
-        <translation>transakce </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2361"/>
-        <source>unsupported transaction format</source>
-        <translation>nepodporovaný formát transakce</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2382"/>
-        <source>Starting refresh...</source>
-        <translation>Započato obnovení...</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2395"/>
-        <source>Refresh done, blocks received: </source>
-        <translation>Obnovení dokončeno, přiajtých bloků: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2402"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2689"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3768"/>
-        <source>daemon is busy. Please try again later.</source>
-        <translation>Démon je zaneprázdněn. Prosím, zkuste to znovu.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2406"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2693"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3772"/>
-        <source>no connection to daemon. Please make sure daemon is running.</source>
-        <translation>Žádné spojení s démonem. Prosím, ověřte, že démon běží.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2411"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2702"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3777"/>
-        <source>RPC error: </source>
-        <translation>Chyba RPC: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2416"/>
-        <source>refresh error: </source>
-        <translation>Chyba obnovení: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2421"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3839"/>
-        <source>internal error: </source>
-        <translation>Interí chyba: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2426"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2707"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3844"/>
-        <source>unexpected error: </source>
-        <translation>Neočekávaná chyba: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2431"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2712"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3265"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3361"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3580"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3849"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4123"/>
-        <source>unknown error</source>
-        <translation>Neznámá chyba</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2436"/>
-        <source>refresh failed: </source>
-        <translation>Obnovení selhalo: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2436"/>
-        <source>Blocks received: </source>
-        <translation>Přijatých bloků: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2460"/>
-        <source>Currently selected account: [</source>
-        <translation>Aktuálně zvolený účet: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2460"/>
-        <source>] </source>
-        <translation>] </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2461"/>
-        <source>Balance: </source>
-        <translation>Zůstatek: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2462"/>
-        <source>unlocked balance: </source>
-        <translation>Neblokované zůstatky: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2467"/>
-        <source>Balance per address:</source>
-        <translation>Zůstatek per adresa:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2468"/>
-        <source>Address</source>
-        <translation>Adresa</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2468"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4965"/>
-        <source>Balance</source>
-        <translation>Zůstatek</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2468"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4965"/>
-        <source>Unlocked balance</source>
-        <translation>Neblokovaný zůstatek</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2468"/>
-        <source>Outputs</source>
-        <translation>Výstup</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2468"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4965"/>
-        <source>Label</source>
-        <translation>Štítek</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2476"/>
-        <source>%8u %6s %21s %21s %7u %21s</source>
-        <translation>%8u %6s %21s %21s %7u %21s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2485"/>
-        <source>usage: balance [detail]</source>
-        <translation>použití: balance [detail]</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2497"/>
-        <source>usage: incoming_transfers [available|unavailable] [verbose] [index=&lt;N&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2550"/>
-        <source>pubkey</source>
-        <translation>veřejný klíč</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2550"/>
-        <source>key image</source>
-        <translation>potvrzení o utracení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2551"/>
-        <source>spent</source>
-        <translation>utraceno</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2551"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2561"/>
-        <source>unlocked</source>
-        <translation>odemčeno</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2551"/>
-        <source>ringct</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2551"/>
-        <source>global index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2551"/>
-        <source>tx id</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2551"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2602"/>
-        <source>addr index</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2560"/>
-        <source>T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2560"/>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2561"/>
-        <source>locked</source>
-        <translation>zamčeno</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2562"/>
-        <source>RingCT</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2562"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2574"/>
-        <source>No incoming transfers</source>
-        <translation>Žádné příchozí převody</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2578"/>
-        <source>No incoming available transfers</source>
-        <translation>Žádné dostupné příchozí převody</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2582"/>
-        <source>No incoming unavailable transfers</source>
-        <translation>Žádné nedostupné příchozí převody</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2593"/>
-        <source>expected at least one payment_id</source>
-        <translation>očekávané alespoň jedno payment_id</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2602"/>
-        <source>payment</source>
-        <translation>platba</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2602"/>
-        <source>transaction</source>
-        <translation>transakce</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2602"/>
-        <source>height</source>
-        <translation>délka blockchain</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2602"/>
-        <source>unlock time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2614"/>
-        <source>No payments with id </source>
-        <translation>Žádné platby s id</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2636"/>
-        <source>payment ID has invalid format, expected 16 or 64 character hex string: </source>
-        <translation>ID platby nemá validní formát, očekávano 16 nebo 64 hexa znaků: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2667"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2733"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3097"/>
-        <source>failed to get blockchain height: </source>
-        <translation>Nepodařilo se zjistit délku blockchain</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2697"/>
-        <source>failed to get spent status</source>
-        <translation>Selhalo získání stavu útraty</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2723"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4394"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4432"/>
-        <source>failed to connect to the daemon</source>
-        <translation>Selhalo připojení s démonem</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2741"/>
-        <source>
-Transaction %llu/%llu: txid=%s</source>
-        <translation>
-Transakce %llu/%llu: txid=%s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2751"/>
-        <source>
-Input %llu/%llu: amount=%s</source>
-        <translation>
-Vstup %llu/%llu: částka=%s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2767"/>
-        <source>failed to get output: </source>
-        <translation>selhalo získání výstupu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2775"/>
-        <source>output key&apos;s originating block height shouldn&apos;t be higher than the blockchain height</source>
-        <translation>číslo bloku výstupního klíče nemůže být větší, než celková délka blockchainu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2779"/>
-        <source>
-Originating block heights: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2794"/>
-        <source>
-|</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2794"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4805"/>
-        <source>|
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2811"/>
-        <source>
-Warning: Some input keys being spent are from </source>
-        <translation>Varování: Některé vstupní klíče byly utraceny z </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2812"/>
-        <source>the same transaction</source>
-        <translation>stejná transakce</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2812"/>
-        <source>blocks that are temporally very close</source>
-        <translation>bloky jsou dočasně velmi blízko</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2813"/>
-        <source>, which can break the anonymity of ring signature. Make sure this is intentional!</source>
-        <translation>, toto ,může mít vliv na anonymitu ring podpisu. Ujistěte se, že je toto v pořádku!</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2949"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3405"/>
-        <source>Ring size must not be 0</source>
-        <translation>Velikost ringu nemůže být 0</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2961"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3417"/>
-        <source>ring size %u is too small, minimum is %u</source>
-        <translation>Velikost ringu %u je příliš malá, minimum je %u</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="2968"/>
-        <source>wrong number of arguments</source>
-        <translation>špatný počet parametrů</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3002"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3451"/>
-        <source>payment id has invalid format, expected 16 or 64 character hex string: </source>
-        <translation>ID platby nemá validní formát, očekávané 16 nebo 64 hexa znaků: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3017"/>
-        <source>bad locked_blocks parameter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3022"/>
-        <source>Locked blocks too high, max 1000000 (˜4 yrs)</source>
-        <translation>Příliš mnoho zamčených bloků, max 1000000 (˜4 roky)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3045"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3469"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3677"/>
-        <source>a single transaction cannot use more than one payment id: </source>
-        <translation>jedna transakce nemůže používat více než jedno ID platby: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3054"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3478"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3645"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3685"/>
-        <source>failed to set up payment id, though it was decoded correctly</source>
-        <translation>Selhalo sestavení ID platby, přestože bylo korektně dekódováno</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3063"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4699"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4707"/>
-        <source>amount is wrong: </source>
-        <translation>Částka je špatně: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3064"/>
-        <source>expected number from 0 to </source>
-        <translation>očekávané číslo od 0 do </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3074"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3487"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3694"/>
-        <source>No payment id is included with this transaction. Is this okay?  (Y/Yes/N/No): </source>
-        <translation>V této transakci není obsažené ID platby. Je toto v pořádku? (Y/Yes/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3079"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3163"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3234"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3331"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3492"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3550"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3699"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3742"/>
-        <source>transaction cancelled.</source>
-        <translation>transakce přerušena.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3116"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3507"/>
-        <source>No outputs found, or daemon is not ready</source>
-        <translation>Výstupy nenalezeny nebo démon není připraven.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3142"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3152"/>
-        <source>Is this okay anyway?  (Y/Yes/N/No): </source>
-        <translation>Je toto v pořádku?  (Y/Yes/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3147"/>
-        <source>There is currently a %u block backlog at that fee level. Is this okay?  (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3152"/>
-        <source>Failed to check for backlog: </source>
-        <translation>Selhala kontrola backlogu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3193"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3523"/>
-        <source>
-Transaction </source>
-        <translation>
-Transakce </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3198"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3528"/>
-        <source>Spending from address index %d
-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3200"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3530"/>
-        <source>WARNING: Outputs of multiple addresses are being used together, which might potentially compromise your privacy.
-</source>
-        <translation>Varování: Výstupy několika adres byly použity zároveň, což může ohrozit vaše soukromí.
-</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3202"/>
-        <source>Sending %s.  </source>
-        <translation>Odesílám %s.  </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3205"/>
-        <source>Your transaction needs to be split into %llu transactions.  This will result in a transaction fee being applied to each transaction, for a total fee of %s</source>
-        <translation>Transakce je třeba rozdělit na transakce% llu. Výsledkem bude transakční poplatek za každou transakci za celkový poplatek ve výši% s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3211"/>
-        <source>The transaction fee is %s</source>
-        <translation>Transakční poplatek je %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3214"/>
-        <source>, of which %s is dust from change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3215"/>
-        <source>.</source>
-        <translation type="unfinished">.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3215"/>
-        <source>A total of %s from dust change will be sent to dust address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3220"/>
-        <source>.
-This transaction will unlock on block %llu, in approximately %s days (assuming 2 minutes per block)</source>
-        <translation>.
-Tato transakce se odemkne na bloku %llu, cca za %s dní (při předpokládu 2minuty na blok)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3246"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3342"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3561"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3752"/>
-        <source>Failed to write transaction(s) to file</source>
-        <translation>Selhalo zapsání transakce do souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3250"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3346"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3565"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3756"/>
-        <source>Unsigned transaction(s) successfully written to file: </source>
-        <translation>Nepodepsané transakce úspěšně zapsané do souboru: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3301"/>
-        <source>No unmixable outputs found</source>
-        <translation>Nebyly nalezeny žádné nezaměnitelné výstupy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3314"/>
-        <source>Sweeping </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3316"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3535"/>
-        <source>Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3322"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3372"/>
-        <source>No address given</source>
-        <translation>žádná adresa</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3541"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3734"/>
-        <source>Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3639"/>
-        <source>failed to parse Payment ID</source>
-        <translation>Selhalo parsování ID platby</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3655"/>
-        <source>usage: sweep_single [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;key_image&gt; &lt;address&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3662"/>
-        <source>failed to parse key image</source>
-        <translation>Selhalo parsování potvrzení o útratě</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3714"/>
-        <source>No outputs found</source>
-        <translation>Nenalezeny výstupy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3719"/>
-        <source>Multiple transactions are created, which is not supposed to happen</source>
-        <translation>Bylo vytvořeno více transakcí, což by se nemělo stát</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3724"/>
-        <source>The transaction uses multiple inputs, which is not supposed to happen</source>
-        <translation>Transakce použila více vstupů, což by se nemělo stát</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3762"/>
-        <source>Money successfully sent, transaction: </source>
-        <translation>Obnos úspěšně odeslán, transakce: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3781"/>
-        <source>failed to get random outputs to mix: </source>
-        <translation>Selhalo získání náhodných výstupů za účelem zamixování: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3788"/>
-        <source>Not enough money in unlocked balance</source>
-        <translation>V dostupných zůstatcích není dostatečný obnos.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3797"/>
-        <source>Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees</source>
-        <translation>Nepodařilo se najít způsob, jak vytvořit transakce. To je obvykle způsobeno prachem, který je tak malý, že si nemůže zaplatit sám sebe za poplatky nebo se pokouší odeslat více peněz než uvolněný zůstatek, nebo jednoduše není dostatečný obnos pro poplatky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3802"/>
-        <source>not enough outputs for specified mixin_count</source>
-        <translation>nenalezen dostatek výstupů pro splnění mixin_count</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3805"/>
-        <source>output amount</source>
-        <translation>výstupní částka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3805"/>
-        <source>found outputs to mix</source>
-        <translation>nalezeny výstupy pro zamixování</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3810"/>
-        <source>transaction was not constructed</source>
-        <translation>transalce nebyla vytvořena</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3814"/>
-        <source>transaction %s was rejected by daemon with status: </source>
-        <translation>transakce %s byla odmítnuta démonem ve stavu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3817"/>
-        <source>Reason: </source>
-        <translation>Důvod: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3825"/>
-        <source>one of destinations is zero</source>
-        <translation>Jeden z cílů je prázdný</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3829"/>
-        <source>failed to find a suitable way to split transactions</source>
-        <translation>Selhalo hledání použitelné cesty rozdělení transakcí</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3834"/>
-        <source>unknown transfer error: </source>
-        <translation>neznámá chyba při přenosu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3865"/>
-        <source>missing amount threshold</source>
-        <translation>chybějící prahová částka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3870"/>
-        <source>invalid amount threshold</source>
-        <translation>nevadlidní prahová částka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3881"/>
-        <source>usage: donate [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;priority&gt;] [&lt;ring_size&gt;] &lt;amount&gt; [&lt;payment_id&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3905"/>
-        <source>Donating </source>
-        <translation>Dárcovství</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3977"/>
-        <source>Claimed change does not go to a paid address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3982"/>
-        <source>Claimed change is larger than payment to the change address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="3991"/>
-        <source>Change goes to more than one address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4008"/>
-        <source>sending %s to %s</source>
-        <translation>zasílám %s do %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4014"/>
-        <source>with no destinations</source>
-        <translation>žádné cíle</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4020"/>
-        <source>%s change to %s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4023"/>
-        <source>no change</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4026"/>
-        <source>Loaded %lu transactions, for %s, fee %s, %s, %s, with min ring size %lu, %s. %sIs this okay? (Y/Yes/N/No): </source>
-        <translation>Nahráno %lu transakcí, pro %s, polatek %s, %s, %s, s minimální velikosti ring %lu, %s. %s Je toto v pořádku? (Y/Yes/N/No): </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4050"/>
-        <source>This is a watch only wallet</source>
-        <translation>Toto je peněženka pouze pro prohlížení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4055"/>
-        <source>usage: sign_transfer [export]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4067"/>
-        <source>Failed to sign transaction</source>
-        <translation>Selhalo podepisování transakce</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4073"/>
-        <source>Failed to sign transaction: </source>
-        <translation>Selhalo podepisování transakce: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4084"/>
-        <source>Transaction successfully signed to file </source>
-        <translation>Transakce úspěšně podepsána do souboru </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4094"/>
-        <source>Transaction raw hex data exported to </source>
-        <translation>Transakční surové hexadecimální data exportované do </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4110"/>
-        <source>Failed to load transaction from file</source>
-        <translation>Selhalo nahrání transakce ze souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4134"/>
-        <source>usage: get_tx_key &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4142"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4177"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4226"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4308"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4388"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4426"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5219"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5247"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5594"/>
-        <source>failed to parse txid</source>
-        <translation>Selhalo parsování txid</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4156"/>
-        <source>Tx key: </source>
-        <translation>Tx klíč: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4161"/>
-        <source>no tx keys found for this txid</source>
-        <translation>Nebyl nalezen tx klíč pro toto txid</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4170"/>
-        <source>usage: get_tx_proof_out &lt;txid&gt; &lt;address&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4195"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4405"/>
-        <source>signature file saved to: </source>
-        <translation>Soubor s podpisem uložen do: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4197"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4407"/>
-        <source>failed to save signature file</source>
-        <translation>Selhalo uložení podpisu do souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4201"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4289"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4367"/>
-        <source>error: </source>
-        <translation>Chyba: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4211"/>
-        <source>usage: check_tx_key &lt;txid&gt; &lt;txkey&gt; &lt;address&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4234"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4243"/>
-        <source>failed to parse tx key</source>
-        <translation>Selhalo parsování tx klíče</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4265"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4338"/>
-        <source>received</source>
-        <translation>přijato</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4265"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4338"/>
-        <source>in txid</source>
-        <translation>v txid</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4268"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4341"/>
-        <source>WARNING: this transaction is not yet included in the blockchain!</source>
-        <translation>Varování: tato transakce ještě není začleněna v blockchainu!</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4274"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4347"/>
-        <source>This transaction has %u confirmations</source>
-        <translation>Tato transakce má %u potvrzení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4278"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4351"/>
-        <source>WARNING: failed to determine number of confirmations!</source>
-        <translation>Varování: selhalo zjištění počtu potvrzení!</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4284"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4357"/>
-        <source>received nothing in txid</source>
-        <translation>nic k přijetí v tomto txid</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4297"/>
-        <source>usage: check_tx_proof &lt;txid&gt; &lt;address&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4324"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4439"/>
-        <source>failed to load signature file</source>
-        <translation>selhalo nahrání podpisu ze souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4335"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4446"/>
-        <source>Good signature</source>
-        <translation type="unfinished">Správný podpis</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4362"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4448"/>
-        <source>Bad signature</source>
-        <translation>Špatný podpis</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4375"/>
-        <source>usage: get_spend_proof &lt;txid&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4381"/>
-        <source>wallet is watch-only and cannot generate the proof</source>
-        <translation>Peněženka je pouze pro čtení a nemůže generovat ověření</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4419"/>
-        <source>usage: check_spend_proof &lt;txid&gt; &lt;signature_file&gt; [&lt;message&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4507"/>
-        <source>usage: show_transfers [in|out|all|pending|failed] [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_height&gt; [&lt;max_height&gt;]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4555"/>
-        <source>bad min_height parameter:</source>
-        <translation>špatný min_height parametr:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4567"/>
-        <source>bad max_height parameter:</source>
-        <translation>špatný max_height parametr:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4627"/>
-        <source>in</source>
-        <translation>v</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4627"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4668"/>
-        <source>out</source>
-        <translation>ven</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4644"/>
-        <source>[Double spend seen on the network: this transaction may or may not end up being mined] </source>
-        <translation>[Zdetekován zdvojení výdaje v síti: tato transakce může nebo nemusí skončit jako vytěžená]</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4668"/>
-        <source>failed</source>
-        <translation>selhalo</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4668"/>
-        <source>pending</source>
-        <translation>čekající</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4680"/>
-        <source>usage: unspent_outputs [index=&lt;N1&gt;[,&lt;N2&gt;,...]] [&lt;min_amount&gt; [&lt;max_amount&gt;]]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4714"/>
-        <source>&lt;min_amount&gt; should be smaller than &lt;max_amount&gt;</source>
-        <translation>&lt;min_amount&gt; by mělo být menší než &lt;max_amount&gt;</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4740"/>
-        <source>There is no unspent output in the specified address</source>
-        <translation>Na těto adrese nejsou neutracené výstupy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4746"/>
-        <source>
-Amount: </source>
-        <translation type="unfinished">
-Částka: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4746"/>
-        <source>, number of keys: </source>
-        <translation>, počet klíčů: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4751"/>
-        <source> </source>
-        <translation> </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4756"/>
-        <source>
-Min block height: </source>
-        <translation>
-Minimální velikost bloku: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4757"/>
-        <source>
-Max block height: </source>
-        <translation>
-Maximální velikost bloku: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4758"/>
-        <source>
-Min amount found: </source>
-        <translation>Minimální nalezená částka: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4759"/>
-        <source>
-Max amount found: </source>
-        <translation>Maximální nalezená částka: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4760"/>
-        <source>
-Total count: </source>
-        <translation>Součet: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4800"/>
-        <source>
-Bin size: </source>
-        <translation>Binární velikost: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4801"/>
-        <source>
-Outputs per *: </source>
-        <translation>Výstupů per *: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4803"/>
-        <source>count
-  ^
-</source>
-        <translation>počet
-^
-</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4805"/>
-        <source>  |</source>
-        <translation>  |</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4807"/>
-        <source>  +</source>
-        <translation>  +</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4807"/>
-        <source>+--&gt; block height
-</source>
-        <translation>+--&gt; velikost bloku
-</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4808"/>
-        <source>   ^</source>
-        <translation>   ^</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4808"/>
-        <source>^
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4809"/>
-        <source>  </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4850"/>
-        <source>wallet</source>
-        <translation>peněženka</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4853"/>
-        <source> (no daemon)</source>
-        <translation> (žádný démon)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4855"/>
-        <source> (out of sync)</source>
-        <translation> (nesynchronizované)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4909"/>
-        <source>(Untitled account)</source>
-        <translation>(Nepojmenovaný účet)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4922"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4940"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5029"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5052"/>
-        <source>failed to parse index: </source>
-        <translation>selhalo parsování indexu: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4927"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5034"/>
-        <source>specify an index between 0 and </source>
-        <translation>zadejte index mezi 0 a </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4958"/>
-        <source>usage: account [new &lt;label text with white spaces allowed&gt; | switch &lt;index&gt; | label &lt;index&gt; &lt;label text with white spaces allowed&gt;]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4965"/>
-        <source>Account</source>
-        <translation type="unfinished">Účet</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4968"/>
-        <source> %c%8u %6s %21s %21s %21s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4976"/>
-        <source>----------------------------------------------------------------------------------</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="4977"/>
-        <source>%15s %21s %21s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5000"/>
-        <source>Primary address</source>
-        <translation>Primární adresa</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5000"/>
-        <source>(used)</source>
-        <translation>(použito)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5021"/>
-        <source>(Untitled address)</source>
-        <translation>(Nepojmenovaná adresa)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5061"/>
-        <source>&lt;index_min&gt; is already out of bound</source>
-        <translation>&lt;index_min&gt; je mimo rozsah</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5066"/>
-        <source>&lt;index_max&gt; exceeds the bound</source>
-        <translation>&lt;index_max&gt; je mimo rozsah</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5074"/>
-        <source>usage: address [ new &lt;label text with white spaces allowed&gt; | all | &lt;index_min&gt; [&lt;index_max&gt;] | label &lt;index&gt; &lt;label text with white spaces allowed&gt; ]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5085"/>
-        <source>usage: integrated_address [payment ID]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5092"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5104"/>
-        <source>Integrated addresses can only be created for account 0</source>
-        <translation>Integrované adresy mohou být vytvořeny pouze pro účet 0</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5097"/>
-        <source>Matching integrated address: </source>
-        <translation>Odpovídající integrovaná adresa: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5116"/>
-        <source>Integrated address: %s, payment ID: %s</source>
-        <translation>Integrovaná adresa: %s, ID platby: %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5121"/>
-        <source>Subaddress: </source>
-        <translation>Podadresa</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5121"/>
-        <source>Standard address: </source>
-        <translation>Standartní adresa: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5126"/>
-        <source>failed to parse payment ID or address</source>
-        <translation>Selhalo parsování ID platby nebo adresy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5137"/>
-        <source>usage: address_book [(add (&lt;address&gt; [pid &lt;long or short payment id&gt;])|&lt;integrated address&gt; [&lt;description possibly with whitespaces&gt;])|(delete &lt;index&gt;)]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5167"/>
-        <source>failed to parse payment ID</source>
-        <translation>Selhalo parsování ID platby</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5185"/>
-        <source>failed to parse index</source>
-        <translation>Selhalo parsování indexu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5193"/>
-        <source>Address book is empty.</source>
-        <translation>Adresář je prázdný.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5199"/>
-        <source>Index: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5200"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5323"/>
-        <source>Address: </source>
-        <translation>Adresa: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5201"/>
-        <source>Payment ID: </source>
-        <translation>ID platby: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5202"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5322"/>
-        <source>Description: </source>
-        <translation>Popis: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5212"/>
-        <source>usage: set_tx_note [txid] free text note</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5240"/>
-        <source>usage: get_tx_note [txid]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5281"/>
-        <source>usage: get_description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5287"/>
-        <source>no description found</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5289"/>
-        <source>description found: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5321"/>
-        <source>Filename: </source>
-        <translation>Soubor: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5324"/>
-        <source>Watch only: </source>
-        <translation>Pouze pro čtení: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5324"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5325"/>
-        <source>Yes</source>
-        <translation>Ano</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5324"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5325"/>
-        <source>No</source>
-        <translation>Ne</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5325"/>
-        <source>Testnet: </source>
-        <translation>Testovací síť</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5333"/>
-        <source>usage: sign &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5338"/>
-        <source>wallet is watch-only and cannot sign</source>
-        <translation>Peněženka je pouze pro čtení a neumožnuje podepisování</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5347"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5370"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5518"/>
-        <source>failed to read file </source>
-        <translation>selhalo čtení souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5359"/>
-        <source>usage: verify &lt;filename&gt; &lt;address&gt; &lt;signature&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5384"/>
-        <source>Bad signature from </source>
-        <translation>Špatný podpis od</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5388"/>
-        <source>Good signature from </source>
-        <translation>Správný podpis od </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5397"/>
-        <source>usage: export_key_images &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5402"/>
-        <source>wallet is watch-only and cannot export key images</source>
-        <translation>Peněženka je pouze pro čtení a neumožňuje exportovat potvrzení o utracení.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5412"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5490"/>
-        <source>failed to save file </source>
-        <translation>selhalo uložení do souboru </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5423"/>
-        <source>Signed key images exported to </source>
-        <translation>Podepsané potvrzení o utracení exportováné do </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5437"/>
-        <source>usage: import_key_images &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5467"/>
-        <source>usage: export_outputs &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5501"/>
-        <source>Outputs exported to </source>
-        <translation>Výstupy exportované do </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5509"/>
-        <source>usage: import_outputs &lt;filename&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5587"/>
-        <source>usage: show_transfer &lt;txid&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5689"/>
-        <source>Double spend seen on the network: this transaction may or may not end up being mined</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5724"/>
-        <source>Transaction ID not found</source>
-        <translation>Nenalezeno ID transakce</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5759"/>
-        <source>Transaction successfully saved to </source>
-        <translation>Transakce úspěšně uložena do </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5759"/>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5761"/>
-        <source>, txid </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5761"/>
-        <source>Failed to save transaction to </source>
-        <translation>Selhalo uložení transakce do </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5766"/>
-        <source>Transaction successfully submitted, transaction </source>
-        <translation>Transakce úspěšně odeslaná, transakce </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5767"/>
-        <source>You can check its status by using the `show_transfers` command.</source>
-        <translation>Stav můžete zkontrolovat pomocí příkazu `show_transfers`.</translation>
-    </message>
-</context>
-<context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="344"/>
-        <location filename="../main.qml" line="555"/>
-        <location filename="../main.qml" line="567"/>
-        <location filename="../main.qml" line="617"/>
-        <location filename="../main.qml" line="629"/>
-        <location filename="../main.qml" line="671"/>
-        <location filename="../main.qml" line="680"/>
-        <location filename="../main.qml" line="732"/>
-        <location filename="../main.qml" line="816"/>
-        <location filename="../main.qml" line="1005"/>
-        <location filename="../main.qml" line="1164"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="345"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Nelte otevřít peněž</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Neblokovaný zůstatek (čekajících na blok)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Neblokovaný zůstatek (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Neblokovaný zůstatek</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="429"/>
+        <location filename="../main.qml" line="435"/>
         <source>Remaining blocks (local node):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Čekám na nastartování démona...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Čekám na zastavení démona...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="500"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Démona se nepodařilo nastartovat</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Prosím, zkontrolujte případné chyby v log peněženky a démona. Taktéž se můžete pokusit nastartovat %1 manuálně.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="557"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Nelze vytvořit transakci: Špatná verze démona: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="559"/>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Nelze vytvořit transakci: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="568"/>
-        <location filename="../main.qml" line="681"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Nemixovatelné výstupy ve sweep</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="580"/>
-        <location filename="../main.qml" line="693"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Potvrzení</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="581"/>
-        <location filename="../main.qml" line="694"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Prosím, potvrďte transakci:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="582"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adresa: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="583"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 ID platby: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="584"/>
-        <location filename="../main.qml" line="695"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -5514,15 +2317,15 @@ Amount: </source>
 Částka: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="585"/>
-        <location filename="../main.qml" line="696"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Poplatek: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -5531,102 +2334,125 @@ Ringsize: </source>
 Počet podpisovatelů: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="768"/>
+        <location filename="../main.qml" line="778"/>
         <source>Payment proof</source>
         <translation>Důkaz platby</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="771"/>
+        <location filename="../main.qml" line="781"/>
         <source>Couldn&apos;t generate a proof because of the following reason: 
 </source>
         <translation>Nemohu vygenerovat důkaz z důvodu:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="797"/>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
         <source>Payment proof check</source>
         <translation>Zkontrolovat důkaz platby</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="800"/>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
         <source>Bad signature</source>
         <translation>Špatný podpis</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="808"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Tato adresa obdržela %1 monero a %2 potvrzení.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1006"/>
-        <location filename="../main.qml" line="1165"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Správný podpis</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
         <source>Wrong password</source>
         <translation>Špatné heslo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1076"/>
+        <location filename="../main.qml" line="1108"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1079"/>
+        <location filename="../main.qml" line="1111"/>
         <source>Error: Filesystem is read only</source>
         <translation>Chyba: Souborový systém je v módu pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1081"/>
+        <location filename="../main.qml" line="1113"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Varování: na diskovém oddílu zbývá pouze %1 GB místa. Blockchain potřebuje ~%2 GB místa.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1083"/>
+        <location filename="../main.qml" line="1115"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Poznámka: na diskovém oddílu zbývá pouze %1 GB místa. Blockchain potřebuje ~%2 GB místa.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1085"/>
+        <location filename="../main.qml" line="1117"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Poznánka: lmdb adresář nenalezen. Vytvořím nový.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1089"/>
+        <location filename="../main.qml" line="1121"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1566"/>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Chyba: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
         <source>Tap again to close...</source>
         <translation>Klepnutím znovu zavřete...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1579"/>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Démon běží</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1580"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Démon zůstane běžet v pozadí i po zavření grafického rozhraní.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1582"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Zastavit démona</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1617"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Je dostupná nová verze grafického klienta: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Počet transakcí: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="588"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -5635,518 +2461,75 @@ Description: </source>
 Popis: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="618"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Částka není správně: předpokládaná částka má být mezi %1 až %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Nedostatečné finanční prostředky. Neblokovaný zůstatek: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="733"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Částku nelze odeslat: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informace</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Částka úspěšně odeslaná: %1 potvrzení</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transakce uložena do souboru: %1</translation>
     </message>
     <message>
-        <source>Payment check</source>
-        <translation type="obsolete">Kontrola platby</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="805"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Tato adresa obdžela %1 monero, ale transakce jestě není potvrzená vytěžením</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="812"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Tato adresa zatím nic neobdržela</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Zůstatek (synchronizuji)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Zůstatek</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1194"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Prosím čekejte...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1218"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Průvodce nastavením programu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1234"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1284"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>Odeslat na stejnou adresu</translation>
-    </message>
-</context>
-<context>
-    <name>sw</name>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="113"/>
-        <source>Generate new wallet and save it to &lt;arg&gt;</source>
-        <translation>Generovat novou peněženku a uložit do &lt;arg&gt;</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="114"/>
-        <source>Generate incoming-only wallet from view key</source>
-        <translation>Generovat peněženku pouze pro příchozí platby z klíče pro prohlížení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="115"/>
-        <source>Generate deterministic wallet from spend key</source>
-        <translation>Generovat deterministickóu peněženku z klíče pro utrácení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="116"/>
-        <source>Generate wallet from private keys</source>
-        <translation>Generovat peněženku z privátního klíče</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="117"/>
-        <source>Generate a master wallet from multisig wallet keys</source>
-        <translation>Generovat a master peněženku z klíčů multisig peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="119"/>
-        <source>Language for mnemonic</source>
-        <translation>Jazyk pro mnemotechniku</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="120"/>
-        <source>Specify Electrum seed for wallet recovery/creation</source>
-        <translation>Určete Electrum seed pro zotavení/vytvoření peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="121"/>
-        <source>Recover wallet using Electrum-style mnemonic seed</source>
-        <translation>Obnovit peněženku použitím mnemonického seed v Electrum stylu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="122"/>
-        <source>Create non-deterministic view and spend keys</source>
-        <translation>Vytvořit nedeterministické klíče pro prohlížení a útratu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="123"/>
-        <source>Enable commands which rely on a trusted daemon</source>
-        <translation>Povolit příkazy které spoléhají na důvěryhodného démona</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="124"/>
-        <source>Allow communicating with a daemon that uses a different RPC version</source>
-        <translation>Povolit komunikaci s démonem používajícím odlišnou verzi RPC</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="125"/>
-        <source>Restore from specific blockchain height</source>
-        <translation>Obnovit od konkrétní délky bloku</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="126"/>
-        <source>The newly created transaction will not be relayed to the monero network</source>
-        <translation>Nově vytvořená transakce nebude rozeslána do sítě Monero</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="168"/>
-        <source>daemon is busy. Please try again later.</source>
-        <translation>Démon je zaneprázdněn. Prosím zkuste to znovu později.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="177"/>
-        <source>possibly lost connection to daemon</source>
-        <translation>Možná ztracené spojení s démonem</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="194"/>
-        <source>Error: </source>
-        <translation>Chyba: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5815"/>
-        <source>Failed to initialize wallet</source>
-        <translation>Selhala inicialiazce peněženky</translation>
-    </message>
-</context>
-<context>
-    <name>tools::wallet2</name>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="103"/>
-        <source>Use daemon instance at &lt;host&gt;:&lt;port&gt;</source>
-        <translation>Použít instanci démona na &lt;host&gt;:&lt;port&gt;</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="104"/>
-        <source>Use daemon instance at host &lt;arg&gt; instead of localhost</source>
-        <translation>Použít instanci démona na &lt;host&gt;:&lt;port&gt; namísto localhost</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="105"/>
-        <source>Wallet password (escape/quote as needed)</source>
-        <translation>Heslo peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="106"/>
-        <source>Wallet password file</source>
-        <translation>Soubor s heslem peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="107"/>
-        <source>Use daemon instance at port &lt;arg&gt; instead of 18081</source>
-        <translation>Použít instanci démona na &lt;host&gt;:&lt;port&gt; namísto 18081</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="108"/>
-        <source>Specify username[:password] for daemon RPC client</source>
-        <translation>Zadejte uživatelské jméno[:heslo] klienta RPC démona</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="109"/>
-        <source>For testnet. Daemon must also be launched with --testnet flag</source>
-        <translation>Pro testnet. Démon musí být také spuštěn s příznakem --testnet</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="110"/>
-        <source>Restricts to view-only commands</source>
-        <translation>Omezit pouze na příkazy pro prohlížení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="148"/>
-        <source>can&apos;t specify daemon host or port more than once</source>
-        <translation>Nelze specifikovat název nebo port více než jednou</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="184"/>
-        <source>can&apos;t specify more than one of --password and --password-file</source>
-        <translation>Nelze specifikovat více než jednou --password nebo--password-file</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="197"/>
-        <source>the password file specified could not be read</source>
-        <translation>soubor s heslem nelze přečíst</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="204"/>
-        <source>no password specified; use --prompt-for-password to prompt for a password</source>
-        <translation>bez zadaného hesla; použijte příkaz --prompt-for-password pro zadání hesla</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="220"/>
-        <source>Failed to load file </source>
-        <translation>Selhalo nahrání souboru</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="226"/>
-        <source>Failed to parse JSON</source>
-        <translation>Selhalo parsování JSON</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="233"/>
-        <source>Version %u too new, we can only grok up to %u</source>
-        <translation>Verze% u je příliš nová, můžeme narazit až na %u</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="249"/>
-        <source>failed to parse view key secret key</source>
-        <translation>Selhalo parsování tajného klíče pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="254"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="319"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="359"/>
-        <source>failed to verify view key secret key</source>
-        <translation>Selhalo ověření tajného klíče pro zobrazení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="265"/>
-        <source>failed to parse spend key secret key</source>
-        <translation>Selhalo parsování tajného klíče pro útratu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="270"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="329"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="384"/>
-        <source>failed to verify spend key secret key</source>
-        <translation>Selhalo ověření tajného klíče pro útratu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="282"/>
-        <source>Electrum-style word list failed verification</source>
-        <translation>Selhalo ověření seznamu slov v Electrum stylu</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="299"/>
-        <source>At least one of Electrum-style word list and private view key and private spend key must be specified</source>
-        <translation>Musí být zadán alespoň jeden seznam slov v Electrum stylu, soukromý klíč pro prohlížení a soukromý klíč</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="303"/>
-        <source>Both Electrum-style word list and private key(s) specified</source>
-        <translation>Seznam slov ve stylu Electrum a soukromý klíč</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="313"/>
-        <source>invalid address</source>
-        <translation>nevalidní adresa</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="322"/>
-        <source>view key does not match standard address</source>
-        <translation>klíč pro prohlížení neodpovídá standarní adrese</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="332"/>
-        <source>spend key does not match standard address</source>
-        <translation>klíč pro útratu neodpovídá standartní adrese</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="340"/>
-        <source>Cannot create deprecated wallets from JSON</source>
-        <translation>Nelze vytvořit zastaralé peněženky z JSON</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="371"/>
-        <source>failed to parse address: </source>
-        <translation>Selhalo parsování adresy: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="377"/>
-        <source>Address must be specified in order to create watch-only wallet</source>
-        <translation>Adresa musí být zadána, aby se vytvořila peněženka pouze pro čtení</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="392"/>
-        <source>failed to generate new wallet: </source>
-        <translation>Selhalo generování nové peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="2505"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="2573"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="2609"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="2867"/>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="3223"/>
-        <source>Primary account</source>
-        <translation>Primární účet</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="6692"/>
-        <source>No funds received in this tx.</source>
-        <translation>V tomto tx nebyly přijaty žádné finanční prostředky.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet2.cpp" line="7097"/>
-        <source>failed to read file </source>
-        <translation>Selhalo čtení souboru </translation>
-    </message>
-</context>
-<context>
-    <name>tools::wallet_rpc_server</name>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="157"/>
-        <source>Daemon is local, assuming trusted</source>
-        <translation>Démon je lokální, předpokládám, že je důvěryhodný</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="172"/>
-        <source>Failed to create directory </source>
-        <translation>Selhalo vytvoření adresáře</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="174"/>
-        <source>Failed to create directory %s: %s</source>
-        <translation>Selhalo vytvoření adresáře %s> %s</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="185"/>
-        <source>Cannot specify --</source>
-        <translation>Nelze zadat --</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="185"/>
-        <source> and --</source>
-        <translation>a --</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="204"/>
-        <source>Failed to create file </source>
-        <translation>Selhalo vytvoření souboru </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="204"/>
-        <source>. Check permissions or remove file</source>
-        <translation>. Zkontrolujte oprávnění nebo odstraňte soubor</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="213"/>
-        <source>Error writing to file </source>
-        <translation>Chyba při zápisu do souboru </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="216"/>
-        <source>RPC username/password is stored in file </source>
-        <translation>RPC uživatelské jméno/heslo je uloženo v souboru </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2296"/>
-        <source>Transaction not possible. Available only %s, transaction amount %s = %s + %s (fee)</source>
-        <translation>Transakce není možná. K dispozici pouze %s, částka transakce %s = %s + %s (poplatek)</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2384"/>
-        <source>Can&apos;t specify more than one of --wallet-file and --generate-from-json</source>
-        <translation>Nelze specifikovat více než jeden --wallet-file nebo --generate-from-json</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2396"/>
-        <source>Must specify --wallet-file or --generate-from-json or --wallet-dir</source>
-        <translation>Je nutno specifikovat --wallet-file nebo --generate-from-json nebo --wallet-dir</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2400"/>
-        <source>Loading wallet...</source>
-        <translation>Nahrávám peněženku...</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2433"/>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2466"/>
-        <source>Storing wallet...</source>
-        <translation>Ukládám peněženku...</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2435"/>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2468"/>
-        <source>Stored ok</source>
-        <translation>Uloženo v pořádku</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2438"/>
-        <source>Loaded ok</source>
-        <translation>Nahráno v pořádku</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2442"/>
-        <source>Wallet initialization failed: </source>
-        <translation>Selhala inicializace peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2449"/>
-        <source>Failed to initialize wallet rpc server</source>
-        <translation>Selhala inicialiazce RPC serveru peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2453"/>
-        <source>Starting wallet rpc server</source>
-        <translation>Startuji RPC server peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2460"/>
-        <source>Failed to run wallet: </source>
-        <translation>Selhalo spouštění peněženky: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2463"/>
-        <source>Stopped wallet rpc server</source>
-        <translation>RPC server peněženky zastaven</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2472"/>
-        <source>Failed to store wallet: </source>
-        <translation>Selhalo uložení peněženky</translation>
-    </message>
-</context>
-<context>
-    <name>wallet_args</name>
-    <message>
-        <location filename="../monero/src/simplewallet/simplewallet.cpp" line="5776"/>
-        <location filename="../monero/src/wallet/wallet_rpc_server.cpp" line="2348"/>
-        <source>Wallet options</source>
-        <translation>Možnosti peněženky</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="72"/>
-        <source>Generate wallet from JSON format file</source>
-        <translation>Generovat peněženku ze souboru JSON</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="76"/>
-        <source>Use wallet &lt;arg&gt;</source>
-        <translation>Použít peněženku &lt;arg&gt;</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="102"/>
-        <source>Max number of threads to use for a parallel job</source>
-        <translation>Maximální počet podprocesů, které chcete použít pro paralelní úlohy</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="103"/>
-        <source>Specify log file</source>
-        <translation>Specifikovat log soubor</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="104"/>
-        <source>Config file</source>
-        <translation>Konfigurační soubor</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="113"/>
-        <source>General options</source>
-        <translation>Obecné možnosti</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="136"/>
-        <source>This is the command line monero wallet. It needs to connect to a monero
-daemon to work correctly.</source>
-        <translation>Jedná se o příkazového řádek peněženky Monero. Pro správnou funkci je třeba se připojit k Monero
-démonu.</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="138"/>
-        <source>Usage:</source>
-        <translation>Použití:</translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="159"/>
-        <source>Can&apos;t find config file </source>
-        <translation>Nelze naléze konfigurační soubor </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="190"/>
-        <source>Logging to: </source>
-        <translation>Přihlášení k: </translation>
-    </message>
-    <message>
-        <location filename="../monero/src/wallet/wallet_args.cpp" line="192"/>
-        <source>Logging to %s</source>
-        <translation>Přihlášení k %s</translation>
     </message>
 </context>
 </TS>

--- a/translations/monero-core_da.ts
+++ b/translations/monero-core_da.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Tilføj ny indtastning></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QRKODE</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Betalings ID &lt;font size=&apos;2&apos;&gt;(Valgfri)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Indsæt 64 hexadecimale tegn</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Beskrivelse &lt;font size=&apos;2&apos;&gt;(Valgfri)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Giv denne indtastning et navn eller beskrivelse</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Tilføj</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Ugyldig adresse</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Kan ikke oprette indtastning</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Betalings ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Starter Monero daemon om %1 sekunder</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>Filtrer transaktions historik</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Skriv for trinvis søgning...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtrer</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Dato fra</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Til</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Avanceret filtrering</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Type af transaktion</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Beløb fra</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Betalings ID:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>IKke flere resultater</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Blokhøjde:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>%1/10 bekræftelser</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">%1/10 bekræftelser {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>UBEKRÆFTET</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>AFVENTENDE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Gebyr</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Tx ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Betalings ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Tx nøgle:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Tx note:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Destinationer:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">%1/10 bekræftelser {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">UBEKRÆFTET</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">AFVENTENDE</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Hemmelig se-kun nøgle</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Offentlig se-kun nøgle</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Hemmelig brugsnøgle</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Offentlig brugsnøgle</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Ulåst saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Modtag</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>historik</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Adresse bog</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Avanceret</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Miner</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Tjek betaling</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Signer/verificer</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Indstillinger</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Ulåst Saldo</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Solo mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(kun tilgængelig for lokale daemons)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>At mine med din computer hjælper med at styrke Monero netværket. Jo flere personer der miner, jo sværere er det for netværket at blive angrebet, og hver eneste lille del hjælper.&lt;br&gt; &lt;br&gt; At mine giver dig også en lille chance for at tjene nogle Monero. Hvis du finder en blok, ville du få den associaserede belønning. Held og lykke!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU tråde</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(valgfri)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Baggrunds miner (eksperimentiel)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Gør det muligt at mine på batteri</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Administrer miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Start miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Fejl ved forsøg at starte mineren</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Kunne ikke starte mineren</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Det kun muligt at mine på lokale daemons. Kør en lokal daemon for at mine</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Stop mineren</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Status: Miner ikke</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Miner med %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Miner ikke</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Status: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Oplåst Saldo:</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Synkroniserer</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Forbundet</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Forkert version</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Frakoblet</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Ugyldig forbindelses status</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Netværk status</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Afbryd</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Indtast tegnebogs kodeord</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Indtast tegnebogs kodeord for:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Afbryd</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Etablerer forbindelse...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Blokke tilbage: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Synkroniserer blokke</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Ugyldig betalings ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>ADVARSEL: ingen forbindelse til daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>I txpoolen: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 bekræftelser: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 bekræftelse: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Ingen transaktion fundet endnu...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transaktion fundet</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 transaktioner fundet</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> med flere penge (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> med ikke nok penge (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Læs-kun tegnebogsadresse vist her</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 hexadecimale tegn</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Ryd</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Integrerede adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Beløb at modtage</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;hjælp&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Sporer betalinger</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klik generer for at oprette et tilfældigt betalings ID for en ny kunde&lt;/p&gt; &lt;p&gt;Lad din kunde skanne QR koden for at lave en betaling (hvis den kunde har software som understøtter QR kode skanning).&lt;/p&gt;&lt;p&gt;Denne side ville automatisk skanne blockchainen og tx pollen for indkomne transaktioner der har brugt denne QR kode. Hvis du indsætter et beløb, ville den også tjekke at indkome transaktioner udgør det beløb.&lt;/p&gt;Det er op til dig om du ville acceptere ubekræftede transaktioner eller ikke. For det meste ville de blive bekræftet kort efter, men der er stadig en chance for at de ikke ville, så for større værdier ville du nok vente på en eller flere bekræftelser.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Gem QrKode</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Fejl ved gemning af QrKode til</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Gem som</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Betalings ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generer</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generer betalings ID for integrerede adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Nyheder</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Hjælp</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Om</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Opret se-kun tegnebog</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Administrer daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Start daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Stop daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Vis status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Daemon opstarts flag</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(valgfri)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Vis seed &amp; nøgler</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Skan tegnebogs saldo igen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Fejl: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Skanning af brugte outputs lykkedes igen </translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Blockchain lokation</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Daemon adresse</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Hostnavn / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Log ind (valgfri)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Brugernavn</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Kodeord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Forbind</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Layout indstillinger</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Brugerdefineret dekorationer</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Log niveau</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(e.g. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Version</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI version: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Indlejret Monero Version: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Daemon log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Vælg venligst en mappe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Fejl: Filsystem er kun læseligt</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Advarsel: Der er kun %1 GB ledigt på din enhed. Blockchainen kræver ~%2 GB data.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Note: Der er %1 GB ledigt på denne enhed. Blockchainen kræver ~%2 GB af data.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Note: lmdb mappe ikke fundet. En ny mappe ville blive oprettet.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Afbryd</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Tegnebog seed &amp; nøgler </translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Hemmelig se-kun nøgle</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Offentlig se-kun nøgle</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>Hemmelig brugsnøgle</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>Offentlig brugsnøgle</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Forkert kodeord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Administrer tegnebog</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Luk tegnebog</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>God signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Det her er en god signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Dårlig signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Denne signatur blev ikke verificeret</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Signer en besked eller filinhold med din adresse:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Enten besked:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Besked at signere</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Signer</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Vælg venligst en fil at signere</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Vælg</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verificer</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Vælg venligst en fil at verificere</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signerer adresse &lt;font size=&apos;2&apos;&gt;  ( indsæt eller vælg fra &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresse bog&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Eller fil:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Filnavn med besked at signere</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Verificer en besked eller fil signatur fra en adresse:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Besked at signere</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Filnavn med besked at verificere</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Afbryd</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Lav (x1 gebyr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Medium (x20 gebyr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Høj (x166 gebyr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langsom (x0,25 gebyr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>Standard (x1 gebyr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>Hurtig (x5 gebyr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Hurtigste (x41,5 gebyr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Sendt</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Modtaget</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Medium</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Høj</translation>
     </message>
@@ -1237,225 +1470,214 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAlias fejl</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Privatlivs niveau (ringstørrelse %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Transaktion prioritet</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Lav (x1 gebyr)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Medium (x20 gebyr)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Høj (x166 gebyr)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adresse &lt;font size=&apos;2&apos;&gt;  ( Indsæt eller vælg fra &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresse bog&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR Kode</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Bestem</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Ingen gyldig adresse fundet på denne OpenAlias adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adresse fundet, men DNSSEC signaturen kunne ikke blive verificeret, så denne adresse kan være misvisende</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>ingen gyldig adresse fundet på denne OpenAlias adresse, men DNSSEC signaturen kunne ikke blive verificeret, så denne adresse kan være misvisende</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Indre fejl</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Ingen adresse fundet</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Beskrivelse &lt;font size=&apos;2&apos;&gt;( Valgfri )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Gemt til lokal tegnebogs historik</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Vis avancererede muligheder</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Sweep kan ikke blandes</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Opret tx fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Signer tx fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Indsend tx fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
+        <source>Connected daemon is not compatible with GUI. 
+Please upgrade or connect to another daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Vælg venligst en fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Start daemon</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Kan ikke loade usignerede transaktioner: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>Nummer af transaktioner: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>Transaktion %1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>Modtager: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>Betalings ID:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>Beløb: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>Gebyr: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>Ringstørrelse:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Bekræftelser</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Kan ikke indsende transaktion: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Penge sendt uden fejl</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Tengebog er ikke forbundet til daemonen.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
-        <source>Connected daemon is not compatible with GUI.
-Please upgrade or connect to another daemon</source>
-        <translation>Forbundet daemon er ikke kompatibel med GUI.
-            Opgrader venligst eller forbind til en anden daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Venter på daemon synkronisation er færdig</translation>
     </message>
@@ -1465,37 +1687,37 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Transaktions pris</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Betalings ID &lt;font size=&apos;2&apos;&gt;( Valgfri )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langsom (x0,25 gebyr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Standard (x1 gebyr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Hurtig (x5 gebyr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Hurtigste (x41,5 fee)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 eller 64 hexadecimale tegn</translation>
     </message>
@@ -1503,64 +1725,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verficer at en tredjepart lavede en betaling ved at supplere:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - modtagers adresse</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - transaktions ID'et</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - den hemmelige transaktions nøgle suppleret af senderen</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>hvis en betaling havde flere transaktioner så må hver eneste blive checket og resultaterne lagt sammen.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Modtagerens tegnebogs adresse</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Generer</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Signatur</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Transaktion ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Indsæt tx ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Indsæt tx nøgle</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Tjek</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Transaktion nøgle</translation>
     </message>
 </context>
 <context>
@@ -1588,7 +1823,7 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="144"/>
         <source>Disk conservation mode uses substantially less disk-space, but the same amount of bandwidth as a regular Monero instance. However, storing the full blockchain is beneficial to the security of the Monero network. If you are on a device with limited disk space, then this option is appropriate for you.</source>
-        <translation>Disk besparende tilstand bruger væsenligt mindre disk-plads, men det samme båndbredde som en regulær Monero instans. dog ved at gemme hele blockchainen styrker det sikkerheden af Monero's netværk. Hvis du er på en enhed med begrænset disk plads, så er denne valgmulighed for dig.</translation>
+        <translation>Disk besparende tilstand bruger væsenligt mindre disk-plads, men det samme båndbredde som en regulær Monero instans. dog ved at gemme hele blockchainen styrker det sikkerheden af Monero&apos;s netværk. Hvis du er på en enhed med begrænset disk plads, så er denne valgmulighed for dig.</translation>
     </message>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="157"/>
@@ -1598,7 +1833,7 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardConfigure.qml" line="175"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
-        <translation>At mine styrker Monero's netværk, og betaler også en lille belønning for arbejdet der bliver gjort. Denne mulighed ville lade Monero mine når din computer er på strøm og inaktiv, og ville stoppe med at mine når du ikke længere er inaktiv.</translation>
+        <translation>At mine styrker Monero&apos;s netværk, og betaler også en lille belønning for arbejdet der bliver gjort. Denne mulighed ville lade Monero mine når din computer er på strøm og inaktiv, og ville stoppe med at mine når du ikke længere er inaktiv.</translation>
     </message>
 </context>
 <context>
@@ -1618,11 +1853,44 @@ Please upgrade or connect to another daemon</source>
     </message>
 </context>
 <context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Blockchain lokation</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(valgfri)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardDonation</name>
     <message>
         <location filename="../wizard/WizardDonation.qml" line="93"/>
         <source>Monero development is solely supported by donations</source>
-        <translation>Monero's udvikling er udelukkende kørt via donationer</translation>
+        <translation>Monero&apos;s udvikling er udelukkende kørt via donationer</translation>
     </message>
     <message>
         <location filename="../wizard/WizardDonation.qml" line="113"/>
@@ -1637,7 +1905,7 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardDonation.qml" line="164"/>
         <source>For every transaction, a small transaction fee is charged. This option lets you add an additional amount, as a percentage of that fee, to your transaction to support Monero development. For instance, a 50% autodonation take a transaction fee of 0.005 XMR and add a 0.0025 XMR to support Monero development.</source>
-        <translation>For hver transaktion, ville der blive trukket et lille gebyr. Denne mulighed lader dig tilføje et ekstra beløb, som en procentdel af den gebyr til din transaktion for at støtte Monero udvikling. F.eks. ville en 50% autodonation tag en transaktions gebyr på 0,005 XMR og lægge 0,0025 XMR oveni for at støtte Monero's udvikling.</translation>
+        <translation>For hver transaktion, ville der blive trukket et lille gebyr. Denne mulighed lader dig tilføje et ekstra beløb, som en procentdel af den gebyr til din transaktion for at støtte Monero udvikling. F.eks. ville en 50% autodonation tag en transaktions gebyr på 0,005 XMR og lægge 0,0025 XMR oveni for at støtte Monero&apos;s udvikling.</translation>
     </message>
     <message>
         <location filename="../wizard/WizardDonation.qml" line="176"/>
@@ -1647,7 +1915,7 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardDonation.qml" line="194"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
-        <translation>>At mine styrker Monero's netværk, og betaler også en lille belønning for arbejdet der bliver gjort. Denne mulighed ville lade Monero mine når din computer er på strøm og inaktiv, og ville stoppe når du ikke længere er inaktiv.</translation>
+        <translation>&gt;At mine styrker Monero&apos;s netværk, og betaler også en lille belønning for arbejdet der bliver gjort. Denne mulighed ville lade Monero mine når din computer er på strøm og inaktiv, og ville stoppe når du ikke længere er inaktiv.</translation>
     </message>
 </context>
 <context>
@@ -1720,44 +1988,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>En tegnebog med samme navn findes allerede. Skift venligst tegnebogs navn</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Ikke-ASCII tegn er ikke tilladt i tegnebogsstien eller konto navn</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>BRUG MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Opret tegnebog</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Succes</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
-        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in:
+        <location filename="../wizard/WizardMain.qml" line="403"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
-        <translation>Se-kun tegnebogen er blevet oprettet. Du kan åbne den ved at lukke denne nuværende tegnebog, og klikker&quot;Åben tegnebog fra fil&quot; knappen, og vælger se tegnebog i:
-        %1 </translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Abort</translation>
     </message>
@@ -1765,47 +2032,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Tengebog navn</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Genopret fra seed</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Genopret fra nøgler</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Konto andresse (offentlig)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Se-nøgle (Privat)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Brugsnøgle (privat)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Genopret højde (valgfri)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Din tegnebog er gemt i</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Vælg venligst en destination</translation>
     </message>
@@ -1818,7 +2090,12 @@ Please upgrade or connect to another daemon</source>
         <translation>Skriv din 25 ords mnemonic seed</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Dette seed er &lt;b&gt;meget&lt;/b&gt; vigtigt at skrive ned og holde hemmeligt. Det er alt du har brug for at backuppe og genoprette din tegnebog.</translation>
     </message>
@@ -1826,37 +2103,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Velkommen til Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Vælg venligst en af de følgende muligheder:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Opret en ny tegnebog</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Genopret tegnebog fra nøgler og mnemonic seed</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Åben en tegnebog fra fil</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Brugerdefineret daemon adresse (valgfri)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1870,7 +2142,7 @@ Please upgrade or connect to another daemon</source>
         <translation>Giv din tegnebog et kodeord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Note: dette kodeord kan ikke blive genoprettet. Hvis du glemmer det, så ville din tegnebog være nødt til at blive genoprettet via dit 25 ords mnemonic seed.&lt;br/&gt;&lt;br/&gt;
@@ -1880,12 +2152,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Kodeord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Bekræft kodeord</translation>
     </message>
@@ -1893,7 +2165,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Genopret tegnebog</translation>
     </message>
@@ -1901,12 +2173,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Velkommen til Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Vælg et sprog og regional format.</translation>
     </message>
@@ -1914,233 +2186,321 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Kunne ikke åbne tegnebog: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Oplåst saldo (venter på blok)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Oplåst saldo (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Oplåst saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Venter på at daemonen starter...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Venter på daemonen stopper...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Daemonen fejlede i at starte</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Tjek din tegnebog og daemon for fejl. Du kan også prøve at starte %1 manuelt.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Kan ikke oprette transaktion. Forkert daemon version: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Kan ikke oprette transaktion: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Kan ikke blande outputs til sweep</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Bekræftelse</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Vælg bekæft transaktion:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>Adresse: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>Betalings ID:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation>Beløb: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>Gebyr: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation>Ringstørrelse: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Dårlig signatur</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Denne adresse modtog %1 monero, med %2 bekræftelse(r).</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">God signatur</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Forkert kodeord</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Fejl: Filsystem er kun læseligt</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Advarsel: Der er kun %1 GB ledigt på din enhed. Blockchainen kræver ~%2 GB data.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Note: Der er %1 GB ledigt på denne enhed. Blockchainen kræver ~%2 GB af data.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Note: lmdb mappe ikke fundet. En ny mappe ville blive oprettet.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Afbryd</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Fejl: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Daemonen kører</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
-        <translation>Daemonen ville stadig køre i baggrunden når GUI'en er lukket.</translation>
+        <translation>Daemonen ville stadig køre i baggrunden når GUI&apos;en er lukket.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Stop daemon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Ny version af monero-tegnebog-gui er tilgængelig: %1&lt;br&gt;%2 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>Nummer af transaktioner: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
         <translation>Beskrivelse: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Beløb er forkert: Forventede nummer fra %1 til %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Utilstrækkelig saldo. Oplåst saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Kunne ikke sende penge: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Penge sendt uden fejl: %1 transaktion(er) </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transaktion gemt til fil: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Betaling kontrol</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Denne adresse modtog %1 monero, men transaktionen er ikke minet endnu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Denne adresse modtog ingenting</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Saldo (synkroniserer)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Vent venligst...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Program opsætningsguide</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>Send til den samme destination</translation>
     </message>

--- a/translations/monero-core_da.ts
+++ b/translations/monero-core_da.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">%1/10 bekræftelser {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 bekræftelser)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">%1/10 bekræftelser {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 bekræftelser)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Eintrag hinzufügen</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QR-Code</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Zahlungs-ID &lt;font size=&apos;2&apos;&gt;(optional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Füge 64 hexadezimale Zeichen ein</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Beschreibung &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Einen Namen oder eine Beschreibung festlegen</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Ungültige Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Eintrag kann nicht erstellt werden</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Zahlungs-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -110,15 +115,15 @@
     <message>
         <location filename="../components/DaemonConsole.qml" line="128"/>
         <source>command + enter (e.g help)</source>
-        <translation>Befehl + Eingabe (z.&#x202f;B. help)</translation>
+        <translation>Befehl + Eingabe (z. B. help)</translation>
     </message>
 </context>
 <context>
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Starte Monero-Daemon in %1 Sekunden</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation> ausgewählt: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Für Suchvervollständigung tippen …</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Datum von</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Bis</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Erweiterter Filter</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Art der Transaktion</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Betrag ab</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Zahlungs-ID:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Ziele:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Blockhöhe:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 Bestätigungen)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 Bestätigungen) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>UNBESTÄTIGT</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>AUSSTEHEND</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Gebühr</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Tx-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Zahlungs-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Tx-Schlüssel:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Tx-Notiz:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Ziele:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Keine weiteren Ergebnisse</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 Bestätigungen) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">UNBESTÄTIGT</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">AUSSTEHEND</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Geheimer View-Schlüssel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Öffentlicher View-Schlüssel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Guthaben</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Verfügbares Guthaben</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Senden</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Empfangen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Transaktionen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Adressbuch</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Mining</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Zahlung überprüfen</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Signieren/Verifizieren</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Guthaben</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Verfügbares Guthaben</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Solo-Mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(nur verfügbar bei lokalem Daemon)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Mit Deinem Computer zu minen hilft dabei, das Monero-Netzwerk zu stärken. Je mehr Leute minen, desto schwieriger kann das Netzwerk angegriffen werden. Jeder kann helfen! &lt;br&gt; &lt;br&gt;Das Mining bietet Dir die Möglichkeit, Monero zu verdienen. Dein Computer errechnet dabei Hash-Werte für neue Blöcke. Wenn Du einen neuen Block findest, bekommst Du die Belohnung dafür. Viel Erfolg!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU-Threads</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(optional)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Im Hintergrund minen (experimentell)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Aktiviere Mining im Akkubetrieb</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Verwalte Miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Starte Mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Fehler beim Starten des Minings</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Das Mining konnte nicht gestartet werden.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Mining ist nur auf dem lokalen Daemon verfügbar. Starte den lokalen Daemon, um zu minen.</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Beende Mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Status: Kein Mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Mining mit %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Kein Mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Status: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished">Verfügbares Guthaben:</translation>
     </message>
@@ -515,12 +664,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Netzwerkstatus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Verbunden</translation>
     </message>
@@ -530,30 +679,58 @@
         <translation>Synchronisiere</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Falsche Version</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Getrennt</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Ungültiger Verbindungsstatus</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Bitte Wallet-Passwort eingeben</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Bitte gib Dein Wallet-Passwort ein:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Stelle Verbindung her …</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Verbleibende Blöcke: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Synchronisiere Blöcke</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Ungültige Zahlungs-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>WARNUNG: Keine Verbindung zum Daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>im Transaktions-Pool: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 Bestätigungen: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 Bestätigung: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Noch keine Transaktion gefunden …</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transaktion gefunden</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 Transaktionen gefunden</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> mit mehr Geld (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> mit ungenügendem Guthaben (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Schreibgeschütztes Wallet wird hier angezeigt</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 hexadezimale Zeichen</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Leeren</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Integrierte Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Erstelle Zahlungs-ID für die integrierte Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>QR-Code speichern</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Fehler beim Speichern des QR-Codes nach </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Speichern unter</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Zahlungs-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Zu erhaltender Betrag</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt; Verfolgen &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Hilfe&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Zahlungen nachverfolgen</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Dies ist ein einfacher Verkaufs-Tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klicke auf Erzeugen, um eine zufällige Zahlungs-ID für einen neuen Kunden zu erstellen.&lt;/p&gt; &lt;p&gt;Lasse Deinen Kunden mit Hilfe des QR-Codes eine Zahlung tätigen. Dies setzt voraus, dass der Kunde die hierfür notwendige Software besitzt.&lt;/p&gt;&lt;p&gt;Diese Seite ermöglicht es Dir, die Blockchain und den TX-Pool automatisch nach eingehenden Transaktionen zu suchen, die mit diesem QR-Code getätigt wurden. Wenn Du einen Betrag angibst, wird zusätzlich überprüft ob die eingehenden Transaktionen aufsummiert diesen Betrag ergeben.&lt;/p&gt;Du entscheidest, ob Du unbestätigte Transaktionen akzeptieren möchtest. Es ist wahrscheinlich, dass die Transaktionen innerhalb kürzester Zeit bestätigt werden. Es besteht jedoch die Gefahr, dass dies nicht geschieht, weswegen Du bei größeren Beträgen eine oder mehrere Bestätigung(en) abwarten solltest.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generieren</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Neuigkeiten</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Hilfe</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Über</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,396 +971,439 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Wallet-Seed &amp; Schlüssel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Geheimer View-Schlüssel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Öffentlicher View-Schlüssel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Falsches Passwort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Daemon-Adresse</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Wallet verwalten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Wallet schließen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Schreibgeschütztes Wallet erstellen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Daemon verwalten</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Daemon starten</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Daemon stoppen</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Startparameter des Daemons</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(optional)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Zeige Seed &amp; Schlüssel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Wallet-Guthaben aktualisieren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Fehler: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Informationen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Ausgaben erfolgreich aktualisiert</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Blockchain-Speicherort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Anmelden (optional)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Benutzername</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Verbinden</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Layout-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Angepasste Oberfläche</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Detailgrad des Berichts</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
-        <translation>(z.&#x202f;B. *:WARNING,net.p2p:DEBUG)</translation>
+        <translation>(z. B. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Version</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI-Version: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Eingebundene Monero-Version: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Daemon-Protokoll</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Bitte wähle ein Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Fehler: Dateisystem ist nicht beschreibbar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Warnung: Es sind nur %1 GB Speicherplatz auf diesem Laufwerk verfügbar, die Blockchain benötigt jedoch ~%2 GB an Speicherplatz.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Info: Es sind %1 GB Speicherplatz auf diesem Laufwerk verfügbar. Die Blockchain benötigt ~%2 GB an Speicherplatz.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Info: lmdb-Ordner wurde nicht gefunden. Ein neuer Ordner wird erstellt.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Hostname / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Status zeigen</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
     </message>
 </context>
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Gültige Signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Diese Signatur ist gültig</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Ungültige Signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Diese Signatur ist nicht gültig</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Nachricht oder Inhalt einer Datei mit Deiner Adresse signieren:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Jegliche Nachricht:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Zu signierende Nachricht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Signieren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Bitte wähle eine zu signierende Datei aus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verifizieren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Bitte wähle eine zu verifizierende Datei aus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Oder Datei:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Dateiname mit zu signierender Nachricht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Nachricht oder Datei einer Adresse verifizieren:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Zu verifizierende Nachricht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Dateiname mit zu verifizierender Nachricht</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signierende Adresse &lt;font size=&apos;2&apos;&gt;  ( Füge ein oder wähle aus dem &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adressbuch&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Niedrig (1-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Mittel (20-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Hoch (166-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langsam (0,25-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>Standard (1-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>Schnell (5-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Am schnellsten (41,5-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Versendet</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Erhalten</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Mittel</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Hoch</translation>
     </message>
@@ -1237,12 +1470,12 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Transaktionspriorität</translation>
     </message>
@@ -1252,257 +1485,247 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAlias-Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Starte Daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Geheimhaltungsstufe (Ringgröße %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Niedrig (1-fache Gebühr)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Mittel (20-fache Gebühr)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Hoch (166-fache Gebühr)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langsam (0,25-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Standard (1-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Schnell (5-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Am schnellsten (41,5-fache Gebühr)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;Adresse &lt;font size=&apos;2&apos;&gt;  ( Füge ein oder wähle aus dem &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adressbuch&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Auflösen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Es wurde keine gültige Adresse unter dieser OpenAlias-Adresse gefunden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Die Adresse wurde zwar gefunden, jedoch konnten die DNSSEC-Signaturen nicht verifiziert werden. Möglicherweise wurde diese Adresse manipuliert</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Unter dieser OpenAlias-Adresse konnte weder eine gültige Adresse gefunden werden, noch konnten die DNSSEC-Signaturen verifiziert werden. Möglicherweise wurde diese Adresse manipuliert</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Interner Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Keine Adresse gefunden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Beschreibung &lt;font size=&apos;2&apos;&gt;( optional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Wird in die lokale Wallet-Historie gespeichert</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Senden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Zeige erweiterte Optionen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Unmischbare Beträge zusammenführen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Erstelle Tx-Datei</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Verbundener Daemon ist nicht mit der GUI kompatibel.
 Bitte aktualisiere oder verbinde einen anderen Daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informationen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Bitte wähle eine Datei aus</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Unsignierte Transaktion kann nicht geladen werden: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Bestätigung</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Transaktion kann nicht eingereicht werden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Geld erfolgreich versendet</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Transaktionskosten</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Daemon starten</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Tx-Datei signieren</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Tx-Datei einreichen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Anzahl an Transaktionen: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transaktion #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Empfänger: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 Zahlungs-ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation type="unfinished">
 Betrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Gebühr: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringgröße: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Wallet ist nicht mit dem Daemon verbunden.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Warte auf vollständige Daemon-Synchronisation</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Zahlungs-ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 oder 64 Hexadezimalzeichen</translation>
     </message>
@@ -1510,62 +1733,75 @@ Ringgröße: </translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verifiziere die Zahlung eines Dritten mittels:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - die Empfänger Adresse</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - die Transaktions-ID</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - der geheime Transaktionsschlüssel des Senders</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Wallet-Adresse des Empfängers</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Transaktions-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Füge tx-ID ein</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Füge tx-Schlüssel ein</translation>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Generieren</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Signatur</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Überprüfen</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Transaktionsschlüssel</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Wenn eine Zahlung aus mehreren Transaktionen bestand, muss jede einzeln überprüft und die Ergebnisse kombiniert werden.</translation>
     </message>
@@ -1622,6 +1858,39 @@ Ringgröße: </translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Erstelle ein neues Wallet</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Blockchain-Speicherort</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(optional)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,43 +1996,43 @@ Ringgröße: </translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Ein Wallet mit diesem Namen ist bereits vorhanden. Bitte ändere den Namen des Wallets</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Nur ASCII-Zeichen sind im Walletpfad oder im Walletname erlaubt</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>VERWENDE MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Erstelle Wallet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Erfolg</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1771,47 +2040,52 @@ Ringgröße: </translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Wallet-Name</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Mit mnemonischem Code wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Mit Schlüssel wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Wallet-Adresse (öffentlich)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>View-Schlüssel (privat)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Spend-Schlüssel (privat)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Wiederherstellungspunkt (optional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Dein Wallet ist hier gespeichert</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Wähle ein Verzeichnis</translation>
     </message>
@@ -1824,7 +2098,12 @@ Ringgröße: </translation>
         <translation>Gib Deinen aus 25 Wörtern bestehenden mnemonischen Code ein</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Es ist &lt;b&gt;sehr&lt;/b&gt; wichtig, dass dieser Code aufgeschrieben und geheim gehalten wird. Das ist alles was Du brauchst, um Dein Wallet zu sichern und wiederherzustellen.</translation>
     </message>
@@ -1832,37 +2111,32 @@ Ringgröße: </translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Willkommen zu Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Bitte wähle eine der folgenden Optionen:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Erstelle ein neues Wallet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Stelle Wallet mit Schlüssel oder mnemonischen Code wieder her</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Öffne Wallet aus einer Datei</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Benutzerdefinierte Daemon-Adresse (optional)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1876,7 +2150,7 @@ Ringgröße: </translation>
         <translation>Erstelle ein Passwort für Dein Wallet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Beachte: Das Passwort kann nicht wiederhergestellt werden. Wenn Du es vergisst, kannst Du nur Zugriff auf Dein Wallet erhalten, indem Du den&lt;br/&gt;&lt;br/&gt;
@@ -1886,12 +2160,12 @@ Ringgröße: </translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Passwort</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Passwort bestätigen</translation>
     </message>
@@ -1899,7 +2173,7 @@ Ringgröße: </translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Wallet wiederherstellen</translation>
     </message>
@@ -1907,12 +2181,12 @@ Ringgröße: </translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Willkommen bei Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Bitte wähle eine Sprache und ein Anzeigeformat.</translation>
     </message>
@@ -1920,152 +2194,165 @@ Ringgröße: </translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Wallet konnte nicht geöffnet werden: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Transaktion konnte nicht erstellt werden: Falsche Daemon-Version: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Keine unmischbaren Ausgänge zum Zusammenführen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Betrag ist falsch: Zahl muss zwischen %1 und %2 liegen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Geld erfolgreich verschickt: %1 Transaktion(en)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Zahlungsüberprüfung</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Diese Adresse hat %1 Monero empfangen, aber die Transaktion wurde noch nicht gemined</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Daemon läuft</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Daemon wird weiter im Hintergrund laufen, wenn das GUI geschlossen wird.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Daemon stoppen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Eine neue Version der monero-wallet-gui ist verfügbar: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Diese Adresse hat nichts empfangen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Transaktion konnte nicht erstellt werden: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Verfügbares Guthaben (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Verfügbares Guthaben</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Verfügbares Guthaben (warte auf Block)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Warte auf Start des Daemons …</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Warte bis der Daemon beendet wird …</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Daemon konnte nicht gestartet werden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Bitte überprüfe Dein Wallet und das Daemon-Protokoll auf Fehler. Du kannst auch versuchen, %1 manuell zu starten.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Bestätigung</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Bitte bestätige Transaktion:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adresse: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 Zahlungs-ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2074,15 +2361,15 @@ Amount: </source>
 Gebühr: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Gebühr: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2091,14 +2378,14 @@ Ringsize: </source>
 Ringgröße: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Anzahl an Transaktionen: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2107,57 +2394,132 @@ Description: </source>
 Beschreibung: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Guthaben reicht nicht aus. Verfügbar: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Geld konnte nicht versendet werden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transaktion gespeichert in Datei: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Ungültige Signatur</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Diese Adresse hat %1 Monero erhalten, mit %2 Bestätigung(en).</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Gültige Signatur</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Guthaben (synchronisiert sich)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Guthaben</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Falsches Passwort</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Warnung</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Fehler: Dateisystem ist nicht beschreibbar</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Warnung: Es sind nur %1 GB Speicherplatz auf diesem Laufwerk verfügbar, die Blockchain benötigt jedoch ~%2 GB an Speicherplatz.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Info: Es sind %1 GB Speicherplatz auf diesem Laufwerk verfügbar. Die Blockchain benötigt ~%2 GB an Speicherplatz.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Info: lmdb-Ordner wurde nicht gefunden. Ein neuer Ordner wird erstellt.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Fehler: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Bitte warten …</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Installations-Assistent</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>an dieselbe Adresse senden</translation>
     </message>

--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 Bestätigungen) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 Bestätigungen)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 Bestätigungen) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 Bestätigungen)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_eo.ts
+++ b/translations/monero-core_eo.ts
@@ -280,22 +280,27 @@
         <translation>NEKONFIRMITA</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="263"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>OKAZONTE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="292"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="384"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Kosto</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="349"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
@@ -343,7 +348,12 @@
         <translation>NEKONFIRMITA</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="153"/>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
         <source>PENDING</source>
         <translation>OKAZONTE</translation>
     </message>
@@ -422,117 +432,122 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="135"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="180"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Disponebla saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="283"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Sendu</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="333"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Ricevi</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="334"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="427"/>
+        <location filename="../LeftPanel.qml" line="439"/>
         <source>Prove/check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="428"/>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="357"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Historio</translation>
     </message>
     <message>
         <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testreto</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="308"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Adresaro</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="309"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="358"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="380"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Spertaĵoj</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="381"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="403"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="404"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="496"/>
+        <location filename="../LeftPanel.qml" line="508"/>
         <source>Seed &amp; Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="497"/>
+        <location filename="../LeftPanel.qml" line="509"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="451"/>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Subskribi/kontroli</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="452"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="474"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Agordoj</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="475"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="284"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>A</translation>
     </message>
@@ -685,24 +700,47 @@
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Nuligi</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="87"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Bonvolu entajpi monujpasvorton</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="87"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Bonvolu entajpi monujpasvorton por:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="155"/>
+        <location filename="../components/PasswordDialog.qml" line="156"/>
         <source>Cancel</source>
         <translation>Nuligi</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="168"/>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -759,142 +797,147 @@
         <translation>Malĝusta paga-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>AVERTO: neniu konekto kun la demono</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>En la transakciujo: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 konfirmoj: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 konfirmoj: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Neniu transakcio trovita ĝis nun...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transakcio trovita</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 trovitaj transakcioj</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>kun pli da mono (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>kun nesufiĉe da mono (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="189"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="196"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Nurlegebla monujadreso montrata ĉi tie</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="208"/>
+        <location filename="../pages/Receive.qml" line="214"/>
         <source>Address copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="229"/>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 deksesumaj signoj</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="241"/>
+        <location filename="../pages/Receive.qml" line="247"/>
         <source>Payment ID copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="264"/>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Vakigi</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="273"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Integrita adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="282"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generi pagan ID-on por integrita adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="294"/>
+        <location filename="../pages/Receive.qml" line="300"/>
         <source>Integrated address copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="384"/>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Konservi la QR-kodon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="385"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Malsukcesis konservi la QR-kodon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="396"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Konservi Kiel</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="221"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Paga-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="306"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="314"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Ricevenda kvanto</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="334"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Sekvi &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;helpo&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="339"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Sekvado de pagoj</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="340"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Jen simpla pago-sekvilo:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Alklaku &quot;Generi&quot; por krei hazardan pago-IDon por nova kliento.&lt;/p&gt; &lt;p&gt;Lasu vian klienton skani tiun QR-kodon por plenumi la pagon (se tiu kliento havas QR-taŭgan aparaton aŭ programon).&lt;/p&gt;&lt;p&gt;Ĉi-paĝo aŭtomate skanos la blokĉenon kaj transakciaron je transakcioj kiuj uzas tiun QR-kodon. Se vi enigas kvanton, la pago-sekvilo ankaŭ kontrolos ke la sumo de la envenantaj transakcioj atingas tiun kvanton.&lt;/p&gt;Vi povas laŭplaĉe akcepti nekonfirmitajn transakciojn aŭ ne. Ili verŝajne konfirmiĝos pli malpli rapide, sed ekzistas ebleco ke ne, do se temas pri grandaj valoroj vi prefere atendu unu konfirmon aŭ pli.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="253"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generi</translation>
     </message>
@@ -929,6 +972,7 @@
     <name>Settings</name>
     <message>
         <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
@@ -948,18 +992,18 @@
         <translation>Krei nurlegeblan monujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="579"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Demontaglibro</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="259"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Montri statuson</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="284"/>
-        <location filename="../pages/Settings.qml" line="314"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(opcia)</translation>
     </message>
@@ -979,47 +1023,57 @@
         <translation>Informo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="277"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="181"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Malĝusta pasvorto</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Pozicio de la blokĉeno</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="337"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Uzantnomo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="346"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Pasvorto</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="371"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Konekti</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="472"/>
+        <location filename="../pages/Settings.qml" line="498"/>
         <source>Debug info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="497"/>
+        <location filename="../pages/Settings.qml" line="523"/>
         <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="498"/>
+        <location filename="../pages/Settings.qml" line="524"/>
         <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="537"/>
+        <location filename="../pages/Settings.qml" line="563"/>
         <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="538"/>
+        <location filename="../pages/Settings.qml" line="564"/>
         <source>Are you sure you want to rebuild the wallet cache?
 The following information will be deleted
 - Recipient addresses
@@ -1031,58 +1085,63 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="566"/>
+        <location filename="../pages/Settings.qml" line="592"/>
         <source>Wallet log path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="570"/>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
         <source>Daemon log path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="588"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Bonvolu elekti dosierujon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="597"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Eraro: dosiersistemo estas nurlegebla</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="604"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Averto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="606"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Noto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="610"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Noto: lmdb-dosierujo ne troviĝis. Nova dosierujo kreiĝos.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="546"/>
-        <location filename="../pages/Settings.qml" line="614"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Nuligi</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="524"/>
+        <location filename="../pages/Settings.qml" line="550"/>
         <source>Save</source>
         <translation>Konservi</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="395"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Aspektagordoj</translation>
     </message>
@@ -1092,72 +1151,72 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="175"/>
+        <location filename="../pages/Settings.qml" line="201"/>
         <source>Local Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="189"/>
+        <location filename="../pages/Settings.qml" line="215"/>
         <source>Remote Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="207"/>
+        <location filename="../pages/Settings.qml" line="233"/>
         <source>Manage Daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="213"/>
+        <location filename="../pages/Settings.qml" line="239"/>
         <source>Show advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="231"/>
+        <location filename="../pages/Settings.qml" line="257"/>
         <source>Start Local Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="246"/>
+        <location filename="../pages/Settings.qml" line="272"/>
         <source>Stop Local Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="307"/>
+        <location filename="../pages/Settings.qml" line="333"/>
         <source>Local daemon startup flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="325"/>
+        <location filename="../pages/Settings.qml" line="351"/>
         <source>Node login (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="356"/>
+        <location filename="../pages/Settings.qml" line="382"/>
         <source>Remote node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="413"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Propraj dekoracioj</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="424"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Taglibro-nivelo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="456"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="486"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI versio: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="491"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Enkorpigita Monera versio: </translation>
     </message>
@@ -1229,9 +1288,14 @@ The old wallet cache file will be renamed and can be restored later.
         <translation>Bonvolu elekti kontrolendan dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="386"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: %1px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;%2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;%3&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: %1px;}&lt;/style&gt;                            Subskribenda adreso &lt;font size=&apos;%2&apos;&gt;  (Algluu ĝin ĉi tien, aŭ selektu ĝin en la &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresaro&lt;/a&gt;&lt;font size=&apos;%3&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Sign.qml" line="160"/>
@@ -1247,8 +1311,8 @@ The old wallet cache file will be renamed and can be restored later.
     <message>
         <location filename="../pages/Sign.qml" line="234"/>
         <location filename="../pages/Sign.qml" line="239"/>
-        <location filename="../pages/Sign.qml" line="412"/>
-        <location filename="../pages/Sign.qml" line="417"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Subskribo</translation>
     </message>
@@ -1406,239 +1470,224 @@ The old wallet cache file will be renamed and can be restored later.
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAlias eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Nivelo de privateco (ringsize %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Enŝalti la demonon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="126"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Kvanto</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="178"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Prioritato de transakcio</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="161"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Ĉiuj</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="191"/>
-        <source>Low (x1 fee)</source>
-        <translation>Malalta (x1 kosto)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="192"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Meza (x20 kosto)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="193"/>
-        <source>High (x166 fee)</source>
-        <translation>Alta (x166 kosto)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="200"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Malrapida (x0.25 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="201"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Antaŭsupoza (x1 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="202"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Rapida (x5 kosto)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="203"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Plej rapida (x41.5 fee)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="239"/>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adreso</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR Kodo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="263"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Solvi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="281"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Neniu valida Adreso troviĝis je ĉi tiu OpenAlias adreso</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="286"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>La adreso troviĝis, sed la DNSSEC-subskriboj ne povis esti kontrolitaj, do la adreso eble estas mistifikita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="288"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Neniu valida Adreso troviĝis je ĉi tiu OpenAlias adreso, sed la DNSSEC subskriboj ne povis esti kontrolitaj, do la adreso eble estas mistifikita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="291"/>
-        <location filename="../pages/Transfer.qml" line="294"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Interna eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="297"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Neniu adreso trovita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Priskribo &lt;font size=&apos;2&apos;&gt;( Opcia )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="322"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Konservita en la loka monujhistorio</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="330"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Sendi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="395"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Montru spertajn agordojn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="423"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Transakcia kosto</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="458"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Balai Nemikseblaĵojn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="472"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Kreu=i tr dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="494"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Subskribi tr dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="508"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Sendi tr dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="541"/>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>Kvanto de transakcioj: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transakcion #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="552"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Ricevanto: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="603"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="530"/>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Bonvolu elekti dosieron</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="225"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                          Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adreso &lt;font size=&apos;2&apos;&gt;  (Algluu ĉi tie aŭ selektu el la &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresaro&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="542"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Ne eblas ŝargi nesubskribitan transakcion: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="553"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>Paga ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="554"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>Kvanto: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="555"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>Kosto: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="556"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>Ringgrandeco: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="570"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Konfirmo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="598"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Ne eblas sendi transakcion: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="604"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Mono sukcese sendita</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="673"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>La konektita demono ne kongruas kun la GUI.
@@ -1650,23 +1699,28 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="658"/>
-        <location filename="../pages/Transfer.qml" line="670"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>La monujo ne estas konektita kun la demono</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="678"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Atendante la finon de demonsinkroniĝado</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="305"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Paga-ID &lt;font size=&apos;2&apos;&gt;( Opcia )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="311"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 aŭ 64 deksesuma karaktroj</translation>
     </message>
@@ -1674,73 +1728,75 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="343"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Se pago havis plurajn transakciojn, ĉiu devas esti kontrolita kaj la rezultoj kombinitaj.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="128"/>
-        <location filename="../pages/TxKey.qml" line="239"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="93"/>
-        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="135"/>
-        <location filename="../pages/TxKey.qml" line="246"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Monujadreso de ricevanto</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="154"/>
-        <location filename="../pages/TxKey.qml" line="265"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
-        <location filename="../pages/TxKey.qml" line="272"/>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
         <source>Optional message against which the signature is signed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="181"/>
+        <location filename="../pages/TxKey.qml" line="186"/>
         <source>Generate</source>
         <translation>Generi</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="204"/>
-        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="291"/>
+        <location filename="../pages/TxKey.qml" line="297"/>
         <source>Signature</source>
         <translation>Subskribo</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="299"/>
+        <location filename="../pages/TxKey.qml" line="305"/>
         <source>Paste tx proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="101"/>
-        <location filename="../pages/TxKey.qml" line="212"/>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Transakcio-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="108"/>
-        <location filename="../pages/TxKey.qml" line="219"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Algluu Tr ID-on</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="320"/>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Kontroli</translation>
     </message>
@@ -2133,296 +2189,321 @@ Bonvolu plibonigi aŭ konekti al alia demono</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="344"/>
-        <location filename="../main.qml" line="555"/>
-        <location filename="../main.qml" line="567"/>
-        <location filename="../main.qml" line="617"/>
-        <location filename="../main.qml" line="629"/>
-        <location filename="../main.qml" line="671"/>
-        <location filename="../main.qml" line="680"/>
-        <location filename="../main.qml" line="732"/>
-        <location filename="../main.qml" line="816"/>
-        <location filename="../main.qml" line="1005"/>
-        <location filename="../main.qml" line="1164"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="345"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Ne sukcesis malfermi monujon: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="557"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Ne sukcesas krei transakcion: Malĝusta demonversio</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="568"/>
-        <location filename="../main.qml" line="681"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Ne malmikseblaj eligoj por balai</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="618"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Kvanto malĝustas: oni postulas nombron de %1 al %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Mono sendiĝis sukcese: %1 transakcio(j)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="805"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Tiu ĉi adreso ricevis %1 moneron; sed la transakcio ankoraŭ ne estas minata</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="812"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Tiu ĉi adreso ricevis nenion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="559"/>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Ne sukcesas krei transakcion</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Disponebla saldo (atendante blokon)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Disponebla saldo (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="376"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Disponebla saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="429"/>
+        <location filename="../main.qml" line="435"/>
         <source>Remaining blocks (local node):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="469"/>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Atendante komencon de la demono</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Atendante halton de la demono</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="500"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Demono malsukcesis starti</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="501"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Bonvolu kontroli la taglibrojn de viaj monujo kaj demonlogo por eraroj. Vi ankaŭ povas provi komenci %1 permane.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="580"/>
-        <location filename="../main.qml" line="693"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Konfirmo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="581"/>
-        <location filename="../main.qml" line="694"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Bonvolu konfirmi transakcion: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="582"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>Adreso: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="583"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>Paga ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="584"/>
-        <location filename="../main.qml" line="695"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation>Kvanto: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="585"/>
-        <location filename="../main.qml" line="696"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>Kosto: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation>Ringgrandeco: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>Kvanto de transakcioj: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="588"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
         <translation>Priskribo: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="768"/>
+        <location filename="../main.qml" line="778"/>
         <source>Payment proof</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="771"/>
+        <location filename="../main.qml" line="781"/>
         <source>Couldn&apos;t generate a proof because of the following reason: 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="797"/>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
         <source>Payment proof check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="800"/>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
         <source>Bad signature</source>
         <translation>Malbona subskribo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1006"/>
-        <location filename="../main.qml" line="1165"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Bona subskribo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
         <source>Wrong password</source>
         <translation>Malĝusta pasvorto</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1076"/>
+        <location filename="../main.qml" line="1108"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1079"/>
+        <location filename="../main.qml" line="1111"/>
         <source>Error: Filesystem is read only</source>
         <translation>Eraro: dosiersistemo estas nurlegebla</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1081"/>
+        <location filename="../main.qml" line="1113"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Averto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1083"/>
+        <location filename="../main.qml" line="1115"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Noto: estas nur %1 GigaBajto da disponebla spaco sur la aparato. La blokĉeno postulas ~%2 Gigabajtojn da spaco.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1085"/>
+        <location filename="../main.qml" line="1117"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Noto: lmdb-dosierujo ne troviĝis. Nova dosierujo kreiĝos.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1089"/>
+        <location filename="../main.qml" line="1121"/>
         <source>Cancel</source>
         <translation>Nuligi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1566"/>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Eraro: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
         <source>Tap again to close...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1579"/>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Demono funkcias</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1580"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>La demono funkciantos en la fono kiam vi fermos la GUI.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1582"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Haltigi demonon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1617"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Nova versio de monero-wallet-gui disponeblas:  %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Nesufiĉe da mono. Disponebla saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="733"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Mono ne sendeblas</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>La transakcio estas konservita en la dosiero %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="808"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Tiu adreso ricevis %1 monerojn, kun %2 konfirmo(j)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Saldo (Sinkroniĝante)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1194"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Bonvolu atendi...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1218"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Programagordilo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1234"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1284"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>Sendu al la sama celo</translation>
     </message>

--- a/translations/monero-core_es.ts
+++ b/translations/monero-core_es.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmaciones) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmaciones)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmaciones) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmaciones)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>
@@ -1380,7 +1380,7 @@ The old wallet cache file will be renamed and can be restored later.
     <message>
         <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
-        <translation type="unfinished">Por defecto (comisión x4) {1 ?}</translation>
+        <translation type="unfinished">Por defecto (comisión x1)</translation>
     </message>
     <message>
         <location filename="../components/StandardDropdown.qml" line="208"/>
@@ -1702,7 +1702,7 @@ Por favor, actualice o conéctese a otro daemon</translation>
     <message>
         <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
-        <translation type="unfinished">Por defecto (comisión x4) {1 ?}</translation>
+        <translation type="unfinished">Por defecto (comisión x1)</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="196"/>

--- a/translations/monero-core_es.ts
+++ b/translations/monero-core_es.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Añadir nueva entrada</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QRCODE</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ID de Pago &lt;font size=&apos;2&apos;&gt;(Opcional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Pegar 64 caracteres hexadecimales</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Descripción &lt;font size=&apos;2&apos;&gt;(Opcional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Dirección inválida</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>No se puede crear la entrada</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>De a esta entrada un nombre o descripción</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>ID de pago:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Iniciando daemon de Monero en %1 segundos</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>Filtrar historial de transacciones</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Escriba para búsqueda incremental...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Fecha desde</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Hasta</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtrar</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Filtrado avanzado</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Tipo de transacción</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Cantidad desde</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>ID de pago:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>No hay mas resultados</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Altura de Bloque:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 confirmaciones)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmaciones) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NO CONFIRMADO</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>PENDIENTE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Comisión</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Tx ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">ID de pago:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Llave Tx:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Nota Tx:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Destinos:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">No hay mas resultados</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmaciones) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">NO CONFIRMADO</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">PENDIENTE</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Balance</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Balance desbloqueado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Recibir</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Historial</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Libreta de direcciones</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Comprobar pago</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Firmar/verificar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Opciones</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Balance</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Balance desbloqueado</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Minado individual</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(sólo disponible para daemons locales)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Minar con tu compudatora ayuda a fortalecer la red Monero. Cuanta más gente minando, más difícil es atacar la red, y cada pequeño esfuerzo cuenta.&lt;br&gt; &lt;br&gt;Minar también le da la pequeña oportunidad de ganar algún Monero. Su computadora creará hashes buscando soluciones a bloques. Si encuentra un bloque, obtendrá la recompensa asociada. Buena suerte!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>Hilos de CPU</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(opcional)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Minado en segundo plano (experimental)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Habilitar minado en uso con batería</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Administrar minero</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Empezar minado</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Error arrancando el minado</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>No se pudo empezar el minado.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>El minado sólo está disponible en nodos locales. Arranque un daemon local para poder minar.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Parar minado</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Estado: no está minando</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Minando a %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>No está minando</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Estado: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Sincronizando</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Versión incorrecta</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Estado de conexión incorrecto</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Estado de la red</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Por favor, introduzca la contraseña del monedero</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Por favor, introduzca la contraseña del monedero para:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Estableciendo conexión...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Bloques restantes: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Sincronizando bloques</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>ID de pago inválida</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>ADVERTENCIA: Sin conexión al daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>en el txpool: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 confirmaciones: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 confirmación: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Aún no se encontraron transacciones...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transacción encontrada</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 transacciones encontradas</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> con mas dinero (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> con insuficiente dinero (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>monedero de sólo lectura</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 caracteres hexadecimales</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Dirección integrada</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Cantidad a recibir</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                          Trazando &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Trazando pagos</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Esto es un trazador de pagos simple:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Haga click en Generar para generar un ID de pago aleatorio para un nuevo cliente&lt;/p&gt; &lt;p&gt;Deje escanear el código QR a su cliente para hacer su pago (si su cliente tiene un software compatible con escaneo de QR.&lt;/p&gt;&lt;p&gt;Esta página escaneará automáticamente la cadena de bloques y la tx pool las transferencias entrantes usando el mencionado QR code. Si ingresa una cantidad, se comprobará también las transferencias entrantes con un monto total a esa cantidad.&lt;/p&gt;Depende de ud. aceptar transacciones sin confirmar o no. Es probable que sean confirmadas en breve, pero también hay una pequeña posibilidad que no lo sean, así que para grandes valores ud. debería esperar a una o más confirmaciones.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Guardar código QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Falló al guardar el código QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ID de pago</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generar</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generar ID de pago para la dirección integrada</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Noticias</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Ayuda</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Acerca de</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Puerto</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Crear un monedero de sólo lectura</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Administrar daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Arrancar daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Parar daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Mostrar estado</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Flags de inicio del daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(opcional)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished">Error: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished">Información</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished">Gastos re-escaneados correctamente</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Dirección del daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Hostname / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Puerto</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Loguear (opcional)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Usuario</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Conectar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Opciones de disposición</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Decoraciones personalizadas</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Nivel de log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(e.g. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Versión</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Versión de GUI: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Versión de Monero embebido: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
-        <source>Daemon log</source>
-        <translation>Log del daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
+        <source>Daemon log</source>
+        <translation>Log del daemon</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Contraseña incorrecta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Administrar monedero</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Cerrar monedero</translation>
     </message>
@@ -1001,171 +1224,186 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Firma correcta</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Es una firma correcta</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Firma incorrecta</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Esta firma no está verificada</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Firma un mensaje o un contenido con tu dirección:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Cualquier mensaje:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Mensaje a firmar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Firmar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Escoja un fichero a firmar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verificar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>O fichero:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Fichero con el mensaje a firmar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Firma</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Verificar un mensaje o fichero desde una dirección:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Mensaje a verificar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Escoja un fichero a verificar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Fichero con mensaje a verificar</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Dirección de firma &lt;font size=&apos;2&apos;&gt;  ( Pegar o seleccionar de la &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Libreta de direcciones&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Baja (comisión x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Media (comisión x20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Alta (comisión x166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished">Por defecto (comisión x4) {1 ?}</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Todas</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Enviadas</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Recibidas</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Media</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Alta</translation>
     </message>
@@ -1237,192 +1470,207 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Error de OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Prioridad de transacción</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Toda</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Arrancar daemon</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Dirección</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>No se ha encontrado una dirección OpenAlias válida</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Dirección encontrada, pero las firmas DNSSEC no han podido ser verificadas, la dirección puede ser suplantada</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Dirección no válida y las firmas DNSSEC no han podido ser verificadas, la dirección puede ser suplantada</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Error interno</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Dirección no encontrada</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Descripción &lt;font size=&apos;2&apos;&gt;( Opcional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Guardado en el historial del monedero</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Mostrar opciones avanzadas</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Barrer no-mezclables</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Crear fichero tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Firmar fichero tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Enviar fichero tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Escoja un fichero</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>No se puede cargar la transacción no firmada:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Número de transacciones: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transacción #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Receptor: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 ID de pago: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Cantidad: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Comisión:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Tamaño de ring: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Confirmación</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>No se puede enviar la transacción:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Dinero enviado satisfactoriamente</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>El monedero no está conectado al daemon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>El daemon conectado no es compatible con la GUI. 
 Por favor, actualice o conéctese a otro daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Esperando a la completa sincronización del daemon</translation>
     </message>
@@ -1432,77 +1680,52 @@ Por favor, actualice o conéctese a otro daemon</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Coste de transacción</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID de pago&lt;font size=&apos;2&apos;&gt;( Opcional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Iniciar daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Nivel de privacidad (ringsize %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Baja (comisión x1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Media (comisión x20)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Alta (comisión x166)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished">Por defecto (comisión x4) {1 ?}</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Dirección &lt;font size=&apos;2&apos;&gt;  ( Pegar o seleccionar de &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Libreta de direcciones&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Resolver</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 o 64 caracteres hexadecimales</translation>
     </message>
@@ -1510,64 +1733,77 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verifique que una tercera parte ha hecho el pago proporcionando:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation>- la dirección del receptor</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation>- la ID de la transacción</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation>- la llave de transacción secreta proporcionada por el remitente</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Si un pago tuvo varias transacciones entonces cada una debe ser comprobada y los resultados combinados.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Dirección del monedero del receptor</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Generar</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Firma</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>ID de pago</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Pegar ID tx</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Pegar llave tx</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Comprobar</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Llave de transacción</translation>
     </message>
 </context>
 <context>
@@ -1622,6 +1858,39 @@ Por favor, actualice o conéctese a otro daemon</translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Crear un nuevo monedero</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(opcional)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1996,44 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Ya existe un monedero con el mismo nombre. Por favor, cámbielo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Caracteres no ASCII no son permitidos en la ruta del monedero o el nombre de cuenta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>USE MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Crear monedero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Éxito</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>El monedero de sólo lectura ha sido creado. Puede abrirlo cerrando el monedero actual, haciendo click en &quot;Abrir monedero desde fichero&quot; y seleccionando el monedero de sólo lectura en: 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
@@ -1772,47 +2041,52 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Nombre de monedero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Restaurar desde semilla</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Restaurar desde llave</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Dirección de cuenta (pública)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Llave de vista (privada)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Llave de gasto (privada)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Restaurar altura (opcional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Su monedero está guardado en</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Por favor seleccione un directorio</translation>
     </message>
@@ -1825,7 +2099,12 @@ Por favor, actualice o conéctese a otro daemon</translation>
         <translation>Ingrese su mnemónico de 25 palabras</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Es &lt;b&gt;muy&lt;/b&gt; importante escribir y guardar esta semilla en secreto. Es todo lo necesario para restaurar su monedero.</translation>
     </message>
@@ -1833,37 +2112,32 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Bienvenido a Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Por favor seleccione una de las siguientes opciones:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Crear un nuevo monedero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Restaurar monedero desde una llave o mnemónico</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Abrir una monedero desde un fichero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Dirección de daemon personalizada (opcional)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1877,7 +2151,7 @@ Por favor, actualice o conéctese a otro daemon</translation>
         <translation>Ingrese una contraseña para su monedero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation>Nota: Esta contraseña no puede ser recuperada. Si la olvida el monedero deberá ser restaurado con el mnemónico de 25 palabras.&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2161,12 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Confirme contraseña</translation>
     </message>
@@ -1900,7 +2174,7 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Restaurar monedero</translation>
     </message>
@@ -1908,12 +2182,12 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Bienvenid@ a Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Por favor, escoja un idioma y un formato regional.</translation>
     </message>
@@ -1921,90 +2195,97 @@ Por favor, actualice o conéctese a otro daemon</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>No se pudo abrir el monedero:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Balance desbloqueado (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Balance desbloqueado</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Esperando al daemon...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Esperando a que el daemon se detenga...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>No se pudo crear la transacción: Versión de daemon incorrecta:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>No se puede crear la transacción:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>No hay salidas no-mezclables que barrer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Confirmación</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Por favor confirme la transacción:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>Dirección:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>ID de pago:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2013,42 +2294,71 @@ Amount: </source>
 Cantidad:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Comisión:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Firma incorrecta</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Esta dirección recibió %1 monero, con %2 confirmacion(es).</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Número de transacciones: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Balance desbloqueado (esperando bloque)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>El daemon ha fallado al iniciar</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Por favor, compruebe si hay errores en los logs de su monedero y daemon. También puede probar iniciar %1 manualmente.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2057,7 +2367,7 @@ Ringsize: </source>
 Ringsize:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2066,97 +2376,149 @@ Description: </source>
 Descripción:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Cantidad errónea: se espera número de %1 a %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Fondos insuficientes. Balance desbloqueado %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>No se pudo enviar el dinero:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Dinero enviado correctamente: %1 transacción(es) </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transacción guardada en fichero: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Comprobación de pago</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Esta dirección recibió %1 monero, pero la transacción no ha sido minada</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Esta dirección no ha recibido nada</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Firma correcta</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Balance (sincronizando)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Balance</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Contraseña incorrecta</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Error: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Espere...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Asistente de configuración</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>enviar a la misma destinatario</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Daemon ejecutando</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>El daemon seguirá corriendo en segundo plano cuando la GUI sea cerrada.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Parar daemon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Nueva versión de monero-wallet-gui disponible: %1&lt;br&gt;%2</translation>
     </message>

--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Lisää uusi osoite</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QR koodi</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Maksutunniste &lt;font size=&apos;2&apos;&gt;(Valinnainen)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Liitä 64 heksadesimaalimerkkiä</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Kuvaus &lt;font size=&apos;2&apos;&gt;(Valinnainen)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Anna tähän nimi tai kuvaus</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Virheellinen osoite</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Ei voida lisätä merkintää</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Maksutunniste:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Käynnistetään Monero taustaohjelma %1 sekunnin kuluttua</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,39 +190,39 @@
         <translation>Suodata tapahtumahistoriaa</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Kirjoita hakeaksesi...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtteri</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Päiväys</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Mihin</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translatorcomment>?</translatorcomment>
         <translation>Lisäsuodatus</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Rahansiirron tyyppi</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Määrä</translation>
     </message>
@@ -231,7 +236,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Maksutunniste:</translation>
     </message>
@@ -256,150 +261,294 @@
         <translation>Ei enempää tuloksia</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Lisätietoja</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Lohkoketjun pituus:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 vahvistusta)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 vahvistusta) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>VAHVISTAMATON</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>VIREILLÄ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Päiväys</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Siirtopalkkio</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Siirron tunniste (Tx ID):</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Maksutunniste:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Siirron avain:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Siirron kommentti:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Kohteet:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Ei enempää tuloksia</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 vahvistusta) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">VAHVISTAMATON</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">VIREILLÄ</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Lukitsematon saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Lähetä</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Vastaannota</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Osoitekirja</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Edistynyt</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Louhinta</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Tarkista maksu</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Allekirjoita/varmenna</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
@@ -407,12 +556,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Lukittamaton Saldo</translation>
     </message>
@@ -420,87 +569,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Soololouhinta</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(saatavilla vain paikallisille taustaohjelmille)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Louhinta tietokoneellasi auttaa vahvistamaan Moneroverkkoa. Mitä enemmän ihmiset louhivat, sitä vaikeampaa on hyökätä verkkoon ja jokainen pieni osa auttaa.&lt;br&gt; &lt;br&gt;Louhinta myös antaa sinulle pienen mahdollisuuden ansaita vähän Moneroa. Tietokoneesi luo haketta etsien lohkon ratkaisuja. Jos löydät lohkon, saat siihen liittyvän palkinnon. Onnea!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(valinnainen)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Louhinta taustalla (kokeellinen)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Salli louhinta akkuvirralla</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Aloita louhinta</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Virhe louhinnan aloittamisessa</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -508,7 +657,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished">Lukitsematon saldo:</translation>
     </message>
@@ -521,40 +670,68 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Yhdistetty</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Väärä versio</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Ei yhdistetty</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Virheellinen yhteys</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Verkon tila</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Syötä lompakon salasana</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -564,9 +741,9 @@
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -590,19 +767,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation type="unfinished">Synkronisoidaan lohkoja</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -613,152 +798,162 @@
         <translation>Virheellinen maksutunniste</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>ReadOnly lompakon osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Integroitu osoite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Maksutunniste</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Luo</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation></translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Uutiset</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Apua</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Tietoja</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Portti</translation>
     </message>
 </context>
 <context>
@@ -777,224 +972,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">(valinnainen)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished">Tietoa</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Palveluprosessin osoite</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Osoite / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Portti</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation type="unfinished">Salasana</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished">Peruuta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Hallitse lompakkoa</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Sulje lompakko</translation>
     </message>
@@ -1002,105 +1225,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Pätevä allekirjoitus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Tämä on pätevä allekirjoitus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Virheellinen allekirjoitus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Tätä allekirjoitusta ei pystytty vahvistamaan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Allekirjoita viesti tai tiedoston sisältö osoitteellasi:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Jompikumpi viesteistä:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Viesti jonka haluat allekirjoittaa</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Tai tiedosto:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Tiedostonimi viestillä jonka haluat allekirjoittaa</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Allekirjoitus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Vahvista viestin tai tiedoston allekirjoitus osoitteesta:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Viesti jonka allekirjoituksen haluat vahvistaa</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Tiedostonimi viestillä jonka haluat vahvistaa</translation>
     </message>
@@ -1108,65 +1336,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1221,16 +1459,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
+        <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1238,221 +1471,211 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Rahansiirron prioriteetti</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation type="unfinished">Lähetä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation type="unfinished">Tietoa</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Osoite</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">
 Rahansiirtojen lukumäärä:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Siirtopalkkio:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation type="unfinished">Hyväksyntä</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1462,42 +1685,42 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Rahansiirron hinta</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Maksutunniste &lt;font size=&apos;2&apos;&gt;( Valinnainen )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 tai 64 heksamerkkiä</translation>
     </message>
@@ -1505,64 +1728,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Vastaannottajan lompakon osoite</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Luo</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Allekirjoitus</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Rahansiirron tunniste</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Rahansiirron avain</translation>
     </message>
 </context>
 <context>
@@ -1616,6 +1852,39 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(valinnainen)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1722,43 +1991,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Lompakko kyseisellä nimellä on jo olemassa. Ole hyvä ja vaihda lompakon nimi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>KÄYTÄ MONEROA</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1766,47 +2035,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
-        <source>Account address (public)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
-        <source>View key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
-        <source>Spend key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
-        <source>Restore height (optional)</source>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Lompakkosi on säilytetty kyseisessä kansiossa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Valitse tiedostopolku</translation>
     </message>
@@ -1819,7 +2093,12 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1827,37 +2106,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Tervetuloa käyttämään Moneroa!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Valitse jokin seuraavista vaihtoehdoista:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation></translation>
     </message>
@@ -1871,7 +2145,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1880,12 +2154,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation type="unfinished">Salasana</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation type="unfinished">Vahvista salasana</translation>
     </message>
@@ -1893,7 +2167,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1901,12 +2175,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished">Tervetuloa käyttämään Moneroa!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Valitse kieli ja alueellinen muoto.</translation>
     </message>
@@ -1914,107 +2188,114 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Lompakkoa ei voitu avata:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">Lukitsematon saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Rahansiirtoa ei onnistuttu tekemään: Palveluprosessin versio on väärä:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Rahansiirtoa ei onnistuttu tekemään:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Hyväksyntä</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Vahvista rahansiirto:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Osoite:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 Maksutunniste:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2023,54 +2304,139 @@ Amount: </source>
 Määrä:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Siirtopalkkio:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Virheellinen allekirjoitus</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Pätevä allekirjoitus</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Rahansiirtojen lukumäärä:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2079,77 +2445,73 @@ Description: </source>
 Kuvaus:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Määrä on virheellinen: odotettiin numeroa %1 :n ja %2 :n välillä</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>riittämättömät varat. Lukitsematon saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Rahansiirtoa ei voitu suorittaa:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Tietoa</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Rahat lähetettiin onnistuneesti: %1  rahansiirto(a)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Maksun tarkistus</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Tähän osoitteeseen on saapunut %1 Moneroa, mutta rahansiirtoa ei ole vielä lisätty lohkoon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Tähän osoitteeseen ei ole saapunut mitään</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation type="unfinished">Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Odota...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Sovelluksen asetusvelho</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>lähetä samaan osoitteeseen</translation>
     </message>

--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -273,7 +273,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 vahvistusta) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 vahvistusta)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -341,7 +341,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 vahvistusta) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 vahvistusta)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_fr.ts
+++ b/translations/monero-core_fr.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmations) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmations)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmations) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmations)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_fr.ts
+++ b/translations/monero-core_fr.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Ajouter nouvelle entrée</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>CODE QR</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ID de paiement &lt;font size=&apos;2&apos;&gt;(Facultatif)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Coller 64 caractères hexadécimaux</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Description &lt;font size=&apos;2&apos;&gt;(Facultatif)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Adresse invalide</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Impossible de créer l&apos;entrée</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Donner un nom ou une description pour cette entrée</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>ID de paiement :</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Lancement du démon Monero dans %1 secondes</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>Filtrer l&apos;historique des transactions</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Entrez du texte pour la recherche incrémentale...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Date du</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Au</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtrer</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Filtrage avancé</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Type de transaction</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Montant à partir de</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>ID paiement :</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Pas d&apos;autre résultat</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Détails</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Hauteur bloc :</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 confirmations)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmations) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NON CONFIRMÉ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>EN ATTENTE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Frais</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">ID transaction :</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Clé de transaction :</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Note de transaction :</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Destinations :</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmations) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">NON CONFIRMÉ</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">EN ATTENTE</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Clé secrète d&apos;audit</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Clé publique d&apos;audit</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Clé secrète de dépense</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Clé publique de dépense</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Solde débloqué</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Envoyer</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Recevoir</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Historique</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Carnet d&apos;adresses</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Avancé</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Mine</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Vérifier paiement</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Signer/vérifier</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Réglages</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Solde Débloqué</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Extraction minière en solo</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(disponible uniquement pour les démons locaux)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>L&apos;extraction minière avec votre ordinateur renforce le réseau Monero. Plus il y en a, plus il est difficile d&apos;attaquer le réseau, donc chaque mineur est utile.&lt;br&gt; &lt;br&gt;La mine vous donne aussi une petite chance de gagner des Moneros. Votre ordinateur va calculer des empreintes pour essayer de créer un bloc valide. Si vous trouvez un bloc, vous obtiendrez la récompense associée. Bonne chance !</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>Threads CPU</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(facultatif)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Mine en arrière plan (expérimental)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Activer la mine en cas de fonctionnement sur batterie</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Gérer le mineur</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Erreur lors du démarrage de l&apos;extraction minière</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Impossible de démarrer l&apos;extraction minière.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>L&apos;extraction minière n&apos;est disponible que pour les démons locaux. Démarrez un démon local pour pouvoir l&apos;utiliser.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Arrêter</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Statut : pas d&apos;extraction minière</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Extraction minière à %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Pas d&apos;extraction minière</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Statut :</translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Solde débloqué :</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Synchronisation</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Connecté</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Mauvaise version</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Déconnecté</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>État de connexion invalide</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>État du réseau</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Entrez le mot de passe du portefeuille</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Entrez le mot de passe du portefeuille pour :&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Établissement de la connexion...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Blocs restants : %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Synchronisation des blocs</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>ID de paiement invalide</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>ATTENTION : non connecté au démon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>dans le pool de transactions : %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 confirmations: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 confirmation: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Pas de transaction trouvée pour le moment...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transaction trouvée</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 transactions trouvées</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> avec plus d&apos;argent (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> avec trop peu d&apos;argent (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Adresse du portefeuille LectureSeule affichée ici</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 caractères hexadécimaux</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Adresse intégrée</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Montant à recevoir</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Suivi &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;aide&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Suivi des paiements</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Ceci est un simple suivi des ventes :&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Cliquez sur Générer pour créer un identifiant de paiement aléatoire pour un nouveau client&lt;/p&gt; &lt;p&gt;Laissez votre client scanner le code QR pour faire un paiement (si ce client a un logiciel permettant de scanner les codes QR).&lt;/p&gt;&lt;p&gt;Cette page va automatiquement scanner la chaîne de blocs et le pool de transactions pour trouver les transactions entrantes utilisant ce code QR. Si vous entrez un montant, il sera aussi vérifié que le total des transactions entrantes arrive à ce montant.&lt;/p&gt;C&apos;est à vous de décider si vous acceptez les transactions non confirmées ou pas. Il est probable qu&apos;elles seront confirmées assez rapidement, mais il y a toujours une possibilité qu&apos;elles ne le soient pas, donc pour de gros montants vous devriez attendre qu&apos;il y ait une confirmation ou plus.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Enregistrer le code QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Impossible d&apos;enregistrer le code QR vers </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ID de paiement</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Générer</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Générer un identifiant de paiement pour une adresse intégrée</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Nouvelles</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Aide</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>À propos</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Créer portefeuille d&apos;audit</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Gérer le démon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Lancer démon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Arrêter démon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Montrer statut</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Options de démarrage</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(facultatif)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Montrer graine et clés</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Rescanner le solde du portefeuille</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Les sorties dépensées ont été rescannées avec succès</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Emplacement de la chaîne de blocs</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Adresse du démon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Nom d&apos;hôte / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Identifiant (facultatif)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Nom d&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Veuillez choisir un répertoire</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Erreur : Système de fichiers en lecture seule</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Attention : Il y a seulement %1 GB disponibles sur le périphérique. La chaîne de blocs a besoin de ~%2 GB.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Note : Il y a %1 GB disponibles sur le périphérique. La chaîne de blocs a besoin de ~%2 GB.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Note : répertoire lmdb non trouvé. Un nouveau répertoire va être créé.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Connecter</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Réglages d&apos;agencement</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Décorations personnalisées</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Niveau journal</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(e.g. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Version</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Version de l&apos;interface graphique : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Version de Monero incorporée : </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Journal du démon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Clés et graine du portefeuille</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Clé secrète d&apos;audit</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Clé publique d&apos;audit</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>Clé secrète de dépense</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>Clé publique de dépense</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Mauvais mot de passe</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Gérer le portefeuille</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Fermer</translation>
     </message>
@@ -1001,171 +1224,186 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Bonne signature</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Ceci est une bonne signature</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Mauvaise signature</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Cette signature n&apos;a pas réussi le test de vérification</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Signer un message ou un fichier avec votre adresse :</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Soit un message :</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Message à signer</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Signer</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Veuillez choisir un fichier à signer</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Sélectionner</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Vérifier</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Veuillez choisir un fichier à vérifier</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Ou un fichier :</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Nom du ficher avec le message à signer</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Signature</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Vérifier la signature d&apos;un message ou d&apos;un fichier avec une adresse :</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Message à vérifier</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Nom du ficher avec le message à vérifier</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Adresse du signataire &lt;font size=&apos;2&apos;&gt;  ( Collez  ou sélectionnez dans le &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Carnet d&apos;adresses&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Bas (frais x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Moyen (frais x20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Haut (frais x166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished">Lent (frais x0.25)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished">Par défaut (frais x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished">Rapide (frais x5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished">Très rapide (frais x41.5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Envoyé</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Reçu</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Moyen</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Haut</translation>
     </message>
@@ -1237,252 +1470,242 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Erreur OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Priorité de transaction</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Lancer le démon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Niveau de confidentialité (taille du cercle %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Tout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Bas (frais x1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Moyen (frais x20)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Haut (frais x166)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Lent (frais x0.25)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Par défaut (frais x1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Rapide (frais x5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Très rapide (frais x41.5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adresse &lt;font size=&apos;2&apos;&gt;  ( Collez ou sélectionnez dans le &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Carnet d&apos;adresses&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>Code QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Résoudre</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Pas d&apos;adresse valide trouvée à cette adresse OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adresse trouvée, mais les signatures DNSSEC n&apos;ont pas pu être vérifiées, donc cette adresse pourrait avoit été falsifiée</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Pas d&apos;adresse valide trouvée à cette adresse OpenAlias, mais les signatures DNSSEC n&apos;ont pas pu être vérifiées, donc ceci pourrait être avoir été falsifié</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Erreur interne</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Pas d&apos;adresse trouvée</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Description &lt;font size=&apos;2&apos;&gt;( Facultatif )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Enregistré dans l&apos;historique du portefeuille local</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Envoyer</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Options avancées</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Non Mélangeables</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Créer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Signer fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Soumettre fichier tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Veuillez choisir un fichier</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Lancer démon</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresse</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Impossible de charger une transaction non signée : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Nombre de transactions : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transaction #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Destinataire : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 identifiant de paiement : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Frais : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Taille du cercle : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Impossible de soumettre la transaction : </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Argent envoyé avec succès</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Le portefeuille n&apos;est pas connecté au démon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Le démon connecté n&apos;est pas compatible avec l&apos;interface graphique. 
 Veuillez mettre à jour ou vous connecter à un autre démon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Attente de la fin de la synchronisation avec le démon</translation>
     </message>
@@ -1492,17 +1715,17 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Coût de transaction</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID de paiement &lt;font size=&apos;2&apos;&gt;( Facultatif )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 ou 64 caractères hexadécimaux</translation>
     </message>
@@ -1510,64 +1733,77 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Vérifiez qu&apos;un tiers a effectué un paiement en fournissant :</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - l&apos;adresse du destinataire</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - l&apos;identifiant de la transaction</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - la clé secrète de transaction fournie par le payeur</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Si un paiement est constitué de plusieurs transactions, chaque transaction doit être vérifiée et les résultats ajoutés.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Adresse du portefeuille du destinataire</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Générer</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Signature</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>ID de transaction</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Coller l&apos;identifiant de transaction</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Coller la clé de transaction</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Vérifier</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Clé de transaction</translation>
     </message>
 </context>
 <context>
@@ -1622,6 +1858,39 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Créer un nouveau portefeuille</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Emplacement de la chaîne de blocs</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(facultatif)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1996,44 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Un portefeuille avec le même nom existe déjà. Veuillez changer le nom du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Les caractères non ASCII ne sont pas autorisés dans le chemin du portefeuille ou le nom du compte</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>UTILISER MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Créer un portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Succès</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>Le portefeuille en vue seule a été créé. Vous pouvez l&apos;ouvrir en fermant le portefeuille actuel, puis en cliquant sur l&apos;option &quot;Ouvrir un fichier portefeuille&quot; et en sélectionnant le portefeuille en vue seule dans : 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Abandonner</translation>
     </message>
@@ -1772,47 +2041,52 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Nom du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Restaurer à partir de la graine</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Restaurer à partir des clés</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Adresse du compte (publique)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Clé d&apos;audit (privée)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Clé de dépense (privée)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Hauteur de restoration (facultatif)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Votre portefeuille est stocké dans</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Veuillez choisir un répertoire</translation>
     </message>
@@ -1825,7 +2099,12 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation>Entrez votre graine mnémonique de 25 mots</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Il est &lt;b&gt;très&lt;/b&gt; important d&apos;&apos;écrire cette graine sur papier et de la garder secrète. C&apos;est tout ce dont vous avez besoin pour sauvegarder et restaurer votre portefeuille.</translation>
     </message>
@@ -1833,37 +2112,32 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Bienvenue dans Monero !</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Veuillez sélectionner une des options suivantes :</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Créer un nouveau portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Restaurer un portefeuille à partir des clés ou de la graine mnémonique</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Ouvrir un fichier portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Adresse de démon personnalisée (facultatif)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1877,7 +2151,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
         <translation>Mettre un mot de passe à votre portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Note : ce mot de passe ne pourra pas être recupéré. Si vous l&apos;oubliez vous devrez restaurer votre portefeuille avec sa graine mnémonique de 25 mots.&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2161,12 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Mot de passe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Confirmer le mot de passe</translation>
     </message>
@@ -1900,7 +2174,7 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Restaurer un portefeuille</translation>
     </message>
@@ -1908,12 +2182,12 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Bienvenue dans Monero !</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Veuillez choisir une langue et un format régional.</translation>
     </message>
@@ -1921,107 +2195,114 @@ Veuillez mettre à jour ou vous connecter à un autre démon</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Impossible d&apos;ouvrir le portefeuille : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Solde débloqué (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Solde débloqué</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Solde débloqué (attente de bloc)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Attente du démarrage du démon...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Attente de l&apos;arrêt du démon...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Échec du lancement du démon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Veuillez vérifier les erreurs dans les journaux du portefeuille et du démon. Vous pouvez aussi essayer de lancer %1 manuellement.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Impossible de créer la transaction : mauvaise version de démon : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Impossible de créer la transaction : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Aucune sortie non mélangeable à balayer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Veuillez confirmer la transaction :
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adresse : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 ID de paiement : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2030,15 +2311,15 @@ Amount: </source>
 Montant : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Frais : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2047,39 +2328,124 @@ Ringsize: </source>
 Taille du cercle : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Mauvaise signature</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Bonne signature</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Mauvais mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Attention</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Erreur : Système de fichiers en lecture seule</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Attention : Il y a seulement %1 GB disponibles sur le périphérique. La chaîne de blocs a besoin de ~%2 GB.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Note : Il y a %1 GB disponibles sur le périphérique. La chaîne de blocs a besoin de ~%2 GB.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Note : répertoire lmdb non trouvé. Un nouveau répertoire va être créé.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuler</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Erreur : </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Le démon fonctionne</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Le démon fonctionnera toujours en arrière plan après fermeture de l&apos;interface graphique.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Arrêter démon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Une nouvelle version de monero-wallet-gui est disponible : %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Cette adresse a reçu %1 monero, avec %2 confirmation(s).</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Nombre de transactions : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2088,77 +2454,73 @@ Description: </source>
 Description : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Montant erroné : nombre entre %1 et %2 attendu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>fonds insuffisants. Solde débloqué : %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Impossible d&apos;envoyer l&apos;argent : </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Argent envoyé avec succès : %1 transaction(s) </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transaction enregistrée dans le fichier : %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Vérification de paiement</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Cette adresse a reçu %1 monero, mais la transaction n&apos;a pas encore été incluse dans un bloc</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Cette adresse n&apos;a rien reçu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Solde (synchronisation en cours)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Solde</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Veuillez patienter…</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Assistant de configuration du programme</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>envoyer à la même destination</translation>
     </message>

--- a/translations/monero-core_he.ts
+++ b/translations/monero-core_he.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 אישורים) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 אישורים)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 אישורים) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 אישורים)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_he.ts
+++ b/translations/monero-core_he.ts
@@ -1,83 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-
 <TS version="2.1">
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>הוסף רשומה חדשה</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="63"/>
-        <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="72"/>
-        <source>QRCODE</source>
-        <translation>קוד QR</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="94"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="103"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>מזהה תשלום &lt;font size=&apos;2&apos;&gt;(אופציונלי)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="105"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
         <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="117"/>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>הדבק 64 תווים הקסדצימלים</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="126"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>תיאור &lt;font size=&apos;2&apos;&gt;(אופציונלי)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="139"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>תן לכתובת זו שם או תיאור</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="155"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>הוסף</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="160"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>כתובת לא תקנית</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="167"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>לא ניתן ליצור רשומה</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="128"/>
-        <source>&lt;b&gt;Tip test test&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;test line 2</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -91,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>מזהה תשלום:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -133,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>מפעיל את מסנכרן הרשת עוד %1 שניות</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -201,52 +190,38 @@
         <translation>סנן היסטוריית עסקאות</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="147"/>
-        <source>&lt;b&gt;Total amount of selected payments&lt;/b&gt;</source>
-        <translation>&lt;b&gt;סכום כולל של תשלומים מסומנים&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="185"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>הקלד לחיפוש...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="281"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>סנן</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="226"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>החל מתאריך</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="228"/>
-        <location filename="../pages/History.qml" line="255"/>
-        <location filename="../pages/History.qml" line="341"/>
-        <location filename="../pages/History.qml" line="378"/>
-        <location filename="../pages/History.qml" line="412"/>
-        <source>&lt;b&gt;Tip tekst test&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="253"/>
-        <location filename="../pages/History.qml" line="410"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>עד</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="319"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>סינון מתקדם</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="339"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>סוג העברה</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="376"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>החל מסכום</translation>
     </message>
@@ -260,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>מזהה תשלום (Payment ID)</translation>
     </message>
@@ -285,160 +260,294 @@
         <translation>אין תוצאות נוספות</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>פרטים</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>גובה בלוק:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 אישורים)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 אישורים) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>ממתין לאישור</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>ממתין להישלח</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>סכום</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>עמלה</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">מזהה העברה (Tx ID):</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">מפתח העברה (Tx key):</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">הערות העברה</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">יעדים:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 אישורים) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">ממתין לאישור</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">ממתין להישלח</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">מפתח צפייה סודי</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">מפתח צפייה ציבורי</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">מפתח שימוש סודי</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">מפתח שימוש ציבורי</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>יתרה</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="135"/>
-        <source>Test tip 1&lt;br/&gt;&lt;br/&gt;line 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LeftPanel.qml" line="178"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>יתרה זמינה</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="181"/>
-        <source>Test tip 2&lt;br/&gt;&lt;br/&gt;line 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LeftPanel.qml" line="281"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>שלח</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="331"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>קבל</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="332"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="425"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="355"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>היסטוריה</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="306"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>ספר כתובות</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="307"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="356"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="378"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>מתקדם</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="379"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="400"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>כרייה</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="401"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="424"/>
-        <source>Check payment</source>
-        <translation>בדוק תשלום</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="448"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>חתום/וודא</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="472"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="282"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="449"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="471"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
@@ -446,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>יתרה</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>יתרה זמינה</translation>
     </message>
@@ -459,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>כרייה באופן עצמאי</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(אפשרי רק עבור מסנכרן רשת לוקאלי שנמצא על מחשב זה)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>כרייה מאבטחת את רשת מונרו. ככל שיותר אנשים יכרו, הקושי לתקוף את הרשת גדל.&lt;br&gt; &lt;br&gt;בנוסף, כרייה נותנת סיכוי קטן לזכות במונרו. המחשב שלך ינסה ליצור את הבלוק הבא בשרשרת, ואם תצליח תזכה. בהצלחה!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
-        <translation>תהליכונים (ת'רדים)</translation>
+        <translation>תהליכונים (ת&apos;רדים)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(אופציונלי)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>כרייה ברקע (נסיוני)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>אפשר כרייה כאשר המחשב פועל על בטרייה</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>נהל את תהליך הכרייה</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>התחל כרייה</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>שגיאה בניסיון כרייה</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>לא ניתן להתחיל תהליך כרייה.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>כרייה אפשרית רק עם מסנכרן רשת לוקאלי. הרץ מסנכרן רשת על מחשב זה על מנת להתחיל כרייה.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>הפסק כרייה</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>סטטוס: לא כורה</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>כורה בקצב  %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>לא כורה</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>סטטוס: </translation>
     </message>
@@ -547,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>יתרה ניתנת לשימוש:</translation>
     </message>
@@ -560,40 +669,68 @@
         <translation>מסתנכרן</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>מחובר</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>גרסה שגויה</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>מנותק</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>סטטוס חיבור לא תקין</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>סטטוס רשת</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>אנא הכנס סיסמת ארנק</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>אנא הכנס סיסמת ארנק עבור:&lt;br&gt;</translation>
     </message>
@@ -603,9 +740,9 @@
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>אישור</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -629,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>יוצר חיבור...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>בלוקים שנותרו: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>מסנכרן בלוקים</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -652,152 +797,162 @@
         <translation>מזהה תשלום לא תקין</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>אזהרה: אין חיבור למסנכרן רשת</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>העברה נשלחה: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 אישורים: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>אישור אחד: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>עוד לא נמצאה העברה...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>העברה נמצאה</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 עסקאות נמצאו</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>עם סכום גבוה יותר (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>עם סכום נמוך יותר (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>הכתובת המוצגת שייכת לארנק לקריאה בלבד</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 תווים הקסדצימלים</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>נקה</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>כתובת משולבת (עם מזהה תשלום)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>סכום לקבלה</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           מעקב &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>מעקב אחר תשלומים</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
-        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;זהו כלי פשוט למעקב אחר מכירות:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;לחץ על 'צור' על מנת ליצור מזהה תשלום אקראי עבור לקוח חדש&lt;/p&gt; &lt;p&gt;הצג קוד QR זה ללקוח על מנת שיסרוק אותו ויבצע תשלום (אם ללקוח יש תוכנה מתאימה לסריקת קוד QR)&lt;/p&gt;&lt;p&gt;דף זה סורק את הרשת עבור עסקאות המשויכות לקוד QR המוצג. אם בנוסף יוכנס סכום, הסריקה מוודאת שהעסקאות המתאימות אכן כוללות את מלוא הסכום.&lt;/p&gt;זו החלטתך האם לקבל עסקאות שעוד לא אושרו. סביר שהן יאושרו תוך זמן קצר, אך עדיין קיימת אפשרות שלא. לכן עבור סכומים גדולים מומלץ להמתין עד לקבלת אישור אחד או יותר.&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;זהו כלי פשוט למעקב אחר מכירות:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;לחץ על &apos;צור&apos; על מנת ליצור מזהה תשלום אקראי עבור לקוח חדש&lt;/p&gt; &lt;p&gt;הצג קוד QR זה ללקוח על מנת שיסרוק אותו ויבצע תשלום (אם ללקוח יש תוכנה מתאימה לסריקת קוד QR)&lt;/p&gt;&lt;p&gt;דף זה סורק את הרשת עבור עסקאות המשויכות לקוד QR המוצג. אם בנוסף יוכנס סכום, הסריקה מוודאת שהעסקאות המתאימות אכן כוללות את מלוא הסכום.&lt;/p&gt;זו החלטתך האם לקבל עסקאות שעוד לא אושרו. סביר שהן יאושרו תוך זמן קצר, אך עדיין קיימת אפשרות שלא. לכן עבור סכומים גדולים מומלץ להמתין עד לקבלת אישור אחד או יותר.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>שמור קוד QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>נכשל לשמור קוד QR אל</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>שמור בשם</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>מזהה תשלום</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>צור</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>צור מזהה תשלום עבור כתובת משולבת</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>סכום</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>טוויטר</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>חדשות</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>עזרה</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>אודות</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">פורט</translation>
     </message>
 </context>
 <context>
@@ -816,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>צור ארנק לצפייה בלבד</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>נהל את מסנכרן הרשת</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>התחל סנכרון</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>עצור סנכרון</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>הצג סטטוס</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>פרמטרים להפעלה</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(אופציונלי)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>הצג משפט סודי ומפתחות</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>סרוק מחדש יתרת ארנק</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>שגיאה: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>מידע</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>סריקה מחדש של הוצאות הסתיימה בהצלחה</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>מיקום בסיס נתונים</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>כתובת מסנכרן</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>שם מחשב / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>פורט</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>התחברות (אופציונלי)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>שם משתמש</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>סיסמה</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>התחבר</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>הגדרות מראה</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>עיצובים מיוחדים</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>רמת פירוט יומן סנכרון</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(למשל *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>גרסה</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>גרסת ממשק גרפי: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>גרסת מונרו: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>יומן סנכרון</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>אנא בחר תיקייה</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>אזהרה</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>שגיאה: מערכת הקבצים היא לקריאה בלבד</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>אזהרה: נותרו רק %1 GB על ההתקן. בסיס הנתונים דורש ~%2 GB של מידע</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>שים לב: נותרו רק %1 GB על ההתקן. בסיס הנתונים דורש ~%2 GB של מידע</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>שים לב: התיקייה lmdb לא נמצאה(בסיס הנתונים). יוצר תיקייה חדשה.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>בטל</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>משפט סודי ומפתחות</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>מפתח צפייה סודי</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>מפתח צפייה ציבורי</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>מפתח שימוש סודי</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>מפתח שימוש ציבורי</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>סיסמה שגויה</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>נהל ארנק</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>סגור ארנק</translation>
     </message>
@@ -1041,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>חתימה נכונה</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>זוהי חתימה נכונה</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>חתימה שגויה</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>חתימה זו לא עברה את תהליך הוידוא</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>חתום על הודעה או קובץ עם הכתובת שלך</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>הודעה:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>ההודעה לחתום</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>חתום</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>אנא בחר קובץ לחתום</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>בחר</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>וודא</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>אנא בחר קובץ לוודא</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            הכתובת החותמת &lt;font size=&apos;2&apos;&gt;  ( הדבק או בחר מ &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;ספר כתובות&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>או קובץ:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>שם קובץ עם הודעה לחתימה</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>חתימה</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
-        <translation>וודא חתימת הודעה או קובץ ע"י כתובת:</translation>
+        <translation>וודא חתימת הודעה או קובץ ע&quot;י כתובת:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>הודעה לוידוא</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>שם קובץ עם הודעה לוידוא</translation>
     </message>
@@ -1147,45 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>אישור</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>נמוך (עמלה x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>בינוני (עמלה x20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>גבוה (עמלה x166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <source>Slow (x0.25 fee)</source>
+        <translation type="unfinished">איטי (עמלה x0.25)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
+        <source>Default (x1 fee)</source>
+        <translation type="unfinished">ברירת מחדל (עמלה x1)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
+        <source>Fast (x5 fee)</source>
+        <translation type="unfinished">מהיר (עמלה x5)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
+        <source>Fastest (x41.5 fee)</source>
+        <translation type="unfinished">הכי מהיר (עמלה x41.5)</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>הכל</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>נשלח</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>התקבל</translation>
     </message>
@@ -1240,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>רגיל</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>בינוני</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>גבוה</translation>
     </message>
@@ -1257,227 +1470,217 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;התחל סנכרון&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>שגיאה בתרגום שם</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>רמת פרטיות (מספר שולחים פוטנציאלים %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>סכום</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>עדיפות העברה</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>הכל</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="193"/>
-        <source>Low (x1 fee)</source>
-        <translation>נמוכה (עמלה x1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="194"/>
-        <source>Medium (x20 fee)</source>
-        <translation>בינונית (עמלה x20)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
-        <source>High (x166 fee)</source>
-        <translation>גבוהה (עמלה x166)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="233"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      כתובת &lt;font size=&apos;2&apos;&gt;  ( הדבק או בחר מ &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;ספר כתובות&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="251"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="281"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>תרגם</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="299"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>לא נמצאה כתובת חוקית עבור שם זה</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="304"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>כתובת נמצאה, אך לא ניתן לוודא את החתימה. ייתכן שכתובת זו אינה נכונה/זדונית</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="306"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>לא נמצאה כתובת חוקית עבור שם זה</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="309"/>
-        <location filename="../pages/Transfer.qml" line="312"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>שגיאה פנימית</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="315"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>לא נמצאה כתובת</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="355"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>תיאור &lt;font size=&apos;2&apos;&gt;( אופציונלי )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="367"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>נשמר בהיסטוריית הארנק</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="397"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>שלח</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="443"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>הצג הגדרות מתקדמות</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="495"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>איחוד יתרות שאינן ניתנות לשימוש</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="509"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>ייצא העברה אל קובץ</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="531"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>חתום על העברה מקובץ</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="545"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>בצע העברה מקובץ</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="578"/>
-        <location filename="../pages/Transfer.qml" line="634"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="640"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>מידע</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="567"/>
-        <location filename="../pages/Transfer.qml" line="628"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>אנא בחר קובץ</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="579"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">התחל סנכרון</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">כתובת</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>לא ניתן לטעון עסקאות לא חתומות</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="586"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>מספר עסקאות: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="588"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>העברה #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="589"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>נמען (מקבל)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>מזהה תשלום</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="591"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>סכום: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 עמלה: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 מספר שולחים פוטנציאלים (גודל חוג): </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="607"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="635"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>העברה נכשלה: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="641"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>כסף נשלח בהצלחה</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="700"/>
-        <location filename="../pages/Transfer.qml" line="712"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>הארנק אינו מחובר למסנכרן רשת</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="715"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>מסנכרן הרשת המחובר אינו מתאים לגרסה של ממשק גרפי זה.
 אנא עדכן את המסנכרן או התחבר למסנכרן אחר</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="720"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>ממתין לסנכרון הרשת להסתיים</translation>
     </message>
@@ -1487,37 +1690,37 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="470"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>עלות העברה</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="330"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>מזהה תשלום &lt;font size=&apos;2&apos;&gt;( אופציונלי )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="202"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>איטי (עמלה x0.25)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="203"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>ברירת מחדל (עמלה x1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="204"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>מהיר (עמלה x5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="205"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>הכי מהיר (עמלה x41.5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="342"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 או 64 תווים הקסדצימלים</translation>
     </message>
@@ -1525,64 +1728,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>וודא שגורם כלשהו ביצע תשלום. יש לספק:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - כתובת הנמען (המקבל)</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - קוד זיהוי העברה</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - מפתח ההעברה הסודי שסופק ע"י השולח</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>אם בתשלום היו מספר עסקאות, יש לוודא כל אחת מהעסקאות</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>כתובת הנמען (המקבל)</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">צור</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">חתימה</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>מזהה העברה</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>הדבק מזהה העברה</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>הדבק מפתח העברה</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>בדוק</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>מפתח העברה</translation>
     </message>
 </context>
 <context>
@@ -1637,6 +1853,39 @@ Please upgrade or connect to another daemon</source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>צור ארנק חדש</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">מיקום בסיס נתונים</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(אופציונלי)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1742,44 +1991,44 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>ארנק עם שם כזה כבר קיים. אנא בחר שם אחר</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>תווים שאינם ASCII אינם מותרים בכתובת ארנק או שם חשבון</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>התחל עם מונרו!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>צור ארנק</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
-        <translation>ארנק לצפייה בלבד נוצר. ניתן לפתוח אותו ע"י סגירת הארנק הנוכחי, לחיצה על &quot;פתח ארנק מקובץ&quot; ובחירת הארנק לצפייה ב: 
+        <translation>ארנק לצפייה בלבד נוצר. ניתן לפתוח אותו ע&quot;י סגירת הארנק הנוכחי, לחיצה על &quot;פתח ארנק מקובץ&quot; ובחירת הארנק לצפייה ב: 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>בטל</translation>
     </message>
@@ -1787,47 +2036,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>שם ארנק</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>שחזר ממשפט סודי</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>שחזר ממפתחות</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>כתובת חשבון (ציבורי)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>מפתח צפייה (סודי)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>מפתח שימוש (סודי)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>שחזר גובה (אופציונלי)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>הארנק שלך מאוחסן ב</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>אנא בחר תיקייה</translation>
     </message>
@@ -1840,7 +2094,12 @@ Please upgrade or connect to another daemon</source>
         <translation>הכנס את המשפט הסודי בעל 25 המילים</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>חשוב &lt;b&gt;מאוד&lt;/b&gt; לכתוב ולשמור את המשפט הסודי. זה כל שתצטרך כדי לגבות ולשחזר את הארנק שלך</translation>
     </message>
@@ -1848,37 +2107,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>ברוכים הבאים למונרו!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>אנא בחר אחת מהאפשרויות הבאות:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>צור ארנק חדש</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>שחזר ארנק ממפתחות או ממשפט סודי</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>פתח ארנק מקובץ</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>כתובת מסנכרן מותאמת אישית (אופציונלי)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1892,7 +2146,7 @@ Please upgrade or connect to another daemon</source>
         <translation>הכנס סיסמה לארנק</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation>&lt;br&gt;שים לב: לא ניתן לשחזר סיסמה זו. אם תשכח אותה תצטרך לשחזר את הארנק בעזרת המשפט הסודי בעל 25 המילים.&lt;br&gt;&lt;br&gt;&lt;br&gt;הכנס סיסמה חזקה&lt;br&gt;(אותיות, מספרים ו/או סמלים)</translation>
@@ -1901,12 +2155,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>סיסמה</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>וודא סיסמה</translation>
     </message>
@@ -1914,7 +2168,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>שחזר ארנק</translation>
     </message>
@@ -1922,12 +2176,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>ברוכים הבאים למונרו!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>אנא בחר שפה.</translation>
     </message>
@@ -1935,105 +2189,112 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>לא ניתן לפתוח קובץ: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>יתרה נעולה (ממתין לבלוק)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>יתרה נעולה (~%1 דקות)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>יתרה נעולה</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>ממתין למסנכרן הרשת להתחיל...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>ממתין למסנכרן הרשת לעצור...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>מסנכרן הרשת נכשל מלהתחיל</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>אנא בדוק את הארנק שלך ואת יומן המסנכרן עבור שגיאות. באפשרותך גם להתחיל %1 באופן ידני.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>לא ניתן לבצע העברה: גרסת מסנכרן שגויה: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>לא ניתן לבצע העברה: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>לא קיימות יתרות שאינן ניתנות לשימוש</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>אישור העברה</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>אנא אשר העברה:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>כתובת: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>מזהה תשלום: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2042,13 +2303,7 @@ Amount: </source>
 סכום: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
-        <source>Fee: </source>
-        <translation>עמלה: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2057,38 +2312,131 @@ Ringsize: </source>
 מספר שולחים פוטנציאלים (גודל חוג):: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">חתימה שגויה</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>כתובת זו קיבלה %1 מונרו, עם %2 אישורים.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">חתימה נכונה</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">סיסמה שגויה</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">אזהרה</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">שגיאה: מערכת הקבצים היא לקריאה בלבד</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">אזהרה: נותרו רק %1 GB על ההתקן. בסיס הנתונים דורש ~%2 GB של מידע</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">שים לב: נותרו רק %1 GB על ההתקן. בסיס הנתונים דורש ~%2 GB של מידע</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">שים לב: התיקייה lmdb לא נמצאה(בסיס הנתונים). יוצר תיקייה חדשה.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">שגיאה: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>מסנכרן פועל</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>מסנכרן הרשת עדיין ירוץ ברקע כאשר התוכנה תיסגר.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>עצור סנכרון</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>גרסה חדשה של מונרו זמינה: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>מספר עסקאות: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished">
+עמלה: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2097,77 +2445,73 @@ Description: </source>
 תיאור: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>סכום שגוי: טווח הערכים הוא %1 עד %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>יתרה אינה מספיקה. יתרה זמינה: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>שליחת הכסף נכשלה</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>מידע</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>כסף נשלח בהצלחה: %1 עסקאות</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>העברה נשמרה לקובץ: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>בדוק תשלום</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
-        <translation>כתובת זו קיבלה %1 מונרו, אך ההעברה טרם אושרה ע"י הרשת</translation>
+        <translation>כתובת זו קיבלה %1 מונרו, אך ההעברה טרם אושרה ע&quot;י הרשת</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>כתובת זו לא קיבלה כלום</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>יתרה (סנכרון מתבצע)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>יתרה</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>אנא המתן...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>אשף התקנה</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>מונרו</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>שלח לאותו היעד</translation>
     </message>

--- a/translations/monero-core_hi.ts
+++ b/translations/monero-core_hi.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>नयी प्रविष्टि डालें</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>पता</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>भुगतान आईडी &lt;font size=&apos;2&apos;&gt;(वैकल्पिक)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>भुगतान आईडी:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,7 +122,7 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
+        <source>Starting local node in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -185,38 +190,38 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>तिथि से</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>तक</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>राशि</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>भुगतान आईडी:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>तिथि</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">भुगतान आईडी:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">और अधिक परिणाम नहीं हैं</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>धनराशि</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>खुली धनराशि</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>प्राप्त करें</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation type="unfinished">धनराशि</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -515,12 +664,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>नेटवर्क स्थिति</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>कनेक्ट किया गया</translation>
     </message>
@@ -530,30 +679,58 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
-        <source>Wrong version</source>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <source>Wrong version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>डिस्कनेक्ट किया गया</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,8 +740,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -589,18 +766,26 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -612,152 +797,162 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>पता</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>यहाँ केवल पठनीय वॉलेट पता प्रदर्शित है</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>एकीकृत पता</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation type="unfinished">राशि</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>भुगतान आईडी</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>उत्पन्न करें</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>ट्विटर</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>समाचार</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>सहायता</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>बारे में</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished">जानकारी</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
-        <source>Daemon log</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
+        <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1001,171 +1224,186 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
+        <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1237,17 +1470,17 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>लेनदेन प्राथमिकता</translation>
     </message>
@@ -1257,244 +1490,234 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation type="unfinished">जानकारी</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">पता</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation type="unfinished">पुष्टिकरण</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation type="unfinished">पैसे सफलतापूर्वक भेजे गए</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>भुगतान आईडी &lt;font size=&apos;2&apos;&gt;( वैकल्पिक )&lt;/font&gt;</translation>
     </message>
@@ -1502,62 +1725,75 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation type="unfinished">पता</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">उत्पन्न करें</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1613,6 +1849,39 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1719,43 +1988,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>MONERO प्रयोग करें</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation type="unfinished">त्रुटि</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1763,47 +2032,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
-        <source>Account address (public)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
-        <source>View key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
-        <source>Spend key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
-        <source>Restore height (optional)</source>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>आपका वॉलेट संग्रहीत है</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>कृपया निर्देशिका चुनें</translation>
     </message>
@@ -1816,7 +2090,12 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1824,37 +2103,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Monero में आपका स्वागत है!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>कृपया निम्नलिखित विकल्पों में से एक का चयन करें:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1868,7 +2142,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1877,12 +2151,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1890,7 +2164,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1898,12 +2172,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished">Monero में आपका स्वागत है!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>कृपया अपनी भाषा और क्षेत्रीय स्वरूप डालें।</translation>
     </message>
@@ -1911,233 +2185,321 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>त्रुटि</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>वॉलेट नहीं खुल पाया: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">खुली धनराशि</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>लेनदेन नहीं हो सकता है: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>पुष्टिकरण</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation type="unfinished">धनराशि</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>पैसेनहीं भेज पाया: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>जानकारी</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>प्रोग्राम सेटअप विज़ार्ड</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>समान गंतव्य पर भेजें</translation>
     </message>

--- a/translations/monero-core_hr.ts
+++ b/translations/monero-core_hr.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation type="unfinished"></translation>
     </message>
@@ -74,6 +74,11 @@
     <message>
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -117,7 +122,7 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
+        <source>Starting local node in %1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -185,38 +190,38 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -255,150 +260,294 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -520,40 +669,68 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -563,8 +740,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -589,18 +766,26 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -612,151 +797,161 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
-        <source>Daemon log</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
+        <source>Daemon log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1001,171 +1224,186 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
+        <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1237,184 +1470,199 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1424,77 +1672,52 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1502,63 +1725,76 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1613,6 +1849,39 @@ Please upgrade or connect to another daemon</source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1719,43 +1988,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1763,47 +2032,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
-        <source>Account address (public)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
-        <source>View key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
-        <source>Spend key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
-        <source>Restore height (optional)</source>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1816,7 +2090,12 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1824,37 +2103,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1868,7 +2142,7 @@ Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1877,12 +2151,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1890,7 +2164,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1898,12 +2172,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1911,233 +2185,321 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/monero-core_id.ts
+++ b/translations/monero-core_id.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Membuat alamat baru</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>Kode QR</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Menandai Pembayaran&lt;font size=&apos;2&apos;&gt;(opsional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Merekatkan 64 simbol heksadesimal</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Catatan &lt;font size=&apos;2&apos;&gt;(Ikhtiari)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Pililah nama atau menuliskan catatan untuk alamat ini</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Tambah</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Macam alamat salah</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Tidak dapat membuat catatan</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Menandai pembayaran:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Jurik Monero akan mulai dalam %1 detik</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>Menyaring riwayat transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Mengetik untuk pencarian tambahan...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Menyaring</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Dari tanggal</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Ke</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Penyaringan terperinci</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Golongan transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Jumlah dari</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Menandai pembayaran:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Hasil selesai</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Rincian</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Ketinggian blok:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10) konfirmasi</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10) konfirmasi {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>BELUM DIKONFIRMASI</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>TERTUNDA</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Biaya</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Menandai transaksi:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Menandai pembayaran:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Kunci transaksi:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Catatan untuk transaksi:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Tujuan-tujuan:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Hasil selesai</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10) konfirmasi {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">BELUM DIKONFIRMASI</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">TERTUNDA</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo Rekening</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Saldo rekening yang tidak terkunci</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>KIRIM</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Menerima</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Riwayat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet (jaringan pelatihan)</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Buku alamat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Terperinci</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Pertambangan</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Mengesahkan pembayaran</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Menandatangani/mengesahkan</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Saldo Rekening</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Saldo rekening yang tidak terkunci</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Pertambangan sendiri</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(Hanya untuk jurik lokal)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Pertambangan dengan komputer Anda menolong mempertahankan jaringan Monero. Makin banyak orang-orang pertambangan, makin sulit menyerangkan jaringan, dan setiap komputer membantu, memang yang kecil.&lt;br&gt; &lt;br&gt;Pertambangan juga memberikan Anda sebuah kesempatan supaya memenangkan sedikit Monero. Komputer Anda akan menebak untuk kunci blok Monero. Jika Anda menemukan kunci yang pas, Anda akan menang sedikit Monero. Semoga sukses!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>Nomor ulir CPU</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(opsional)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Pertambangan latar belakang</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Memboleh pertambangan dengan daya baterai</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Mengelola pertambangan</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Mulai pertambangan</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Kesalahan mulai pertambangan</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Tidak dapat mulai pertambangan.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Pertambangan hanya diboleh dengan jurik lokal. Mohon mulai jurik yang lokal jika Anda ingin pertambangan.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Berhenti pertambangan</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Status: tidak pertambangan</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Pertambangan %1 H/s (tebakan per detik)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Tidak pertambangan</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Status: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished">Saldo rekening yang tidak terkunci:</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Menerima dan memeriksa blok</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Tersambung</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Versi salah</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Koneksi terputus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Status sambungan salah</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Status jaringan</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Membatalkan</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Silahkan masuk kata sandi untuk dompet Anda</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Silahkan masuk kata sandi untuk dompet:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Membatalkan</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Sedang berkomunikasi...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Jumlah blok yang tersisa: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Menerima dan memeriksa blok</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Menandai pembayaran salah</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>PERINGATAN: tidak dapat koneksi dengan jurik</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>dalam txpool: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 konfirmasi: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 konfirmasi: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Transaksi belum dapat ditemukan...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transaksi ditemukan</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 transaksi ditemukan</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>dengan lebih uang (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>dengan kurang uang (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Alamat dompet BacaSaja ditampilkan disini</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 simbol heksadesimal</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Bersih</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Alamat tergabung (menandai pembayaran sudah termasuk)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Jumlah untuk terima</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Pelacakan &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Pelacakan pembayaran</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Ini pelacakan penjualan yang sederhana:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Pekan Membuat supaya membuat menandai pembayaran yang acak, untuk pelanggan yang baru&lt;/p&gt; &lt;p&gt;Pelanggan Anda bisa membayar dengan kode QR (jika ponsel atau komputer mereka bisa membaca kode QR).&lt;/p&gt;&lt;p&gt;Halaman ini akan memeriksa rantaiblok dan transaksi baru untuk transaksi dari kode QR itu. Jika Anda ingin jumlah yang pas, halaman ini juga bisa periksa jumlah pembayaran sesuai.&lt;/p&gt;Anda harus pilih kalau Anda ingin menerima pembayaran yang belum disahkan. Biasanya, transaksi akan dikonfirmasi dalam rantablok dalam berapa menit, tetapi lebih aman kalau Anda menunggu lebih dari satu konfirmasi untuk pembayaran yang besar.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Menyimpan Kode QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Tidak dapat menyimpan Kode QR di </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Menympan dengan nama</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Menandai pembayaran</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Membuat</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Membuat menandai transaksi untuk alamat tergabung (menandai pembayaran sudah termasuk)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Berita</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Bantuan</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Tentang</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Membuat dompet hanya untuk menonton</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Mengelola jurik</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Mulai jurik</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Berhenti jurik</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Menunjukkan status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Bendera saat mulai jurik</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(opsional)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished">Kesalahan: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished">Informasi</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished">Keperiksaan yang terkeluar dengan sukses</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Alamat jurik</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Nama host / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Login (opsional)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Nama pengguna</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Kata sandi</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished">Membatalkan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Pengaturan tata letak</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Dekorasi kustom</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Tingkat log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(e.g. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Versi</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Versi GUI: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Versi Monero termasuk: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Log jurik</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Kata sandi yang salah</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Mengelola dompet Anda</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Menutup dompet</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Tandatangan bagus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Ini adalah tandatangan yang bagus</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Tandatangan buruk</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Tandatangan ini tidak dapat disahkan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Menandatangani pesan atau isi arsip dengan alamat Anda:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Atau pesan:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Pesan untuk ditandatangani</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Menandatangani</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Mohon memilih arsip untuk ditandatangani</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Pilih</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Mengesahkan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Pililah arsip untuk disahkan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Alamat menandatangani &lt;font size=&apos;2&apos;&gt;  ( Merekatkan atau pilih dari &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Buku alamat&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Atau arsip:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Nama arsip dengan pesan untuk ditandatangani</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Tanda tangan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Mengesahkan pesan atau tanda tangan arsip dari alamat:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Pesan untuk disahkan</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Nama arsip dengan pesan untuk disahkan</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Membatalkan</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Rendah (Biaya x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Sedang (Biaya x20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Tinggi (Biaya x166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Semua</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Terkirim</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Diterima</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Biasa</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Sedang</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Tinggi</translation>
     </message>
@@ -1237,244 +1470,234 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Kesalahan dengan OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Kepentingan pribadi (transaksi dalam cincin %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Mulai jurik&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Kepentingan transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Rendah (biaya x1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Sedang (biaya x20)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Tinggi (biaya x166)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Alamat &lt;font size=&apos;2&apos;&gt;  ( Merekatkan atau memilih dari &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Buku alamat&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>Kode QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Menyelesaikan</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Tidak menerima alamat yang sah dari alamat OpenAddress ini</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Alamat ditemukan, tetapi tanda tangan DNSSEC tidak dapat disahkan, jadi adalah kemungkinan alamat ini telah dipalsukan</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Tidak menerima alamat yang sah dari alamat OpenAddress ini, dan juga tanda tangan DNSSEC tidak dapat disahkan, jadi adalah kemungkinan ini telah dipalsukan</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Kesalahan internal</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Tidak dapat menemukan alamat</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Catatan &lt;font size=&apos;2&apos;&gt;( Opsional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Sedia dalam riwayat dompet lokal</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>MENGIRIM</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Menunjukkan opsi terperinci</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Menggabungkan transaksi yang tak dapat dicampurkan</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Membuat arsip transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Semua</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Menandatangani arsip transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Menyerahkan arsip transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>&gt;Mohon memilih arsip</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Mulai jurik</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Alamat</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Tidak bisa membuka transaksi yang tidak ditandatangani: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>Jumlah transaksi: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>Transaksi #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>Penerima: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>Menandai Pembayaran: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>Jumlah: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>Biaya: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>Ukuran cincin: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Tidak bisa mengirim transaksi: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Uang terkirim dengan sukses</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Dompet tidak dapat menghubung ke jurik</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Jurik yang terhubung tidak cocok dengan GUI. Silahkan meningkatkan jurik atau menghubungkan jurik yang lain</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Menunggu jurik untuk selesai menerima dan memeriksa blok</translation>
     </message>
@@ -1484,17 +1707,17 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Biaya transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Menandai pembayaran &lt;font size=&apos;2&apos;&gt;( Ikhtiari )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 atau 64 simbol heksadesimal</translation>
     </message>
@@ -1502,64 +1725,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Anda bisa periksa pembayaran oleh pihak ketiga dengan:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - alamat penerima</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - menandai transaksi</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - rahasia transaksi dari pengirim</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Jika pembayaran termasuk beberapa transaksi, setiapnya harus diperiksa dan hasil ditambah.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Alamat dompet penerima</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Membuat</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Tanda tangan</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Menandai transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Merekatkan menandai transaksi</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Merekatkan kunci transaksi</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Periksa</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Kunci transaksi</translation>
     </message>
 </context>
 <context>
@@ -1614,6 +1850,39 @@ Please upgrade or connect to another daemon</source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Membuat dompet baru</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(opsional)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1719,43 +1988,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Dompet bernama ini sudah ada. Tolong mengganti nama dompet yang baru</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Hanya diperbolehkan untuk menggunakan huruf ASCII</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>MENGGUNAKAN MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Membuat dompet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Sukses</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>Dompet hanya untuk menonton baru dibuat untuk Anda. Anda bisu membukanya kalau dompet ini ditutup, pekan &quot;Membuka dompet dari arsip&quot; dan memilih dompet hanya untuk menonton di: %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Menggugurkan</translation>
     </message>
@@ -1763,47 +2032,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Nama dompet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Mengembalikan dari kata-kata biji acak</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Mengembalikan dari kunci</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Alamat rekening</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Kunci nonton (pribadi)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Kunci membayarkan (pribadi)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Mengembalikan dari nomor blok (opsional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Dompet Anda disimpan di</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Silahkan memilihkan direktori</translation>
     </message>
@@ -1816,7 +2090,12 @@ Please upgrade or connect to another daemon</source>
         <translation>Memasukkan 25 kata-kata biji acak Anda</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>&lt;b&gt;Sangat&lt;/b&gt; penting kata-kata biji acak ini dicatat karena cuma oleh sebagai ini dompet Anda dapat dipulihkan</translation>
     </message>
@@ -1824,37 +2103,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Selamat datang di dunia Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Mohon memilihkan salah satu opsi:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Membuat dompet baru</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Mengembalikan dompet dari kunci atau kata-kata biji acak</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Membuka dompet dari arsip</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Alamat jurik yang dipilih oleh Anda (opsional)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet (jaringan pelatihan)</translation>
     </message>
@@ -1868,7 +2142,7 @@ Please upgrade or connect to another daemon</source>
         <translation>Memilih kata sandi untuk dompet Anda</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Peringatan: kata sandi ini tidak pernah dapat diperoleh kembali. Jika Anda lupa kata sandi, dompet Anda harus dikembalikan dari kata biji acak.&lt;br/&gt;&lt;br/&gt;
@@ -1878,12 +2152,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Kata sandi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Memastikan kata sandi</translation>
     </message>
@@ -1891,7 +2165,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Mengembalikan dompet</translation>
     </message>
@@ -1899,12 +2173,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Selamat datang di dunia Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Silahkan memilih bahasa dan pilihan daerah</translation>
     </message>
@@ -1912,233 +2186,321 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Tidak bisa membuka dompet: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Tidak bisa membuat transaksi: Versi jurik yang salah: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Tidak bisa membuat transaksi: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Tidak ada keluaran yang tidak dapat dicampur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Saldo rekening yang tidak terkunci (sedang menunggu blok)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Saldo rekening yang tidak terkunci (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Saldo rekening yang tidak terkunci</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Menunggu jurik untuk memulai</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Menunggu jurik untuk berhenti</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Jurik tidak dapat mulai</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Tolong periksahkan log-log dompet dan jurik untuk kesalahan. Anda juga dapat mencoba untuk memulai %1 secara manual</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Silakan memastikan transaksi:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>Alamat: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>Menandai pembayaran: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation>Jumlah: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>Biaya</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation>Berapa transaksi dalam cincin: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>Jumlah transaksi: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
         <translation>Gambaran</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Jumlah salah: nomor antar %1 dan %2 diharapkan</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Dana tidak mencukupi. Saldo rekening yang tidak terkunci: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Tidak bisa mengirim uang monero: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informasi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Uang monero dikirim dengan sukses: %1 transaksi </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transaksi disimpan dalam arsip: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Mengesahkan pembayaran</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Alamat ini menerima %1 monero, tetapi transaksinya belum termasuk dalam blok</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Alamat ini menerima %1 monero, dengan %2 konfirmasi.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Jurik telah dimulai</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Jurik akan menjalankan di latar belakang kapan GUI tertutup.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Berhenti jurik</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Versi baru untuk monero-wallet-gui tersedia: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Alamat ini tidak menerima apa-apa</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Tandatangan buruk</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Tandatangan bagus</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Saldo rekening (sedang menerima dan memeriksa blok)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Saldo Rekening</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Kata sandi yang salah</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Membatalkan</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Kesalahan: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Mohon tunggu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Wizard untuk medirikan program ini</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>kirim ke tujuan yang sama</translation>
     </message>

--- a/translations/monero-core_id.ts
+++ b/translations/monero-core_id.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10) konfirmasi {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 konfirmasi)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10) konfirmasi {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 konfirmasi)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_it.ts
+++ b/translations/monero-core_it.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Aggiungi nuovo indirizzo</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>Codice QR</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ID Pagamento &lt;font size=&apos;2&apos;&gt;(Opzionale)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Inserisci 64 caratteri esadecimali</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Descrizione &lt;font size=&apos;2&apos;&gt;(Opzionale)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Inserisci nome o descrizione</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Indirizzo invalido</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Impossibile creare questa voce</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>ID Pagamento:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Il daemon partirà tra %1 secondi</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>selezionato: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Inserisci per ricerca incrementale...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Data da</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtra</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Filtri avanzati</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Tipo di transazione</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Quantità da</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>ID Pagamento</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Destinazioni:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Dettagli</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Numero Blocco:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 conferme)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 conferme) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NON CONFERMATO</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>IN ATTESA</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Commissione</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Quantità</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">ID tx:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Chiave Tx:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Tx nota:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Destinazioni:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Nessun altro risultato</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 conferme) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">NON CONFERMATO</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">IN ATTESA</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Chiave segreta di visualizzazione</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Chiave di visualizzazione pubblica</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Chiave segreta di spesa </translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Chiave di spesa pubblica</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Totale</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Totale sbloccato</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Invia</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Ricevi</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Storico</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Rubrica</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Mining</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Verifica pagamento</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Firma/verifica</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Totale</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Totale Sbloccato:</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Solo mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(disponibile solo per daemons locali)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Avviare mining con il tuo computer incrementa la resistenza del network. Più persone avviano il mining, più è difficile attaccare monero, e anche un singolo bit è importante.&lt;br&gt; &lt;br&gt;Avviare il mining ti da anche una piccola chance di guadagnare qualche Monero. Il tuo computer creerà &quot;hashes&quot; cercando di risolvere un blocco. Se ne trovi uno, riceverai la ricompensa associata al blocco. Buona fortuna!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU threads</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(opzionale)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Avviare mining in background (sperimentale)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Abilitare mining quando in modalità batteria</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Gestisci miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Avvia mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Errore durante avvio mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Impossibile avviare mining&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Il mining è possibile solo utilizzando il daemon locale. Avvia daemon locale per avviare il mining&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Arresta mining</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Stato: mining non avviato</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Mining attivo a %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Mining non avviato</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Stato: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Totale Sbloccato:</translation>
     </message>
@@ -515,12 +664,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Stato Rete</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Connesso</translation>
     </message>
@@ -530,30 +679,58 @@
         <translation>Sincronizzando</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Versione sbagliata</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Connessione invalida</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancella</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Inserisci la password del tuo portafoglio</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Inserisci la password del tuo portafoglio per:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Inizializzando connessione...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Blocchi rimanenti: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Sincronizzazione blocchi</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>ID pagamento invalido</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>AVVISO: non connesso al daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>nel txpool: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 conferme: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 conferma: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Ancora nessuna transazione trovata...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transazione trovata</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 transazioni trovate</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>con più fondi (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>senza fondi sufficienti (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Portafoglio in sola lettura</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 caratteri esadecimali</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Indirizzo integrato</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Salva codice QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Impossibile salvare codice QR in </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Salva Come</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ID Pagamento</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Genera ID Pagamento per l&apos;indirizzo integrato</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Quantità</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Quantità da ricevere</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Traccia pagamenti</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Questo è un semplice tracker per le vendite:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Clicca &quot;Genera&quot; per creare un ID Pagamento casuale per un nuovo cliente&lt;/p&gt; &lt;p&gt;Fai scannerizzare al cliente il codice QR per effettuare un pagamento (Se il cliente possiede un QR scanner).&lt;/p&gt;&lt;p&gt;Questa pagina scannerizzerà automaticamente la blockchain e il txpool in cerca di transazioni in entrata usando il codice QR. Se inserisci una qauntità controllerà anche se ci sono transazioni in entrata per l&apos;ammontare specificato.&lt;/p&gt;It&apos;Sta a te decidere se accettare transazioni non confermate.</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Genera</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Novità</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Aiuto</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Informazioni</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Porta</translation>
     </message>
 </context>
 <context>
@@ -776,396 +971,439 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Seed &amp; chiavi Portafoglio</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Chiave segreta di visualizzazione</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Chiave di visualizzazione pubblica</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>Chiave segreta di spesa </translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>Chiave di spesa pubblica</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Password errata</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Mostra stato</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Indirizzo daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Gestisci portafoglio</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Chiudi portafoglio</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Crea portafoglio solo-vista</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Gestisci daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Avvia daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Arresta daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Parametri inizializzazione daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(opzionale)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Mostra seed &amp; chiavi</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Riscannerizza bilancio portafoglio</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Errore: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Informazione</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Output riscannerizzati con successo</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Posizione blockchain</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Login (opzionale)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Nome utente</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Connetti</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Settaggi layout</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Decorazioni personalizzate</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Livello di dettaglio Log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(esempio: *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Versione</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Versione interfaccia grafica (GUI):</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Versione Monero integrata: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Log daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Scegli una cartella</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Avviso</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Errore: Filesystem è di solo-lettura</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Avviso: ci sono solo %1 GB disponibili nel dispositivo. La blockchain richiede ~%2 GB di spazio.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Nota: ci sono %1 GB disponibili nel dispositivo. La blockchain richiede ~%2 GB di spazio.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Nota: cartella lmdb non trovata. Verrà creata una nuova cartella.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Hostname / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Porta</translation>
     </message>
 </context>
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Firma valida</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Questa è una firma valida</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Firma non valida</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Questa firma non ha potuto essere verificata</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Firma un messaggio o il contenuto di un file con il tuo indirizzo:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>O messaggio:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Messaggio da firmare</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Firma</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Scegli un file da firmare</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verifica</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>O file:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Nome del file con messaggio da firmare:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Firma</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Verifica un messaggio o la firma di un file da un indirizzo:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Messaggio da verificare</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Scegli un file da verificare</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Nome del file con messaggio da verificare</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Indirizzo di firma &lt;font size=&apos;2&apos;&gt;  ( Incolla  oppure seleziona da &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Rubrica&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Basso (x1 commissione)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Medio (x20 commissione)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Alto (x166 commissione)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Lento (x0.25 commissione)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>Default (x1 commissione)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>Veloce (x5 commissione)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Velocissimo (x41.5 commissione)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Tutte</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Inviato</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Ricevuto</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normale</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Medio</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Alto</translation>
     </message>
@@ -1237,12 +1470,12 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Quantità</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Priorità Transazione</translation>
     </message>
@@ -1252,249 +1485,239 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Costo della transazione</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Firma file tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Invia file tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portafoglio non connesso al daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Il daemon connesso non è compatibile con l&apos;interfaccia grafica. Aggiorna o connetti ad un altro daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>In attesa di completamento sincronizzazione</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID Pagamento &lt;font size=&apos;2&apos;&gt;( Opzionale )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Errore OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Livello di privacy (ringsize %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Avvia daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Tutto</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Basso (x1 commissione)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Medio (x20 commissione)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Alto (x166 commissione)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Lento (x0.25 commissione)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Default (x1 commissione)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Veloce (x5 commissione)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Velocissimo (x41.5 commissione)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Indirizzo &lt;font size=&apos;2&apos;&gt;  ( Incolla oppure seleziona da &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Rubrica&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Risolvere</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Nessun indirizzo valido trovato in questo indirizzo OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Indirizzo trovato ma le firme DNSSEC non hanno potuto essere verificate. L&apos;indirizzo potrebbe essere alterato</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Nessun indirizzo valido trovato in questo indirizzo OpenAlias ma le firme DNSSEC non hanno potuto essere verificate. L&apos;indirizzo potrebbe essere alterato</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Errore interno</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Nessun indirizzo trovato</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 o 64 caratteri esadecimali</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Descrizione &lt;font size=&apos;2&apos;&gt;( Opzionale )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Salva in storico portafoglio locale</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Invia</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Mostra opzioni avanzate</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Esegui Sweep Unmixable</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Crea file tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Seleziona un file</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Avvia daemon</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Indirizzo</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Impossibile caricare transazione non firmata</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>Numero di transazioni</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>Transazione #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>Destinatario:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>ID pagamento:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>Totale: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>Commissione: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>Ringsize: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Impossibile inviare transazione: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Fondi inviati correttamente</translation>
     </message>
@@ -1502,62 +1725,75 @@ Ringsize: </source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verifica pagamento da parte terza fornendo: </translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - Indirizzo del destinatario</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - ID della transazione</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - la chiave di transazione segreta fornita dal mittente</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Indirizzo portafoglio del destinatario</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>ID transazione</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Inserisci tx ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Inserisci chiave tx</translation>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Genera</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Firma</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Valida</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Chiave transazione</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Se un pagamento aveva multiple transazioni ogni transazione deve essere validata e i risultati abbinati</translation>
     </message>
@@ -1614,6 +1850,39 @@ Ringsize: </source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Crea nuovo portafoglio</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Posizione blockchain</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(opzionale)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1719,44 +1988,44 @@ Ringsize: </source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Esiste già un portafoglio con questo nome. Cambia nome del portafoglio</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Caratteri non-ASCII non sono permessi per la cartella del portafoglio o per i nome del conto</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>USA MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Crea portafoglio</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Successo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>Il portafoglio solo-vista è stato creato. Puoi aprirlo chiudendo il portafoglio corrente, cliccando su &quot;Apri portafoglio dall&apos;opzione file&quot; e selezionando il portafoglio solo-vista in: 
         %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Interrompi</translation>
     </message>
@@ -1764,47 +2033,52 @@ Ringsize: </source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Nome portafoglio</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Ripristina da seed</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Ripristina da chiave</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Indirizzo portafoglio (pubblico)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Chiave di visualizzazione(privata)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Chiave di spesa (privata)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Ripristina da blocco (opzionale)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Il tuo portafoglio è salvato in</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Seleziona una cartella</translation>
     </message>
@@ -1817,7 +2091,12 @@ Ringsize: </source>
         <translation>Inserisci il tuo seed mnemonico di 25 parole</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>E&apos; veramente importante che salvi queste parole in quanto sono l&apos;unico backup che serve per il tuo portafoglio.</translation>
     </message>
@@ -1825,37 +2104,32 @@ Ringsize: </source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Benvenuto in Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Seleziona una delle seguenti opzioni:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Crea nuovo portafoglio</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Ripristina portafoglio da chiave o seed mnemonico</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Apri portafoglio da file</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Indirizzo daemon personalizzato (opzionale)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1869,7 +2143,7 @@ Ringsize: </source>
         <translation>Imposta una password per il tuo portafoglio</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Nota: questa password non può essere recuperata. Se la dimentichi, in tal caso il portafoglio può essere ripristinato dal seed mnemonico composto di 25 parole.&lt;br/&gt;&lt;br/&gt;
@@ -1879,12 +2153,12 @@ Ringsize: </source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Conferma Password</translation>
     </message>
@@ -1892,7 +2166,7 @@ Ringsize: </source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Ripristina portafoglio</translation>
     </message>
@@ -1900,12 +2174,12 @@ Ringsize: </source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Benvenuto in Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Seleziona una lingua e un formato regionale.</translation>
     </message>
@@ -1913,233 +2187,321 @@ Ringsize: </source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Conferma transazione:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation>Totale: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>Numero di transazioni: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
         <translation>Descrizione: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>La quantità è sbagliata: à previsto un numero tra l&apos;%1 e %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Impossibile creare la transazione: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Impossibile aprire portafoglio: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Totale sbloccato (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Totale sbloccato</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Totale sbloccato (aspettando blocco)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
-        <translation>Sto aspettando l'avvio del daemon...</translation>
+        <translation>Sto aspettando l&apos;avvio del daemon...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
-        <translation>Sto aspettando l'arresto del daemon...</translation>
+        <translation>Sto aspettando l&apos;arresto del daemon...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Impossibile avviare daemon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Controlla i log del portafoglio e del daemon. Puoi anche tentare di aprire %1 manualmente.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Impossibile creare transazione: Versione daemon sbagliata: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Nessun output non mixabile su cui eseguire lo sweep</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation>Ringsize: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Firma non valida</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Questo indirizzo ha ricevuto %1 monero con %2 conferma/e.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Firma valida</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Password errata</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Avviso</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Errore: Filesystem è di solo-lettura</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Avviso: ci sono solo %1 GB disponibili nel dispositivo. La blockchain richiede ~%2 GB di spazio.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Nota: ci sono %1 GB disponibili nel dispositivo. La blockchain richiede ~%2 GB di spazio.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Nota: cartella lmdb non trovata. Verrà creata una nuova cartella.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancella</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Errore: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Daemon attivo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Il daemon continuerà ad essere attivo dopo che l&apos;interfaccia grafica è stata chiusa.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Arresta daemon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Una nuova versione dell&apos;interfaccia grafica è disponibile: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>Indirizzo: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>ID Pagamento: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>Commissione: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Fondi insufficienti: totale sbloccato: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Impossibile inviare fondi: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Attendi...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Impostazione Programma</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Fondi inviati correttamente: %1 transazione/i</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transazione salvata nel file: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Verifica pagamento</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Questo indirizzo ha ricevuto %1 monero, ma la transazione non è ancora stata validata dal network</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Questo indirizzo non ha ricevuto nulla</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Totale (in sincronizzazione)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Totale</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>manda alla stessa destinazione</translation>
     </message>

--- a/translations/monero-core_it.ts
+++ b/translations/monero-core_it.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 conferme) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 conferme)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 conferme) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 conferme)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_ja.ts
+++ b/translations/monero-core_ja.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 承認済) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 承認済)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 承認済) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 承認済)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_ja.ts
+++ b/translations/monero-core_ja.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>新規項目の追加</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QRコード</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ペイメントID &lt;font size=&apos;2&apos;&gt;(オプショナル)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>16文字または64文字の16進数の文字列を入力してください</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>説明 &lt;font size=&apos;2&apos;&gt;(オプショナル)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>この宛先の名前や説明を入力してください</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>不正なアドレス</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>項目を作成できません</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>ペイメントID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>デーモンを開始するまであと%1秒</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation> 件: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>タイプしてインクリメンタル検索</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>日付の下限</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>上限</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>適用</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>高度なフィルタ</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>取引の種類</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>金額の下限</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>ペイメントID:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>宛先</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>詳細</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>ブロック高</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 承認済)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 承認済) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>未承認</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>ペンディング</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>手数料</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">取引ID</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">ペイメントID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">取引の秘密鍵</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">取引の説明</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">宛先</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">これ以上表示するデータがありません</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 承認済) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">未承認</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">ペンディング</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">ビューキー (秘密)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">ビューキー (公開)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">スペンドキー (秘密)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">スペンドキー (公開)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>残高</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>ロック解除された残高</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>テストネット</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>送金する</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>アドレス帳</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>受け取る</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>履歴</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>高度な機能</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>マイニング</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>支払い証明</translation>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>電子署名</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>残高</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>ロック解除された残高</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>ソロマイニング</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(ローカル上のデーモンでのみ可能)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>あなたのコンピュータでマイニングを行うことで、モネロのネットワークをより強固にすることができます。マイニングをする人が増えるほど、ネットワークへの攻撃が難しくなります。一人一人の協力が大切です。&lt;br&gt; &lt;br&gt;マイニングをすると、低確率ですがモネロを獲得できる可能性があります。あなたのコンピュータは、ある計算問題の解となるブロックとそのハッシュ値を計算します。正解のブロックが見つかると、あなたはそれに伴う報酬を得ます。グッドラック!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPUスレッド数</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(オプショナル)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>バックグラウンドマイニング (実験的)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>バッテリ駆動中でもマイニングを行う</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>マイナーの管理</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>マイニングの開始</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>マイニングの開始エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>マイニングを開始できませんでした。&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>マイニングはローカル上のデーモンからのみ行えます。マイニングをするには、ローカル上でデーモンを起動してください。&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>マイニングの停止</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>状態: マイニングしていません</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>ハッシュレート %1 H/s でマイニング中</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>マイニングしていません</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>状態: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>ロック解除された残高:</translation>
     </message>
@@ -515,12 +664,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>ネットワークの状態</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>接続されました</translation>
     </message>
@@ -530,30 +679,58 @@
         <translation>同期中</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>不正なバージョン</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>接続されていません</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>不正な接続状態</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>ウォレットのパスワード</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>このウォレットのパスワード:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>接続を確立中...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>残りブロック数: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>ブロックの同期中</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>不正なペイメントID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>警告: デーモンに接続していません</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>メモリプール中: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 回の承認: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 回の承認: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>取引はまだ見つかっていません...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>取引を発見</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 個の取引を発見</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>: 指定の金額を上回っています (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>: 指定の金額を下回っています (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>読み取り専用ウォレットのアドレスがここに表示されます</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16桁の16進数</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>クリア</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>統合アドレス</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>統合アドレス使うためにペイメントID作る</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>受ける金額</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           トラッキング &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;ヘルプ&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>支払いをトラッキング中</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;これはシンプルな支払いトラッカーです:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;「生成」ボタンをクリックすると、新しいお客さんのための新しいペイメントIDが作成されます。&lt;/p&gt; &lt;p&gt;あなたのお客さんがQRコードに対応したソフトウェアを持っている場合は、このQRコードをスキャンしてもらうことで支払いを簡単に行うことができます。&lt;/p&gt;&lt;p&gt;このページではブロックチェーンと取引プールを自動的にスキャンすることで、このQRコードを使った送金をリアルタイムでチェックします。もし金額も指定した場合は、取引の合計金額についてもチェックします。&lt;/p&gt;未承認の取引を正式な入金と見なすかどうかはあなた次第です。未承認の取引はすぐに承認される場合がほとんどですが、承認されないことも可能性としてはあり得ますので、金額が大きい場合は1回または複数回の承認を待った方が良いかも知れません。&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>QRコードを保存</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>QRコードの保存に失敗しました </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ペイメントID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>生成</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>ツイッター</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>ニュース</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>ヘルプ</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>情報</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">ポート番号</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>ウォレットの管理</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>ViewOnlyウォレットを作る</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>シードと鍵を見せて</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>残高を再スキャンする</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>エラー: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>情報</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>使用済みアウトプットの再スキャンを完了しました</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>デーモンの管理</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>デーモンを起動</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>デーモンを終了</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>状態を表示</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>ブロックチェーンの場所</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>起動時のフラグ</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>フォルダを選んでください</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>エラー:　ファイルシステムは読み取り専用です</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>警告: デバイスに使用できるギガバイトはわずか１％です。ブロックチェーンには２％以上が必要です。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>備考: デバイスに使用できるギガバイトはわずか１％です。ブロックチェーンには２％以上が必要です。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>lmdbのフォルダ見つかりませんでした。新しいの作ります。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(オプショナル)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>デーモンのアドレス</translation>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>ホスト名またはIPアドレス</translation>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>ポート番号</translation>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>ログイン (オプショナル)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>ユーザ名</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>パスワード</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>コネクトする</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>レイアウト設定</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>カスタムデコレーション</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>ログレベル</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(例えば *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>バージョン</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUIのバージョン: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>埋め込まれたモネロのバージョン</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>デーモンのログ</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>ウォレットのシードとキー</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>ビューキー (秘密)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>ビューキー (公開)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>スペンドキー (秘密)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>スペンドキー (公開)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>パスワードが間違っています</translation>
     </message>
@@ -1001,171 +1224,186 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>正しい署名</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>これは正しい署名です</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>不正な署名</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>この署名は不正です</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>あなたのアドレスを使って、メッセージまたはファイルに対する電子署名を生成します:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>メッセージ:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>署名するメッセージ</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>署名を生成</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>署名するファイルを選択してください</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>署名を検証</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>または署名するファイル:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>署名するファイルの名前</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>シグネチャ</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>指定したアドレスの持ち主による、メッセージまたはファイルに対する電子署名を検証します:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>検証するメッセージ</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>検証するファイルを選択してください</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>検証するファイルの名前</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            署名者のアドレス &lt;font size=&apos;2&apos;&gt;  ( 直接貼り付けるか、&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;アドレス帳&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;から選択 )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>低 (標準の手数料)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>中 (20倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>高 (166倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>遅い (.25倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>既定 (標準の手数料)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>早い (5倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>最速 (41.5倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>出金</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>入金</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>通常</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>中</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>高</translation>
     </message>
@@ -1237,17 +1470,17 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAliasエラー</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>取引のプライオリティ</translation>
     </message>
@@ -1257,252 +1490,241 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>取引のコスト</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>このOpenAliasアドレスに結びつけられた有効なアドレスが見つかりません</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">デーモンを起動</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>遅い (.25倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>既定 (標準の手数料)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>早い (5倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>最速 (41.5倍の手数料)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">アドレス</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>アドレスは見つかりましたが、DNSSEC署名が検証できませんでした。このアドレスは改ざんされている可能性があります。</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>このOpenAliasアドレスに結びつけられた有効なアドレスが見つかりませんでしたが、DNSSEC署名が検証できませんでした。このアドレスは改ざんされている可能性があります。</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>内部エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>アドレスが見つかりません</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16文字または64文字の16進数の文字列</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>説明 &lt;font size=&apos;2&apos;&gt;( オプショナル )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>ローカル上の履歴に保存されます</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
+        <source>Connected daemon is not compatible with GUI. 
+Please upgrade or connect to another daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>プライバシーレベル (リングサイズ %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;デーモンの開始&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>低 (標準の手数料)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>中 (20倍の手数料)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>高 (166倍の手数料)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      アドレス &lt;font size=&apos;2&apos;&gt;  ( 貼り付けるか、&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;アドレス帳&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;から選択 )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QRコード</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>名前解決</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>送金</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>高度な設定を表示</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>ミックス不能なアウトプットをスイープする</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>取引ファイルを生成</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>取引ファイルに署名</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>取引ファイルを送信</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>情報</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>ファイルを選択してください</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>未署名の取引を読み込めませんでした</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 取引の数: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 取引 #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 受取人: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 ペイメントID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 金額: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 手数料: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 リングサイズ: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>取引を送信できません</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>送金に成功しました</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>ウォレットがデーモンに接続していません</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
-        <source>Connected daemon is not compatible with GUI.
-Please upgrade or connect to another daemon</source>
-        <translation>接続しているデーモンにGUIとの互換性がありません。
-デーモンを更新するか、他のデーモンに接続してください。</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>同期が終了するのを待っています</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ペイメントID &lt;font size=&apos;2&apos;&gt;( オプショナル )&lt;/font&gt;</translation>
     </message>
@@ -1510,62 +1732,75 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>以下の情報があれば、第三者がある支払いを行ったことを検証できます:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - 受取人のアドレス</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - 取引のID</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - 送金者から提供された取引の秘密鍵</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>もし支払いが複数の取引にまたがる場合は、それぞれについての検証が必要です。</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>受取人のウォレットのアドレス</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">生成</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">シグネチャ</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>取引のID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>取引IDを貼り付けてください</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>取引の秘密鍵</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>取引の秘密鍵を貼り付けてください</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>検証</translation>
     </message>
@@ -1622,6 +1857,39 @@ Please upgrade or connect to another daemon</source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>新しいウォレットの作成</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">ブロックチェーンの場所</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(オプショナル)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1995,43 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>同名のウォレットが既に存在します。ウォレットの名前を変更してください</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>ASCII文字以外はウォレットのパス名またはファイル名に使用することができません</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>モネロを使う</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>ウォレットを作る</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>成功</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
-        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in:
+        <location filename="../wizard/WizardMain.qml" line="403"/>
+        <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
-        <translation>ViewOnlyウォレットが作成されました。これを開くには現在のウォレットを閉じて、&quot;ファイルからウォレットを開く&quot; オプションから、このViewOnlyウォレットを選択してください:
-        %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>中止</translation>
     </message>
@@ -1772,47 +2039,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>ウォレット名</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>シードから復元</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>秘密鍵から復元</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>ウォレットのアドレス (公開)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>ビューキー (秘密)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>スペンドキー (秘密)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>復元するブロック高 (オプショナル)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>ウォレットが保存される場所</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>ディレクトリを選択してください</translation>
     </message>
@@ -1825,7 +2097,12 @@ Please upgrade or connect to another daemon</source>
         <translation>25個のニーモニックシードを入力してください</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>このシードを書き写して秘密の場所に保管することは、&lt;b&gt;非常に&lt;/b&gt;重要です。ウォレットのバックアップと復元に必要な唯一の情報です。</translation>
     </message>
@@ -1833,37 +2110,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>モネロへようこそ!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>以下のオプションの中から選択してください:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>新しくウォレットを作る</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>ニーモニックシードまたは秘密鍵からウォレットを復元する</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>ファイルからウォレットを開く</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>カスタムデーモンアドレス (オプショナル)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>テストネット</translation>
     </message>
@@ -1877,7 +2149,7 @@ Please upgrade or connect to another daemon</source>
         <translation>ウォレットのパスワードを設定してください</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;備考: 作る後でこのパスワードは復元できませんよ。 パスワードを忘れてしまった場合、ウォレットはウォレットの25語ニーモニックシードで復元する必要があります。&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2159,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>パスワード</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>パスワードの確認</translation>
     </message>
@@ -1900,7 +2172,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>ウォレットの復元</translation>
     </message>
@@ -1908,12 +2180,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>モネロへようこそ!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>言語と地域フォーマットを選択してください。</translation>
     </message>
@@ -1921,97 +2193,110 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>ウォレットを開けませんでした: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>金額が不正です: %1から%2の範囲内としてください</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>取引データを作成できません: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>ロック解除された残高 (~%1分)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>ロック解除された残高</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>ロック解除された残高 (ブロックの待機中)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>デーモンが開始するのを待っています...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>デーモンが停止するのを待っています...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>デーモンの起動に失敗しました</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>ウォレットとデーモンのログを参照してエラーを確認してください。手動で%1を起動することもできます。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>デーモンのバージョンが不正なため、取引を作成できません: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>スイープするミックス不能なアウトプットがありません</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>取引内容を確認してください:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2020,7 +2305,7 @@ Amount: </source>
 金額: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2029,96 +2314,96 @@ Ringsize: </source>
 リングサイズ: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>取引データをファイルに保存しました: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>送金に成功しました: %1個の取引</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>支払いの検証</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>このアドレスは%1XMRを受け取りましたが、取引はまだ採掘されていません。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>このアドレスは%1XMRを受け取り、その取引は%2回承認されました。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>このアドレスはこの取引において何も受け取っていません。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>残高 (同期中)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>残高</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>デーモンが起動中です</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>GUIを閉じた後もバックグラウンドでデーモンを起動し続けます。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>デーモンを停止</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>新しいバージョンのmonero-wallet-guiを入手できます: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 アドレス: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 ペイメントID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 手数料: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 取引の数: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2127,37 +2412,112 @@ Description: </source>
 説明: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>残高不足です。ロック解除された残高: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>送金できませんでした</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>情報</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">不正な署名</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">正しい署名</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">パスワードが間違っています</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">エラー:　ファイルシステムは読み取り専用です</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">警告: デバイスに使用できるギガバイトはわずか１％です。ブロックチェーンには２％以上が必要です。</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">備考: デバイスに使用できるギガバイトはわずか１％です。ブロックチェーンには２％以上が必要です。</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">lmdbのフォルダ見つかりませんでした。新しいの作ります。</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">エラー: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>お待ちください...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>モネロ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>プログラムセットアップウィザード</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>同じ宛先に送金する</translation>
     </message>

--- a/translations/monero-core_ko.ts
+++ b/translations/monero-core_ko.ts
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="ko" sourcelanguage="en">
+<TS version="2.1" language="ko" sourcelanguage="en">
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>새 항목 추가</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QR코드</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>결제 신분증 &lt;font size=&apos;2&apos;&gt;(선택 항목)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation> 16진수 문자 64자 붙여넣기</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>설명 &lt;font size=&apos;2&apos;&gt;(선택 항목)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>이 항목에 이름 또는 설명 제공</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>추가</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>잘못된 주소</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>항목을 만들 수 없습니다</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>결제 아이디:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>모네로 데몬이 %1 초 후 실행됩니다</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>거래내역 정렬</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>자동완성 검색을 위해 검색어 입력...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>정렬</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>에서 날짜</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>에게</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>고급 정렬</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>거래 유형</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>부터 금액</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>결제 아이디:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>결과가 더 이상 없음</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>상세 내용</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>블록하이트:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
+        <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
         <translation type="unfinished">(%1/%2의 컨퍼메이션}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>확인되지 않음</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>보류 중</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>금액</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>수수료</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">거래 아이디:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">결제 아이디:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">거래 암호:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">거래 메모</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">목적지:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">결과가 더 이상 없음</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/%2의 컨퍼메이션}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">확인되지 않음</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">보류 중</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">비공개 키</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">공개 키</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">비공개 결제 키</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">공개 결제 키</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>잔액</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>잠금해제된 잔액</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>전송</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>수취</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>내역</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>테스트넷</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished">S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>주소록</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished">B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished">R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished">H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>고급</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished">D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>마이닝</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished">M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>결제 확인</translation>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished">K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>서명/확인</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished">I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>환경설정</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished">E</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>잔액</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>잠금해제된 잔액</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>개별 마이닝</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(로컬 데몬에서만 사용 가능)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>당신의 컴퓨터로 마이닝을 하면 모네로 네트워크가 강화됩니다. 더 많은 사람이 조금씩이라도 마이닝을 시행할수록 네트워크가 공격으로부터 안전해집니다. 또한 마이닝은 약간의 모네로를 벌 수있는 작은 기회를 제공합니다. 컴퓨터가 마이닝을 시행하면, 블록 솔루션을 찾는 해시를 만들고, 맞는 블록을 찾으면 해당하는 보상을 받게됩니다. 행운을 빕니다!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU 쓰레드</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(선택 항목)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>백그라운드 마이닝 (실험적 기능)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>배터리로 구동시 마이닝 사용가능</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>마이닝 관리</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>마이닝 시작</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>마이닝 시작 중 오류 발생</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>마이닝을 시작할 수 없습니다.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>마이닝은 로컬 데몬에서만 사용할 수 있습니다. 로컬 데몬을 실행하여 마이닝을 활성화합니다.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>마이닝 중지</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>상태: 마이닝중이 아님</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation> %1 H/s 로 마이닝 중</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>마이닝중이 아님</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>상태: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>잠금해제된 잔액</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>동기화 중</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>연결됨</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>잘못된 버전</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>연결이 끊어짐</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>잘못된 연결 상태</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>네트워크 상태</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>지갑 비밀번호를 입력하세요</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>다음을 위해 지갑 비밀번호를 입력하세요 :&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>승인</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>연결 중...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>남아있는 블록: % 1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>블록 동기화 중</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>잘못된 결제 아이디</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>경고: 데몬에 연결되지 않았습니다.</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>트랜잭션풀에 포함: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 확인: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 확인: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>발견된 거래 없음...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>거래 발견</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 거래 발견</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> 더 많은 금액 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> 부족한 금액 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>읽기전용 지갑주소가 표기됨</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16진수 16자</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>지움</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>통합 주소</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>받을 금액</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>결제 추적</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Qr코드 저장</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Qr코드를 저장하지 못했습니다 </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>다른 이름으로 저장</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>결제 신분증</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>생성</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>통합주소를 위한 결제 아이디 생성</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>금액</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>트위터</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>뉴스</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>도움말</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>소개</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">포트</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>보기 전용 지갑 만들기</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>데몬 관리</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>데몬 시작</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>데몬 중지</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>상태 표시</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>데몬 시작 플래그</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(선택 항목)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>시드 키 표시</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>지갑 잔액 다시 스캔하기</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>오류: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>정보</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>소비된 아웃풋이 성공적으로 다시 스캔되었습니다.</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>블록체인 위치</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>데몬 주소</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>호스트 이름 / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>포트</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>로그인 (선택 항목)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>사용자 이름</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>암호</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>연결</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>레이아웃 설정</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>사용자 설정 디자인</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>로그 레벨</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(예: *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>버전</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI 버전:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>임베디드 모네로 버전:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>데몬 로그</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>폴더를 선택하세요</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>경고</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>오류: 해당 파일시스템은 읽기전용입니다</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>경고 : 해당장치에 사용 가능한 공간은 %1 GB뿐입니다. 블록체인에는 ~ %2 GB의 데이터가 필요합니다.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>참고: %1 GB의 장치를 사용할 수 있습니다. 블록체인에는 ~ %2 GB의 데이터가 필요합니다.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>참고: lmdb 폴더를 찾을 수 없습니다. 새 폴더가 생성됩니다.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>지갑 시드 키</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>비공개 키</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>공개 키</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>비공개 결제 키</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>공개 결제 키</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>잘못된 암호</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>지갑 관리</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>지갑 닫기</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>올바른 서명</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>올바른 서명입니다</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>잘못된 서명</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>이 서명은 확인할 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>귀하의 주소로 메시지 또는 파일 내용을 서명하십시오:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>해당 메시지:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>서명 할 메시지</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>서명</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>서명할 파일을 선택하세요</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>확인할 파일을 선택하세요</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished">서명할 주소 &lt;font size=&apos;2&apos;&gt;  (&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;주소록&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;에서 붙여넣거나 선택하십시오 )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>또는 파일 :</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>서명할 메시지가 있는 파일 이름</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>서명</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>메시지나 파일의 서명을 주소로부터 확인합니다</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>확인할 메시지</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>확인할 메시지가 있는 파일 이름</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>승인</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>낮은 (x1 보상)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>중간 (x20 보상)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>높음 (x166 수수료)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>느림 (x0.25 수수료)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>기본 (x1 수수료)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>빠름 (x5 수수료)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>가장 빠름 (x41.5 수수료)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>전부</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>전송됨</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>받음</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>표준</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>중간</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>높음</translation>
     </message>
@@ -1237,224 +1470,214 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt; 데몬 시작&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Open Alias 오류</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>개인정보 보호 수준 (링 사이즈 %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>금액</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>거래 우선순위</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>전부</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>낮음 (x1 수수료)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>중간 (x20 수수료)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>높음 (x166 수수료)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      주소 &lt;font size=&apos;2&apos;&gt; (에 붙여 넣기 또는에서 선택 &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;주소록&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>문제해결</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>이 Open Alias 주소에 유효한 주소가 없습니다</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>주소가 발견되었으나 DNSSEC 서명이 확인되지 않습니다. 이 주소는 스푸핑(spoof)되었을 수 있습니다</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>이 Open Alias 주소에서 유효한 주소 또는 DNSSEC 서명을 확인할 수 없습니다. 이 주소는 스푸핑(spoof)되었을 수 있습니다</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>내부 오류</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>주소를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>설명 &lt;font size=&apos;2&apos;&gt;( 선택 사항 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>로컬 지갑 기록에 저장됨</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>전송</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>고급 옵션 표시</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>혼합 불가능한 스윕</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>거래 파일 만들기</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>거래 파일 서명</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>거래 파일 제출</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>거래 횟수: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>수신자: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>결제 신분증: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>금액: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>반지 사이즈:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>정보</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>파일을 선택하세요</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">데몬 시작</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">주소</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>서명되지 않은 거래를 불러올 수 없습니다: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>수수료:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>거래를 전송할 수 없습니다:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>송금 완료</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="699"/>
-        <location filename="../pages/Transfer.qml" line="711"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>지갑이 데몬에 연결되어있지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="714"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>연결된 데몬은 GUI와 호환되지 않습니다. 다른 데몬으로 업그레이드하거나 연결하세요.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>데몬 동기화가 완료 될 때까지 기다림</translation>
     </message>
@@ -1464,37 +1687,37 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>거래 비용</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>결제 신분증 &lt;font size=&apos;2&apos;&gt;( 선택 사항 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>느린 (x0.25 수수료)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>디폴트 (x1 수수료)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>빠른 (x5 수수료)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>가장 빠른 (x41.5 수수료)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 또는 64 자의 16 진수</translation>
     </message>
@@ -1502,72 +1725,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>타사 결제를 한 것으로 확인 공급함으로써 :</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - 수신자 주소</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - 거래 신분증</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - 송신자가 제공 한 비밀 거래 키</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>결제에 여러 거래가있는 경우 각각을 점검하고 결과를 결합해야합니다.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>수취인의 지갑 주소</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">생성</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">서명</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>거래 아이디</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>거래 아이디 붙여넣기</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>거래 키 붙여 넣기</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>검사</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>거래 키</translation>
-    </message>
-</context>
-<context>
-    <name>WalletManager</name>
-    <message>
-        <location filename="../src/libwalletqt/WalletManager.cpp" line="153"/>
-        <source>Unknown error</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1622,6 +1850,39 @@ Please upgrade or connect to another daemon</source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>새 지갑 만들기</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">블록체인 위치</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(선택 항목)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1988,44 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>같은 이름의 지갑이 이미 존재합니다. 지갑 이름을 변경하세요.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation> ASCII(미국 문자 표준코드체계)가 아닌 문자는 지갑 경로 이름 또는 파일 이름으로 허용되지 않습니다.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>모네로 사용하기</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>지갑 만들기</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>성공</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>보기 전용 지갑이 생성되었습니다. 해당 지갑을 열기 위해서는 현재 지갑을 닫고 &quot;파일에서 지갑 열기&quot;를 클릭한 후 보기 전용 지갑을 선택하십시오:
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>중단</translation>
     </message>
@@ -1772,47 +2033,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>지갑 이름</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>시드(seed)에서 복원</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>키에서 복원</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>계정 주소 (공개)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>보기 키 (비공개)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>결제 키 (비공개)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>블록 높이 복원 (선택 항목)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>당신의 지갑은 다음 위치에 저장되었습니다: </translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>디렉토리를 선택하세요</translation>
     </message>
@@ -1825,7 +2091,12 @@ Please upgrade or connect to another daemon</source>
         <translation>귀하의 25 단어 니모닉 시드을 입력하세요</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation> 지갑의 백업 및 복원에 필요한 유일한 정보인 이 시드를 받아 적어, 보안이 되는 안전한 장소에 보관 하는것은 &lt;b&gt;매우 &lt;/b&gt; 중요합니다.</translation>
     </message>
@@ -1833,37 +2104,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>모네로에 오신 것을 환영합니다!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>다음 옵션 중 하나를 선택하세요:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>새 지갑 만들기</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>니모닉 시드 또는 개인 키에서 지갑을 복원</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>파일에서 지갑 열기</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>사용자 지정 데몬 주소 (선택 항목)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>테스트넷</translation>
     </message>
@@ -1877,7 +2143,7 @@ Please upgrade or connect to another daemon</source>
         <translation>지갑의 비밀번호를 설정하세요</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;참고: 이 암호는 복구 될 수 없으며, 지갑분실시 25 단어 니모닉 시드에서 지갑을 복원해야합니다.&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2153,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>비밀번호</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>비밀번호 확인</translation>
     </message>
@@ -1900,7 +2166,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>지갑 복원</translation>
     </message>
@@ -1908,12 +2174,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>모네로에 오신 것을 환영합니다!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>언어와 지역 포맷을 선택하세요.</translation>
     </message>
@@ -1921,224 +2187,321 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="329"/>
-        <location filename="../main.qml" line="497"/>
-        <location filename="../main.qml" line="509"/>
-        <location filename="../main.qml" line="559"/>
-        <location filename="../main.qml" line="571"/>
-        <location filename="../main.qml" line="613"/>
-        <location filename="../main.qml" line="622"/>
-        <location filename="../main.qml" line="674"/>
-        <location filename="../main.qml" line="712"/>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="330"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>지갑을 열 수 없습니다:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="361"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>잠금해제된 잔액 (블록 대기 중)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="361"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>잠금해제된 잔액 (~%1 분)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="361"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>잠금해제된 잔액</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>데몬 시작까지 기다리는 중...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="419"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>데몬 종료까지 기다리는 중...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>데몬 시작에 실패했습니다</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="445"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>지갑과 데몬 로그에서 오류를 확인하십시오. 수동으로 %1을 시작할 수도 있습니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="499"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>잘못된 데몬 버전으로 거래를 만들 수 없습니다: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="614"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>거래를 만들 수 없습니다:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="510"/>
-        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>스윕처리할 비혼합 아웃풋 없습니다</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
-        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
-        <location filename="../main.qml" line="636"/>
-        <source>Please confirm transaction: </source>
-        <translation>거래 내용을 확인하세요:</translation>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
+        <source>Please confirm transaction:
+</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
-        <source> Address: </source>
-        <translation>주소:</translation>
+        <location filename="../main.qml" line="588"/>
+        <source>
+Address: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="525"/>
-        <source> Payment ID: </source>
-        <translation>결제 아이디: </translation>
+        <location filename="../main.qml" line="589"/>
+        <source>
+Payment ID: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="526"/>
-        <location filename="../main.qml" line="637"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
+        <source>
+Fee: </source>
+        <translation type="unfinished">수수료:</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="592"/>
+        <source>
+
+Ringsize: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="593"/>
+        <source>
+Number of transactions: </source>
+        <translation type="unfinished">거래 횟수: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
+        <source>
+
+Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">잘못된 서명</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
         <translation>금액: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="527"/>
-        <location filename="../main.qml" line="638"/>
-        <source> Fee: </source>
-        <translation>수수료: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="528"/>
-        <source> Ringsize: </source>
-        <translation> 링사이즈: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="734"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>이 주소로 %1 XMR을 받아, %2 번의 컨펌을 받았습니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1324"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>데몬이 실행 중입니다</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1325"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>GUI가 닫혀도 데몬은 백그라운드에서 계속 실행됩니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1327"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>데몬 중지</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1361"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>monero-wallet-gui의 새 버전을 사용할 수 있습니다: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="529"/>
-        <source> Number of transactions: </source>
-        <translation>거래 수: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="530"/>
-        <source> Description: </source>
-        <translation>설명: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="560"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>금액이 잘못되었습니다 : % 1에서 % 2까지의 예상 숫자</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>잔액이 불충분합니다. 잠금해제 된 잔액: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="675"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>돈을 전송하지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>정보</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="684"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>송금 완료: %1 개의 거래 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="684"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>거래 데이터를 파일에 저장되었습니다: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="724"/>
-        <source>Payment check</source>
-        <translation>결제 확인</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="729"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>이 주소는 % 1XMR을 받았지만, 해당 거래가 아직 채굴에 포함되지 않았습니다</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>이 주소는 아무것도 받지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="750"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">올바른 서명</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>잔액 (동기화)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="750"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>잔액</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="985"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">잘못된 암호</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">경고</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">오류: 해당 파일시스템은 읽기전용입니다</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">경고 : 해당장치에 사용 가능한 공간은 %1 GB뿐입니다. 블록체인에는 ~ %2 GB의 데이터가 필요합니다.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">참고: %1 GB의 장치를 사용할 수 있습니다. 블록체인에는 ~ %2 GB의 데이터가 필요합니다.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">참고: lmdb 폴더를 찾을 수 없습니다. 새 폴더가 생성됩니다.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">오류: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>기다려주십시오...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1009"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>프로그램 설치 마법사</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1024"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>모네로</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1072"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>동일한 대상에게 송금하기</translation>
     </message>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Voeg nieuw contact toe</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QRCODE</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Betaal-ID &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Plak 64 hexadecimale karakters</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Geef deze vermelding een naam of omschrijving</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Ongeldig adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Kan vermelding niet opslaan</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Betaal-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Monero node wordt gestart in %1 seconde(n)</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation> geselecteerd: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filteren</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Begin te typen voor incrementeel zoeken...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Datum van</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Geavanceerd filteren</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Soort transactie</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Bedrag van</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Betaal-ID:</translation>
     </message>
@@ -255,151 +260,295 @@
         <translation>Bestemmingen:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Blokhoogte:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 bevestigingen)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 bevestigingen) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>ONBEVESTIGD</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>IN AFWACHTING</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Vergoeding</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Transactie-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Betaal-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Transactiesleutel:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Transactienotitie:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Bestemmingen:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Verder geen resultaten</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 bevestigingen) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">ONBEVESTIGD</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">IN AFWACHTING</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Geheime alleen-lezen sleutel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Openbare alleen-lezen sleutel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Geheime bestedingssleutel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Openbare bestedingssleutel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="178"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Beschikbaar saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="281"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="331"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Ontvangen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="332"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="425"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="355"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Geschiedenis</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="306"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Adresboek</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="307"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="356"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="378"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="379"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="400"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translatorcomment>Wat is een juiste vertaling voor minen/mining? Winning misschien, zoals het winnen van delfstoffen. Of ontginning/ontginnen?</translatorcomment>
         <translation>Minen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="401"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="424"/>
-        <source>Check payment</source>
-        <translation>Betaling controleren</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="448"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Ondertekenen/verifiëren</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="449"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="471"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="472"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="282"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
@@ -407,12 +556,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Beschikbaar saldo</translation>
     </message>
@@ -420,87 +569,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Solo minen</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(alleen beschikbaar voor lokale nodes)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Minen met uw computer helpt het Monero-netwerk sterker te worden. Hoe meer individuen er minen, des te moeilijker het is om het Monero-netwerk aan te vallen. Ieder beetje helpt dus.&lt;br&gt; &lt;br&gt; Minen geeft u ook een kleine kans om Monero te verdienen. Uw computer zal namelijk specifieke tekenreeksen berekenen en zodoende op zoek gaan naar Monero blok-oplossingen. Als u een blok vindt, ontvangt u de bijbehorende beloning. Veel success!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU threads</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Minen op de achtergrond (experimenteel)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Start het minen ook indien de accu gebruikt wordt</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Beheer de miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Start het minen</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Fout opgetreden bij het starten van de miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Kon niet starten met minen.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Minen is alleen beschikbaar voor lokale nodes. Start een lokale node om te kunnen minen.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Stop het minen</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Status: er wordt niet gemined</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Er wordt gemined met %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Er wordt niet gemined</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Status: </translation>
     </message>
@@ -508,7 +657,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Beschikbaar saldo:</translation>
     </message>
@@ -516,12 +665,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Netwerkstatus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
@@ -531,30 +680,58 @@
         <translation>Synchroniseren</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Verkeerde versie</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Niet verbonden</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Ongeldige verbindingsstatus</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Vul het wachtwoord voor de portemonnee in</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Vul het wachtwoord van de portemonnee in voor:&lt;br&gt;</translation>
     </message>
@@ -564,9 +741,9 @@
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>OK</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -590,19 +767,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Bezig met verbinding te maken...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Blokken resterend: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Blokken synchroniseren</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -613,152 +798,162 @@
         <translation>Ongeldige betaal-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>WAARSCHUWING: er is geen verbinding met een node</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>in de transactiepoel: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 bevestigingen: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 bevestiging: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Nog geen transactie gevonden...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transactie gevonden</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 gevonden transacties</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> met meer geld (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> met onvoldoende geld (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Adres alleen-lezen portemonnee wordt hier weergegeven</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 hexadecimale tekens</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Wissen</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Geïntegreerd adres</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Genereer Betaal-ID voor geïntegreerd adres</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>QR-Code opslaan</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>QR-code niet opgeslagen in </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Betaal-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Te ontvangen bedrag</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Traceren &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Betalingen traceren</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Dit is een eenvoudige verkooptracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klik hier om een willekeurige betaal-ID te maken voor een nieuwe klant&lt;/p&gt; &lt;p&gt;Laat uw klant deze QR-code scannen om een betaling uit te voeren (als die klant over software beschikt die QR-codes kan scannen).&lt;/p&gt;&lt;p&gt;Deze pagina zal automatisch de blockchain en transactiepoel doorzoeken op inkomende transacties met behulp van deze QR-code. Als u een bedrag invult, wordt er ook gecontroleerd of het complete bedrag ontvangen is.&lt;/p&gt;Het is aan u om eventuele onbevestigde transacties te accepteren of niet. Het is zeer waarschijnlijk dat deze op korte termijn bevestigd zullen worden, maar er is nog steeds een mogelijkheid dat dit niet gebeurt. Bij grote bedragen is het dus aan te raden om te wachten op een of meer bevestigingen.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Genereer</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Nieuws</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Help</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Over</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Poort</translation>
     </message>
 </context>
 <context>
@@ -777,224 +972,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Hersteltekst en sleutels van portemonnee</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Geheime alleen-lezen sleutel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Openbare alleen-lezen sleutel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>Geheime bestedingssleutel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>Openbare bestedingssleutel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Verkeerd wachtwoord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Node-adres</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Portemonnee beheren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Portemonnee sluiten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Maak een alleen-lezen portemonnee aan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Node beheren</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Start lokale node</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Stop lokale node</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Node-log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Hostnaam/IP-adres</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Bekijk status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Startargumenten voor node</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Toon hersteltekst en sleutels</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Saldo van portemonnee opzoeken</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Fout: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>De uitgaven zijn doorzocht</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Locatie van blockchain</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Poort</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Inlognaam (optioneel)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Gebruikersnaam</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Verbinden</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Kies een map</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Fout: het bestandssysteem is alleen-lezen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Waarschuwing: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Let op: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>LMDB-map niet gevonden. Er wordt een nieuwe map gemaakt.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Opmaakinstellingen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Aangepaste decoraties</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Logniveau</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(b.v. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Versie</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI-versie: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Ingebouwde Monero-versie: </translation>
     </message>
@@ -1002,105 +1225,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Geldige handtekening</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Dit is een geldige handtekening</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Ongeldige handtekening</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Deze handtekening is ongeldig</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Onderteken een bericht of bestandsinhoud met uw adres:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Een bericht:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Te ondertekenen bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Ondertekenen</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Kies een bestand om te ondertekenen</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verifiëren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Kies een bestand om te verifiëren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Adres voor ondertekenen &lt;font size=&apos;2&apos;&gt;  (Vul in of slecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Of bestand:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Bestand met bericht om te ondertekenen</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Handtekening</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Verifieer een bericht of bestandsinhoud met een adres:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Het te verifiëren bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Bestandsnaam met bericht om te verifiëren</translation>
     </message>
@@ -1108,65 +1336,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Laag (vergoeding × 1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Gemiddeld (vergoeding × 20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Hoog (vergoeding × 166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langzaam (vergoeding × 0,25)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>Normaal (vergoeding × 1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>Snel (vergoeding × 5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Razendsnel (vergoeding × 41,5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Verzonden</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Ontvangen</translation>
     </message>
@@ -1221,16 +1459,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normaal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Gemiddeld</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Hoog</translation>
     </message>
@@ -1238,12 +1471,12 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Prioriteit transactie</translation>
     </message>
@@ -1253,258 +1486,248 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Transactiekosten</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Fout in OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translatorcomment>Is &apos;vertrouwenscirkel grootte&apos; een betere vertaling?</translatorcomment>
         <translation>Privacyniveau (ring grootte %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start lokale node&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Laag (vergoeding × 1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Gemiddeld (vergoeding × 20)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Hoog (vergoeding × 166)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langzaam (vergoeding × 0,25)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Normaal (vergoeding × 1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Snel (vergoeding × 5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Razendsnel (vergoeding × 41,5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adres &lt;font size=&apos;2&apos;&gt;  (Vul in of selecteer uit het &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Oplossen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Geen geldig adres gevonden voor dit OpenAlias-adres</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adres gevonden, maar de DNSSEC-handtekeningen kunnen niet geverifiëerd worden, dus het adres kan gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Geen geldig adres gevonden onder het opgegeven OpenAlias-adres, en de DNSSEC-handtekeningen kunnen niet geverifiëerd worden, dus het adres kan gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Interne fout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Geen adres gevonden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Wordt opgeslagen in de lokale portemonnee-geschiedenis</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Laat geavanceerde opties zien</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Verbonden node is niet compatibel met de GUI.
 Upgrade of maak verbinding met een andere node</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Onmengbare bedragen samenvoegen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Maak TX-bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Onderteken TX-bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Verzend TX-bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Kies een bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Start lokale node</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adres</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Het laden van de niet-ondertekende transactie is mislukt: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Aantal transacties: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transactie #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Ontvanger: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 Betaal-ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringgrootte: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Kan transactie niet insturen: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Het geld is verstuurd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portemonnee is niet verbonden met de node.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Wachten totdat de synchronisatie met de node compleet is</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Betaal-ID &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 of 64 hexadecimale tekens</translation>
     </message>
@@ -1512,64 +1735,77 @@ Ringgrootte: </translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verifieer een betaling van een derde door het volgende op te geven:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - het adres van de ontvanger</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - het transactie-ID</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - de geheime transactiesleutel verstrekt door de verzender</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Als een betaling meerdere transacties had, dan moet elk afzonderlijk gecontroleerd worden en het resultaat opgeteld worden.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Portemonnee-adres van de ontvanger</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Genereer</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Handtekening</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Transactie-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Plak een transactie-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Plak een transactiesleutel</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Controleren</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Transactiesleutel</translation>
     </message>
 </context>
 <context>
@@ -1624,6 +1860,39 @@ Ringgrootte: </translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Maak een nieuwe portemonnee aan</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Locatie van blockchain</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(optioneel)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1729,32 +1998,32 @@ Ringgrootte: </translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Er bestaat al een portemonnee met dezelfde naam. Verander de naam van uw portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Niet-ASCII karakters zijn niet toegestaan in het portemonnee-pad of de portemonnee-naam</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>GEBRUIK MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Portemonnee maken</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Geslaagd</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translatorcomment>The exact option text is: Open a wallet from file</translatorcomment>
@@ -1762,12 +2031,12 @@ Ringgrootte: </translation>
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Afbreken</translation>
     </message>
@@ -1775,47 +2044,52 @@ Ringgrootte: </translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Naam van portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Herstel met hersteltekst</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Herstel met sleutels</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Adres van portemonnee (openbaar)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Aleen-lezen sleutel (privé)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Bestedingssleutel (privé)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Herstelpunt (optioneel)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Uw portemonnee is opgeslagen in</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Kies een locatie</translation>
     </message>
@@ -1828,7 +2102,12 @@ Ringgrootte: </translation>
         <translation>Vul uw hersteltekst van 25 woorden in</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Deze hersteltekst is &lt;b&gt;zeer&lt;/b&gt; belangrijk om veilig op te slaan en privé te houden. Het is het enige dat u nodig heeft om een back-up van uw portemonnee te maken of uw portemonnee te herstellen.</translation>
     </message>
@@ -1836,37 +2115,32 @@ Ringgrootte: </translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Welkom bij Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Selecteer een van de volgende opties:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Maak een nieuwe portemonnee aan</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Herstel een portemonnee met behulp van uw hersteltekst of sleutels</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Open een portemonnee vanaf een bestand</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Aangepast node-adres (optioneel)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1880,7 +2154,7 @@ Ringgrootte: </translation>
         <translation>Beveilig uw portemonnee met een wachtwoord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Let op: dit wachtwoord kan niet hersteld worden. Als u het wachtwoord vergeet, kan de portemonnee alleen hersteld worden worden met u hersteltekst van 25 woorden.&lt;br/&gt;&lt;br/&gt;
@@ -1890,12 +2164,12 @@ Ringgrootte: </translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Wachtwoord bevestigen</translation>
     </message>
@@ -1903,7 +2177,7 @@ Ringgrootte: </translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Portemonnee herstellen</translation>
     </message>
@@ -1911,12 +2185,12 @@ Ringgrootte: </translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Welkom bij Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Selecteer een taal en regio.</translation>
     </message>
@@ -1924,46 +2198,48 @@ Ringgrootte: </translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Portemonnee kan niet geopend worden: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Transactie kan niet worden aangemaakt: Verkeerde node-versie: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Geen onmengbare bedragen gevonden om samen te voegen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Bevestig de transactie:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -1972,14 +2248,14 @@ Amount: </source>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Aantal transacties: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -1988,101 +2264,107 @@ Description: </source>
 Omschrijving: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Verkeerd bedrag: bedrag tussen %1 en %2 verwacht</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Het geld is verzonden: %1 transactie(s) </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Betaling controleren</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Dit adres heeft %1 monero ontvangen, maar de transactie is nog niet verwerkt</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Dit adres heeft niets ontvangen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Transactie kan niet worden aangemaakt: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Beschikbaar saldo (wachten op blok)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Beschikbaar saldo (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Beschikbaar saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Wachten tot de node gestart is...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Wachten tot de node gestopt is...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Het starten van de node is mislukt</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Controleer de logs van uw portemonnee en node op fouten. Of probeer %1 handmatig te starten.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adres: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 Betaal-ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2091,77 +2373,157 @@ Ringsize: </source>
 Ringgrootte: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Onvoldoende geld. Beschikbaar saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Het geld kan niet worden verstuurd: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transactie opgeslagen in bestand: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Ongeldige handtekening</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Dit adres heeft %1 monero ontvangen, met %2 bevestiging(en).</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Geldige handtekening</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Saldo (synchroniseren)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Verkeerd wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Waarschuwing</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Fout: het bestandssysteem is alleen-lezen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Waarschuwing: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Let op: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">LMDB-map niet gevonden. Er wordt een nieuwe map gemaakt.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Fout: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Even geduld alstublieft...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Installatie-assistent</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>naar hetzelfde adres verzenden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Node is gestart</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Node wordt nog steeds op de achtergrond uitgevoerd nadat de GUI gesloten wordt.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Stop node</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Nieuwe versie van monero-wallet-gui is beschikbaar: %1&lt;br&gt;%2</translation>
     </message>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 bevestigingen) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 bevestigingen)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 bevestigingen) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 bevestigingen)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_pl.ts
+++ b/translations/monero-core_pl.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 potwierdzeń) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 potwierdzeń)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 potwierdzeń) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 potwierdzeń)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_pl.ts
+++ b/translations/monero-core_pl.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Dodaj nowy wpis</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation type="unfinished">QR Kod</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation type="unfinished">4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Identyfikator płatności &lt;font size=&apos;2&apos;&gt;(Opcjonalny)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation type="unfinished">Wklej 64 znaki w postaci heksadecymalnej (dodaj na początku adresu &apos;0x&apos;))</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation type="unfinished">Opis &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation type="unfinished">Dodaj nazwę lub opis dla tego wpisu</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation type="unfinished">Dodaj</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation type="unfinished">Niepoprawny adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation type="unfinished">Nie można utworzyć wpisu</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Identyfikator płatności:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation type="unfinished">Uruchomienie procesu Monero za %1 sekund</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation> wybrano: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Wpisz aby wyszukać...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Data od</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation type="unfinished">Filtruj</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Zaawansowane filtrowanie</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Typ transakcji</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Wartość od</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Identyfikator płatności:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Cel:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Szczegóły</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Wysokość bloku:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation type="unfinished">(%1/10 potwierdzeń)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 potwierdzeń) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation type="unfinished">NIEPOTWIERDZONE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation type="unfinished">OCZEKUJĄCE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Opłata</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Wartość</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Identyfikator tx:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Identyfikator płatności:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Klucz tx:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Notatka tx:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Cel:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">To już wszystkie wyniki</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 potwierdzeń) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">NIEPOTWIERDZONE</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">OCZEKUJĄCE</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Dostępne saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Wyślij</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Otrzymaj</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>P</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation type="unfinished">Zaawansowane</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished">D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation type="unfinished">Sprawdź płatność</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Podpisz/weryfikuj</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished">I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>P</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation type="unfinished">Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation type="unfinished">Dostępne saldo</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation type="unfinished">Kopanie solo</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation type="unfinished">(dostępne jedynie dla lokalnego procesu/daemona)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation type="unfinished">Kopanie z udziałem twojego komputera wzmacnia sieć Monero. Im więcej osób kopie tym trudniej zaatakować sieć, a każdy najmniejszy wkład jest pomocny. Dodatkowo kopanie daje ci małą szansę na zarobienie Monero. Twój komputer utworzy hashe/sumy kontrolne aby znaleźć rozwiązanie dla bloku. Jeżeli znajdziesz rozwiązanie wtedy otrzymasz swój udział w postaci zapłaty w Monero. Powodzenia!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation type="unfinished">Wątki CPU</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation type="unfinished">(opcjonalnie)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation type="unfinished">Kopanie w tle (wersja eksperymentalna)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation type="unfinished">Uruchom kopanie gdy działasz na baterii</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation type="unfinished">Zarządzaj koparką</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation type="unfinished">Uruchom kopanie</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation type="unfinished">Błąd uruchamiania koparki</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation type="unfinished">Nie można było uruchomić kopania.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation type="unfinished">Kopanie jest możliwe tylko mając uruchomiony proces daemona loklanie. Uruchom daemona aby mieć możliwość kopania.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation type="unfinished">Zatrzymaj kopanie</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation type="unfinished">Status: nie kopie</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation type="unfinished">Szybkość kopania: %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished">Dostępne saldo:</translation>
     </message>
@@ -515,12 +664,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Status sieci</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Połączono</translation>
     </message>
@@ -530,30 +679,58 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Nieprawidłowa wersja</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Rozłączono</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Nieprawidłowy status połączenia</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Podaj hasło portfela</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Podaj hasło dla portefela:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Synchronizowanie bloków</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Nieprawidłowy identyfikator płatności</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>UWAGA: brak połączenia z procesem</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>w puli tx: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>potwierdzeń: %2 na %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 potwierdzenie: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Jeszcze nie znaleziono transakcji...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Znaleziono transakcje</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>znalezionych transakcji: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> więcej pieniędzy (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> nie wystarczające pieniądze (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Adres portfela tylko do odczytu</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Adres zintegrowany</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Identyfikator płatności</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Wartość</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Śledzenie &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;pomoc&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Śledzenie płatności</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Tutaj możesz śledzić sprzedaż:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Kliknij w Generuj aby stworzyć losowy identyfikator płatności dla nowego klienta&lt;/p&gt; &lt;p&gt;Klient może także zeskanować kod aby dokonać płatności (jeśli posiada oprogramowanie do skanowania kodów).&lt;/p&gt;&lt;p&gt;Ta strona automatycznie śledzi łańcuch bloków i pulę tx wyszukująć transakcji przychodzących. Jeśli wprowadzisz wartość, będzie szukała transakcji do maksymalnie tej wartości.&lt;/p&gt;Sam decydujesz, czy akceptujesz niepotwierdzone transakcje czy nie. Powinny zostać zatwierdzone niedługo potem, ale istenieje prawdopodobieństwo, że nie zostaną. Dla wiekszych kwot możesz chcieć poczekać na jedno lub więcej powiadomień.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generuj</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Nowości</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Pomoc</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>O programie</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,396 +971,439 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Nieprawidłowe hasło</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Adres procesu</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Zarządzaj portfelem</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Zamknij portfel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Zarządzaj procesem</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Uruchom proces</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Zatrzymaj proces</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation type="unfinished">(opcjonalnie)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished">Informacja</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation type="unfinished">Hasło</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
-        <source>Daemon log</source>
-        <translation>Log procesu</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
+        <source>Daemon log</source>
+        <translation>Log procesu</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Host / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
     </message>
 </context>
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Podpis prawidłowy</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Ten podpis jest prawidłowy</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Zły podpis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Ten podpis nie jest prawidłowy</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Podpisz wiadomość lub plik swoim adresem:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Wiadomość:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Wiadomość do podpisania</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Lub plik:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Nazwa pliku z wiadomością do podpisania</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Potwierdź wiadomość lub plik podpisu z adresu:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Wiadomość do potwierdzenia</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Nazwa pliku z wiadomością do potwierdzenia</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
+        <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1237,12 +1470,12 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Wartość</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Priorytet transakcji</translation>
     </message>
@@ -1252,251 +1485,241 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Koszt transakcji</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Potrfel nie jest podłączony do procesu.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Połączony proces nie jest kompatybilny z interfejsem graficznym.
 Uaktualnij go lub podłącz się do innego procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Poczekaj na zakończenie synchronizacji procesu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Identyfikator płatności &lt;font size=&apos;2&apos;&gt;(Opcjonalny)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adres</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 lub 64 znaków szesnastkowych</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation type="unfinished">Wyślij</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation type="unfinished">Informacja</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Uruchom proces</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation type="unfinished">Liczba transakcji: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation type="unfinished">
 Opłata: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation type="unfinished">Potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1504,62 +1727,75 @@ Ringsize: </source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Potwierdź że dokonano płatności podając:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - adres odbiorcy</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - identyfikator transakcji</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - sekretny klucz transakcji podany przez nadawcę</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Adres portfela odbiorcy</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Identyfikator transakcji</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Wklej identyfikator tx</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Wklej klucz tx</translation>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Generuj</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Podpis</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Klucz transakcji</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1615,6 +1851,39 @@ Ringsize: </source>
     <message>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(opcjonalnie)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1721,43 +1990,43 @@ Ringsize: </source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Portfel o takiej nazwie istenieje. Podaj inną nazwę</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>W nazwie portfela lub konta użyte niedozwolone znaki</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>UŻYJ MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1765,47 +2034,52 @@ Ringsize: </source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
-        <source>Account address (public)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
-        <source>View key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
-        <source>Spend key (private)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
-        <source>Restore height (optional)</source>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <source>Account address (public)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
+        <source>View key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
+        <source>Spend key (private)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
+        <source>Restore height (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Twoj portfel został zachowany w</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Wybierz katalog</translation>
     </message>
@@ -1818,7 +2092,12 @@ Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1826,37 +2105,32 @@ Ringsize: </source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Witaj w świecie Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Wybierz jedną z opcji:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Śieć testowa</translation>
     </message>
@@ -1870,7 +2144,7 @@ Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation type="unfinished"></translation>
@@ -1879,12 +2153,12 @@ Ringsize: </source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation type="unfinished">Hasło</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation type="unfinished">Potwierdź hasło</translation>
     </message>
@@ -1892,7 +2166,7 @@ Ringsize: </source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1900,12 +2174,12 @@ Ringsize: </source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation type="unfinished">Witaj w świecie Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Wybierz język i region.</translation>
     </message>
@@ -1913,46 +2187,48 @@ Ringsize: </source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Nie można otworzyć portfela: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Nie można zrealizować transakcji: Zła wersja procesu: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Brak niemiksowalnych wyjść do zmieszania</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Potwierdź transakcję:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -1961,13 +2237,13 @@ Amount: </source>
 Wartość: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>Liczba transakcji: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -1976,178 +2252,264 @@ Description: </source>
 Opis: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Wartość nieprawidłowa: oczekiwano liczby od %1 do %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Nie można zrealizować transakcji:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation type="unfinished">Dostępne saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Czekam na start procesu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Czekam na zakończenie procesu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Potwierdzenie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adres: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 Identyfikator płatności: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Opłata: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Zły podpis</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Podpis prawidłowy</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Nieprawidłowe hasło</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation type="unfinished">Zatrzymaj proces</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>niewystarczające środki: Dostępne saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Nie mogę przesłać pieniędzy: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informacja</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation type="unfinished">Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Proszę czekać...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Pomyślne przesłane pieniędzy, liczba transakcji: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Sprawdź płatność</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Ten adres otrzymał %1 monero, ale transakcja nie została jeszcze wykopana</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Ten adres nic nie otrzymał</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>wyślij do tego samego celu</translation>
     </message>

--- a/translations/monero-core_pt-br.ts
+++ b/translations/monero-core_pt-br.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmações) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmações)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmações) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmações)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_pt-br.ts
+++ b/translations/monero-core_pt-br.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Adicionar novo endereço</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QRCODE</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ID do Pagamento &lt;font size=&apos;2&apos;&gt;(Opcional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Cole os 64 caracteres hexadecimais</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Descrição &lt;font size=&apos;2&apos;&gt;(Opcional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Forneça um nome ou descrição a esta entrada</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Erros</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Endereço inválido</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Não foi possível criar entrada</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>ID do Pagamento:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Iniciando daemon do Monero em %1 segundos</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>Filtrar histórico de transação</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Digite para realizar busca...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtrar</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Data a partir de</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Filtragem avançada</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Tipo de transação</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Quantidade a partir de</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>ID do Pagamento:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Sem mais resultados</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Altura de bloco:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 confirmações)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmações) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NÃO CONFIRMADO</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>EM ESPERA</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Taxa</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">ID da Transação:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">ID do Pagamento:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Chave da Transação:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Observação sobre a Transação:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Destinos:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmações) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">NÃO CONFIRMADO</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">EM ESPERA</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">View key secreta</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">View key pública</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Spend key secreta</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Spend key pública</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Saldo desbloqueado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Receber</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Histórico</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Caderneta de endereços</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Avançado</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Mineração</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Checar pagamento</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Assinar/Verificar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Preferências</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Saldo desbloqueado</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Mineração solo</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(apenas disponível para daemons locais)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Minerar com seu computador ajuda a fortalecer a rede do Monero. Quanto mais pessoas minerarem, mais difícil é para a rede ser atacada, qualquer quantidade ajuda. &lt;br&gt; &lt;br&gt;Minerar também lhe garante uma pequena chance de ganhar Monero. Seu computador irá criar hashes procurando por blocos. Caso encontre um bloco, você receberá a recompensa associada. Boa sorte!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>Threads da CPU</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(opcional)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Mineração de segundo-plano (experimental)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Habilitar mineração quando estiver usando bateria</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Configurar minerador</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Iniciar mineração</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Erro ao iniciar mineração</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Não foi possível iniciar mineração&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>A mineração só está disponível para daemons locais. Execute um daemon local para minerar.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Parar mineração</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Estado: não minerando</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Minerando à %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Não minerando</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Estado: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Saldo desbloqueado:</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Sincronizando</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Versão incorreta</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Estado de conexão inválido</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Estado da rede</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Por favor digite a senha da carteira</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Por favor digite a senha da carteira:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Estabelecendo conexão...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Blocos restantes: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Sincronizando blocos</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>ID do Pagamento inválida</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>AVISO: sem conexão com o daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>na txpool: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 confirmações: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 confirmação: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Nenhuma transação encontrada ainda...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transação encontrada</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 transação encontrada</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> com mais dinheiro (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> sem dinheiro suficiente (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Endereço da carteira de somente leitura mostrado aqui</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 caracteres hexadecimais</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Limpar</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Endereço Integrado</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Quantidade a receber</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Rastreando &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Rastreando pagamentos</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Este é um rastreador de vendas:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Clique para gerar um ID de pagamento aleatório para um novo cliente&lt;/p&gt; &lt;p&gt;Permita seu cliente escanear o código QR para realizar um pagamento (se o cliente possuir software que suporte leitura de código QR).&lt;/p&gt;&lt;p&gt;Esta página irá escanear automaticamente a blockchain e a txpool em busca de transações utilizando este código QR. Caso você especifique uma quantidade, também checará por transação sendo recebida atá a quantidade especificada.&lt;/p&gt;Depende de você caso queira aceitar transações sem confirmações. É provavel que elas serão confirmadas em pouco tempo porém existe uma possibilidade de que não sejam, para valores altos é recomendado aguardar uma ou mais confirmações.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Salvar código QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Falha ao salvar código QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Salvar como</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ID do Pagamento</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Gerar</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Gerar ID do pagamento para endereço integrado</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Notícias</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Ajuda</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Sobre</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Porta</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Criar carteira de somente vizualização</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Gerenciar o daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Iniciar o daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Parar o daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Mostrar status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Flags de inicialização do daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(opcional)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Mostrar keys da semente</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Escanear saldo da carteira novamente</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Erro: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Saidas gastas escaneadas novamente</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Localização da Blockchain</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Local do Daemon</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Nome da máquina / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Porta</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Login (opcional)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Nome de usuário</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Senha</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Conectar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Por favor escolha um diretório</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Alerta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Erro: Filesystem é apenas de leitura</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Aviso: Existe apenas %1 GB disponível no dispositivo. A Blockchain necessita de ~%2 GB de dados.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Atenção: Existe apenas %1 GB disponível no dispositivo. A Blockchain necessita de ~%2 GB de dados.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Aviso: Diretório do lmdb não encontrado. Um novo diretório será criado.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Preferências de layout</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Decorações customizadas</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Nível de log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(ex: *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Versão</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Versão da GUI: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Versão do Monero integrada: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Log do daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Erros</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Keys da semente</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>View key secreta</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>View key pública</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>Spend key secreta</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>Spend key pública</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Senha incorreta</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Configurar carteira</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Fechar carteira</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Assinatura válida</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Esta é uma assinatura válida</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Assinatura inválida</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Esta assinatura não verificou</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Assine uma mensagem ou conteúdo de arquivo com seu endereço</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Uma mensagem:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Mensagem a ser assinada</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Assinar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Por favor escolha um arquivo para assinar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Selecionar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verificar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Por favor escolha um arquivo para verificar</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Endereço do assinante &lt;font size=&apos;2&apos;&gt;  ( Cole ou selecione através do &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Ou arquivo:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Nome do arquivo com mensagem a ser assinada</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Assinatura</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Verificar uma mensagem ou assinatura de um arquivo a partir de um endereço:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Mensagem a ser verificada</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Nome do arquivo com mensagem a ser verificada</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Baixa (taxa x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Média (taxa x20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Alta (taxa x166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished">Lenta (taxa x0.25)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished">Padrão (taxa x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished">Rápida (taxa x5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished">Mais rápida (taxa x41.5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Todos</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Enviado</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Recebido</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Média</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Alta</translation>
     </message>
@@ -1237,252 +1470,242 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Erro no OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Nível de privacidade (ringsize %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Iniciar daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Prioridade da transação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Baixa (taxa x1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Média (taxa x20)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Alta (taxa x166)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Lenta (taxa x0.25)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Padrão (taxa x1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Rápida (taxa x5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Mais rápida (taxa x41.5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Endereço &lt;font size=&apos;2&apos;&gt;  ( Cole ou selecione da &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Caderneta de endereços&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Resolver</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Nenhum endereço válido encontrado neste endereço OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Endereço encontrado, porém as assinaturas do DNSSEC não puderam ser verificas, este endereço pode ser falsificado</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Nenhum endereço válido encontrado neste endereço OpenAlias, porém as assinaturas do DNSSEC não puderam ser verificas, então este pode ter sido falsificado</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Erro interno</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Nenhum endereço encontrado</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Descrição &lt;font size=&apos;2&apos;&gt;( Opcional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Salvo no histórico de carteira local</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Mostrar opçoes avançadas</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Limpar não misturavel</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Criar arquivo da tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Todos</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Assinar arquivo da tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Enviar arquivo da tx</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Erros</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Por favor escolha um arquivo</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Iniciar o daemon</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Endereço</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Não foi possível carregar transação não assinada: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Número de transações: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transação #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Destinatário: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 ID do pagamento:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Quantidade: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Taxa: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringsize: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Confirmação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Não foi possível enviar transação: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Dinheiro enviado com sucesso</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>A carteira não está conectada ao daemon.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>O daemon conectado não é compatível com a GUI.
 Por favor atualize ou conecte outro daemon</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Aguardando a sincronização no daemon terminar</translation>
     </message>
@@ -1492,17 +1715,17 @@ Por favor atualize ou conecte outro daemon</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Custo da transação</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID do Pagamento &lt;font size=&apos;2&apos;&gt;( Opcional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 ou 64 caracteres hexadecimal</translation>
     </message>
@@ -1510,64 +1733,77 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verifique que um pagamento foi realizado informando:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - o endereço do destinatário</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - a ID da transação</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - a chave secreta da transação informada pelo remetente</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Se um pagamento foi realizado através de várias transações, cada transação deve ser checada e os resultados agregados</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Endereço da carteira do destinatário</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Gerar</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Assinatura</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>ID da Transação</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Cole ID da tx</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Cole chave da tx</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Checar</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Chave da Transação</translation>
     </message>
 </context>
 <context>
@@ -1622,6 +1858,39 @@ Por favor atualize ou conecte outro daemon</translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Criar uma nova carteira</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Localização da Blockchain</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(opcional)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1996,44 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Uma carteira com o mesmo nome já existe. Por favor mude o nome da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Somente caracteres ASCII são permitido no caminho da carteira ou nome da conta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>USAR O MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Criar carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Sucesso</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>A carteira de somente vizualização foi criada. Você pode abri-la fechando a carteira atual, clicando em &quot;Abrir carteira de um arquivo&quot; e selecionando a carteira de vizualização em:
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Erros</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Cancelar</translation>
     </message>
@@ -1772,47 +2041,52 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Nome da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Restaurar da semente</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Restaurar da keys</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Endereço (público)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>View key (secreta)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Spend key (secreta)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Restaurar da altura (opcional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Sua carteira está armazenada em</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Por favor escolha um diretório</translation>
     </message>
@@ -1825,7 +2099,12 @@ Por favor atualize ou conecte outro daemon</translation>
         <translation>Digite as 25 palavras da semente</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Esta semente é &lt;b&gt;muito&lt;/b&gt; importante, anote em um lugar seguro. É tudo o que é necessário para restaurar sua carteira.</translation>
     </message>
@@ -1833,37 +2112,32 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Bem-vindo ao Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Por favor selecione uma das seguintes opções:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Criar nova carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Restaurar carteira de keys ou semente</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Abrir carteira de um arquivo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Endereço customizado do daemon (opcional)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1877,7 +2151,7 @@ Por favor atualize ou conecte outro daemon</translation>
         <translation>Digite uma senha para a carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Atenção: esta senha não pode ser recuperada. Caso a esqueça terá que recuperar a carteira através da semente.&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2161,12 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Senha</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Confirme a senha</translation>
     </message>
@@ -1900,7 +2174,7 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Restaurar carteira</translation>
     </message>
@@ -1908,12 +2182,12 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Bem-vindo ao Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Por favor escolha um idioma e formato da localização</translation>
     </message>
@@ -1921,107 +2195,114 @@ Por favor atualize ou conecte outro daemon</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Erros</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Não foi possível abrir a carteira: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Saldo desbloqueado (aguardando bloco)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Saldo desbloqueado (~%1 minuto)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Saldo desbloqueado</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Aguardando o daemon iniciar...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Aguardando o daemon encerrar...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>O daemon falhou ao iniciar</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Por favor cheque o log de sua carteira e do daemon por erros. Você também pode tentar iniciar %1 manualmente</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Não foi possível criar a transação: Versão do daemon incorreta: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Não foi possível criar a transação: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Sem saídas impossiveis de serem misturadas para limpar</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Confirmação</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Por favor confirme a transação:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Endereço: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 ID do Pagamento: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2030,15 +2311,15 @@ Amount: </source>
 Quantidade: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Taxa: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2046,39 +2327,124 @@ Ringsize: </source>
 Ringsize: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Assinatura inválida</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Este endereço recebeu %1 monero, com %2 confirmação(ões)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Assinatura válida</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Senha incorreta</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Alerta</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Erro: Filesystem é apenas de leitura</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Aviso: Existe apenas %1 GB disponível no dispositivo. A Blockchain necessita de ~%2 GB de dados.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Atenção: Existe apenas %1 GB disponível no dispositivo. A Blockchain necessita de ~%2 GB de dados.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Aviso: Diretório do lmdb não encontrado. Um novo diretório será criado.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Erro: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>O daemon está em execução</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>O daemon continuará a ser executado no plano de fundo quando a GUI for fechada.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Parar daemon</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Nova versão da GUI do Monero disponível: %1&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Número de transações: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2087,77 +2453,73 @@ Description: </source>
 Descrição: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Quantidade incorreta: aceitável vai de %1 até %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Saldo insuficiente. Total desbloqueado: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Não foi possível enviar as moedas: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Moedas enviadas com sucesso: %1 transação(ões) </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transação salva no arquivo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Verificação de pagamento</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Este endereço recebeu %1 monero, porém a transação ainda não foi minerada</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Este endereço não recebeu moedas</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Saldo (sincronizando)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Por favor aguarde...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Assistente de configuração inicial</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>enviar ao mesmo destino</translation>
     </message>

--- a/translations/monero-core_ro.ts
+++ b/translations/monero-core_ro.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Adaugă o nouă înregistrare</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>Cod QR</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Identificator plată &lt;font size=&apos;2&apos;&gt;(Opțional)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Lipește 64 de caractere hexadecimale</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Descriere &lt;font size=&apos;2&apos;&gt;(Opțională)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Adaugă</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Adresă incorectă</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Nu s-a putut crea înregistrarea</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Dă un nume sau o descriere acestei înregistrări</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Identificator plată:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Serviciul Monero pornește în %1 secunde</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>Filtrează istoricul de tranzacții</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Introdu text pentru o căutare incrementală...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Data de la</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>La</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtrează</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Filtrare avansată</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Tipul tranzacției</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Sumă începând de la</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Identificator plată:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Nu mai sunt alte rezultate</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Detalii</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Înălțime bloc:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 confirmări)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmări) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NECONFIRMATĂ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>ÎN AȘTEPTARE</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Dată</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Sumă</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Comision</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Identificator tranzacție:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Identificator plată:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Cheia tranzacției:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Nota tranzacției:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Destinații:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Nu mai sunt alte rezultate</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 confirmări) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">NECONFIRMATĂ</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">ÎN AȘTEPTARE</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Cheie secretă de citire</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Cheie publică de citire</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Cheie secretă de cheltuială</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Cheie publică de cheltuială</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Sold</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Sold deblocat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Trimite</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Primește</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Istoric</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Agendă</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Avansat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Minat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Verifică plată</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Semnează/verifică</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Sold</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Sold deblocat</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Minat individual</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(disponibil doar pentru servicii locale)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Minatul cu propriul calculator ajută la creșterea puterii rețelei Monero. Cu cât se minează mai mult, cu atât rețeaua e mai greu de atacat și fiecare miner ajută.&lt;br&gt; &lt;br&gt;Minatul îți oferă de asemenea o mică șansă de a câștiga un pic de Monero. Calculatorul tău va crea hash-uri în căutarea de soluții pentru blocuri. Dacă descoperi un bloc, primești recompensa aferentă. Succes!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>Thread-uri CPU</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(opțional)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Minat pe fundal (experimental)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Activează minatul în timpul utilizării bateriei</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Administrare miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Pornește minatul</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Eroare la pornirea minatului</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Nu s-a putut porni minatul.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Minatul e disponibil doar pentru servicii locale. Rulează un serviciu local ca să poți să minezi.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Oprește minatul</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Stare: nu se minează</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Se minează cu %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Nu se minează</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Stare: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Sold deblocat:</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Se sincronizează</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Conectat</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Versiune incorectă</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Deconectat</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Stare conexiune incorectă</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Stare rețea</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Renunță</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Completează parola portofelului</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Completează parola portofelului pentru:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Renunță</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Se stabilește conexiunea...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Blocuri rămase: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Se sincronizează blocurile</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Identificator de plată incorect</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>ATENȚIE: nu există conexiune către serviciu</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>în fondul de tranzacții (txpool): %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 confirmări: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 confirmare: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Nu a fost găsită nicio tranzacție încă...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Tranzacție găsită</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 tranzacții găsite</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> cu mai mulți bani (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> cu prea puțini bani (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation type="unfinished">Adresa portofelului în mod &quot;doar-citire&quot;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 caractere hexadecimale</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Șterge</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Adresă integrată</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Sumă de primit</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Urmărire &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;ajutor&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Urmărire plăți</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Acesta este un sistem simplu pentru urmărirea vânzărilor:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Apasă pe &quot;Generează&quot; pentru a crea un identificator de plată aleator pentru un nou client&lt;/p&gt; &lt;p&gt;Permite clientului să scaneze codul QR pentru a face o plată (dacă clientul are posibilitatea de a scana coduri QR).&lt;/p&gt;&lt;p&gt;Această pagină va scana automat blockchain-ul și fondul de tranzacții pentru a găsi tranzacții inițiate cu acest cod QR. Dacă introduci o sumă, pagina va verifica și dacă tranzacțiile inițiate însumate ajung la valoarea respectivă.&lt;/p&gt;Este decizia ta dacă vrei să accepți tranzacții neconfirmate sau nu. Este foarte probabil că vor fi confirmate în scurt timp, dar există și posibilitatea să nu fie, așa că, pentru sume mai mari, s-ar putea să vrei să aștepți una sau mai multe confirmări.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Salvează codul QR</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Codul QR nu s-a salvat în </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Salvează ca</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Identificator plată</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generează</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generează un identificator de plată pentru o adresă integrată</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Sumă</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Noutăți</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Ajutor</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Despre</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation type="unfinished">Crează un portofel doar pentru citire</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Administrare serviciu</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Pornește serviciu</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Oprește serviciu</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Afișează starea</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Opțiuni de pornire serviciu</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(opțional)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Afișează seed-ul și cheile</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Scanează din nou soldul portofelului</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Eroare: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Informații</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished">Ieșirile au fost scanate din nou cu succes</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Localizare blockchain</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Adresa serviciului</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Nume gazdă / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Autentificare (opțional)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Nume utilizator</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Parolă</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Alege un director</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Atenție</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation type="unfinished">Eroare: Sistemul de fișiere e în mod &quot;doar-citire&quot;</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Atenție: Pe dispozitiv sunt disponibili doar %1 GB. Blockchain-ul are nevoie de ~%2 GB.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Notă: Pe dispozitiv sunt disponibili %1 GB. Blockchain-ul are nevoie de ~%2 GB.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Notă: directorul lmdb nu a fost găsit. Un nou director va fi creat.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Renunță</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Conectare</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Setări afișare</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Decorațiuni personalizate</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Nivel detalii jurnal</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(ex. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Versiune</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Versiune interfață grafică: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Versiune Monero integrată: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Jurnal serviciu</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Seed-ul și cheile portofelului</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Cheie secretă de citire</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Cheie publică de citire</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished">Cheie secretă de cheltuială</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished">Cheie publică de cheltuială</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Parolă incorectă</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Administrează portofelul</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Închide portofelul</translation>
     </message>
@@ -1001,171 +1224,186 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Semnătură corectă</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Aceasta este o semnătură corectă</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Semnătură incorectă</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Această semnatură nu trecut testul de verificare</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Semnează un mesaj sau conținutul unui fișier cu adresa ta:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Ori mesaj:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Mesajul de semnat</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Semnează</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Selectează un fișier pentru a fi semnat</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Selectează</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verifică</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Selectează un fișier pentru a fi verificat</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Ori fișier:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Numele fișierului cu mesajul de semnat</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Semnătură</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Verifică un mesaj sau o semnătură de fișier dintr-o adresă:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Mesajul de verificat</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Numele fișierului cu mesajul de verificat</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Adresa semnatară &lt;font size=&apos;2&apos;&gt;  ( Lipește  sau selectează din &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Agendă&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Renunță</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Scăzut (comision x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Mediu (comision x20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Ridicat (comision x166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Încet (comision x0.25)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>Normal (comision x1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>Rapid (comision x5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Cel mai rapid (comision x41.5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Trimis</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Primit</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Mediu</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Ridicat</translation>
     </message>
@@ -1237,252 +1470,242 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Eroare OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Prioritatea tranzacției</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Pornește serviciu&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Nivel de confidențialitate (ringsize %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Scăzut (comision x1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Mediu (comision x20)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Ridicat (comision x166)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Încet (comision x0.25)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Normal (comision x1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Rapid (comision x5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Cel mai rapid (comision x41.5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adresă &lt;font size=&apos;2&apos;&gt;  ( Lipește sau selectează din &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Agendă&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Soluționează</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Nu am găsit o adresă corectă la această adresă OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adresa a fost găsită, dar semnăturile DNSSEC nu au putut fi verificate, deci această adresă ar fi putut fi falsificată</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Nu am găsit nicio adresă corectă la această adresă OpenAlias, dar semnăturile DNSSEC nu au putut fi verificate, deci această adresă ar fi putut fi falsificată</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Eroare internă</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Nu am găsit nicio adresă</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Descriere &lt;font size=&apos;2&apos;&gt;( Opțională )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Salvat în istoricul portofelului local</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Trimite</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Afișează setările avansate</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation type="unfinished">Sweep Unmixable</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Creează fișier tranzacție</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Semnează fișier tranzacție</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Trimite fișier tranzacție</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informații</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Alege un fișier</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Pornește serviciu</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresă</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Tranzacția nesemnată nu poate fi încărcată: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Număr de tranzacții: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Tranzacția #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Destinatar: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 identificator plată: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Sumă: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Comision: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringsize: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Confirmare</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Nu se poate trimite tranzacția: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Bani trimiși cu succes</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portofelul nu este conectat la serviciu.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Servicul conectat nu este compatibil cu interfața grafică. 
 Actualizează sau conectează-te la un alt serviciu</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Se așteaptă finalizarea sincronizării serviciului</translation>
     </message>
@@ -1492,17 +1715,17 @@ Actualizează sau conectează-te la un alt serviciu</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Cost tranzacție</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Identificator plată &lt;font size=&apos;2&apos;&gt;( Opțional )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 sau 64 de caractere hexadecimale</translation>
     </message>
@@ -1510,64 +1733,77 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verifică dacă un terț a făcut o plată furnizând:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - adresa destinatarului</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - identificatorul tranzacției</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - cheia secretă a tranzacției furnizată de expeditor</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Dacă o plată a fost compusă din multe tranzacții, atunci fiecare tranzacție trebuie verificată si rezultatele trebuie combinate.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Adresa de portofel a destinatarului</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Generează</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Semnătură</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Identificator tranzacție</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Lipește identificatorul de tranzacție</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Lipește cheia tranzacției</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Verifică</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Cheia tranzacției</translation>
     </message>
 </context>
 <context>
@@ -1622,6 +1858,39 @@ Actualizează sau conectează-te la un alt serviciu</translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Crează un nou portofel</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Localizare blockchain</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(opțional)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1996,44 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Un portofel cu acelasi nume există deja. Schimbă numele portofelului</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Caracterele non-ASCII nu punt permise în cadrul căii portofelului sau în numele contului</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>FOLOSEȘTE MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Creează portofel</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation type="unfinished">Am terminat</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished">Portofelul doar pentru citire a fost creat. Poți să-l accesezi închizând portofelul curent, apăsând pe opțiunea &quot;Deschide portofel din fișier&quot; și alegând portofelul doar pentru citire din: 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Renunță</translation>
     </message>
@@ -1772,47 +2041,52 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Nume portofel</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Recuperare din seed</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Recuperare din chei</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Adresă cont (publică)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Cheie de citire (privată)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Cheie de cheltuială (privată)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Înălțimea de revenire (opțional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Portofelul tău este stocat în</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Alege un director</translation>
     </message>
@@ -1825,7 +2099,12 @@ Actualizează sau conectează-te la un alt serviciu</translation>
         <translation>Completează seed-ul mnemonic de 25 de cuvinte</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Este &lt;b&gt;foarte&lt;/b&gt; important să notezi pe hârtie acest seed și să-l ții secret. Este tot ce ai nevoie pentru a-ți păstra și recupera portofelul.</translation>
     </message>
@@ -1833,37 +2112,32 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Bine ai venit la Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Alege una dintre următoarele variante:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Crează un nou portofel</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Recuperează un portofel folosind cheile sau seed-ul mnemonic</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Deschide un fișier portofel</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Adresă personalizată serviciu (opțional)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1877,7 +2151,7 @@ Actualizează sau conectează-te la un alt serviciu</translation>
         <translation>Alege o parolă pentru portofelul tău</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Notă: această parolă nu poate fi recuperată. Dacă o uiți, va trebui să recuperezi portofelul folosind seed-ul mnemonic format din 25 de cuvinte.&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2161,12 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Parolă</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Confirmă parola</translation>
     </message>
@@ -1900,7 +2174,7 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Recuperare portofel</translation>
     </message>
@@ -1908,12 +2182,12 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Bine ai venit la Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Alege o limbă și un format regional.</translation>
     </message>
@@ -1921,107 +2195,114 @@ Actualizează sau conectează-te la un alt serviciu</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Nu am putut deschide portofelul: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Sold deblocat (min ~%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Sold deblocat</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Sold deblocat (se așteptă blocul)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Se așteaptă pornirea serviciului...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Se așteaptă oprirea serviciului...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Serviciul nu a putut fi pornit</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Verifică erorile din jurnalul portofelului și jurnalul serviciului. Poți să încerci să pornești %1 manual.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Nu s-a putut crea tranzacția: versiune incorectă a serviciului: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Nu s-a putut crea tranzacția: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation type="unfinished">No unmixable outputs to sweep</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Confirmare</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Confirmă tranzacția:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adresă: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 Identificator plată: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2030,15 +2311,15 @@ Amount: </source>
 Sumă: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Comision: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2047,39 +2328,124 @@ Ringsize: </source>
 Ringsize: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Semnătură incorectă</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Semnătură corectă</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Parolă incorectă</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Atenție</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Eroare: Sistemul de fișiere e în mod &quot;doar-citire&quot;</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Atenție: Pe dispozitiv sunt disponibili doar %1 GB. Blockchain-ul are nevoie de ~%2 GB.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Notă: Pe dispozitiv sunt disponibili %1 GB. Blockchain-ul are nevoie de ~%2 GB.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Notă: directorul lmdb nu a fost găsit. Un nou director va fi creat.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Renunță</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Eroare: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Servicul este pornit</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Serviciul va continua să ruleze pe fundal după închiderea interfeței grafice.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Oprește serviciul</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>O nouă versiune monero-wallet-gui este disponiilă: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Această adresă a primit %1 monero, având %2 confirmări.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Număr de tranzacții: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2088,77 +2454,73 @@ Description: </source>
 Descriere: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Suma e incorectă: se dorește un număr între %1 și %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Fonduri insuficiente. Sold deblocat: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Nu s-au putut trimite banii: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informații</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Banii au fost trimiși cu succes: %1 tranzacții </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Tranzacția a fost salvată în fișier: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Verificare plată</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Această adresă a primit %1 monero, dar tranzacția nu a fost încă minată</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Această adresă nu a primit nimic</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Sold (se sincronizează)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Sold</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Așteaptă...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Asistent de configurare program</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>trimite la aceeași destinație</translation>
     </message>

--- a/translations/monero-core_ro.ts
+++ b/translations/monero-core_ro.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmări) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmări)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 confirmări) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 confirmări)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_ru.ts
+++ b/translations/monero-core_ru.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Новая запись</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QR-код</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ID платежа &lt;font size=&apos;2&apos;&gt;(Опционально)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Вставьте 64 шестнадцатеричных символа</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Описание &lt;font size=&apos;2&apos;&gt;(Опционально)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Введите имя или описание</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Неправильный адрес</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Нельзя создать запись</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Payment ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Запуск демона Monero через %1 секунд</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation> выбрано: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Введите для пошагового поиска...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Дата с</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>До</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Фильтр</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Дополнительные фильтры</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Тип транзакции</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Количество от</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>ID платежа:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Получатели:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Детали</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Высота блока:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 подтверждений)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 подтверждений) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>НЕПОДТВЕРЖДЕНО</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>В ОЖИДАНИИ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Комиссия</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Количество</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">ID транзакции</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Ключ транзакции</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Примечание транзакции</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Получатели:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Нет результатов</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 подтверждений) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">НЕПОДТВЕРЖДЕНО</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">В ОЖИДАНИИ</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Баланс</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Доступный баланс</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Отправить</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Получить</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>История</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Тестовая сеть</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Адресная книга</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Дополнительно</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Майнинг</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Проверить платеж</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Войти/проверить</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Баланс</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Доступный баланс</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Соло майнинг</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(доступно только для локальных демонов)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Майнинг на вашем компьютере помогает обезопасить сеть Monero. Чем больше людей майнит, тем сложнее атаковать сеть, и каждый майнер немного помогает.&lt;br&gt; &lt;br&gt;Майнинг также дает вам маленький шанс добыть несколько монет Monero. Ваш компьютер будет искать хэшы для решения блоков. Если вы найдете блок, то получите вознаграждение. Удачи!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU потоки</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(необязательно)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Фоновый майнинг (эксперементально)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Разрешить майнинг при работе от батареи</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Настроить майнер</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Запустить майнинг</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Ошибка запуска майнинга</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Нельзя запустить майнинг&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Майнинг доступен только на локальных демонах. Запустите локальный демон, чтобы майнить</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Остановить майнинг</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Статус: майнинг выключен</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Майнинг на скорости %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Майнинг выключен</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Статус: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -515,12 +664,12 @@
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Состояние сети</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Подключен</translation>
     </message>
@@ -530,30 +679,58 @@
         <translation>Синхронизация</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Неверная версия</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Отключен</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Недопустимый статус подключения.</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Пожалуйста введите пароль кошелька</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Пожалуйста введите пароль кошелька для:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>ОК</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Установка соединения...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Блоков осталось: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Синхронизация блоков</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Неверный ID платежа</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>ВНИМАНИЕ: нет подключения к демону</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>в пуле транзакций: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 подтверждений: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 подтверждение: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Не найдено транзакций пока...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Транзакция найднеа</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 транзакций найдено</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> с достаточным количеством денег (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> с недостаточным количеством денег (% 1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Адрес кошелька только для чтения</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 шестнадцатеричных символов</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Очистить</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Интегрированный адрес</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Сохранить QR-код</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Не удалось сохранить QR-код для</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Сохранить Как</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ID платежа</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Сгенерировать ID платежа для интегрированного адреса</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Количество</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Сумма для получения</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Отслеживание &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Отслеживание платежей</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Это простой инструмент для отслеживания операций:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Нажмите «Сгенерировать», чтобы создать случайный ID платежа для нового клиента.&lt;/p&gt; &lt;p&gt;Пусть ваш клиент отсканирует QR-код, чтобы произвести платеж (если у этого клиента есть программное обеспечение, которое поддерживает сканирование QR-кодов).&lt;/p&gt;&lt;p&gt;Эта страница автоматически сканирует блокчейн и пул транзакций для входящих транзакций, используя этот QR-код. Если вы введете сумму, она также будет проверена тем, что входящие транзакции составляют эту сумму.&lt;/p&gt;Вам решать, принимать или нет неподтвержденные транзакции. Вероятно, они вскоре будут подтверждены, но есть вероятность, что они могут не подтвердится, поэтому для больших сумм вы можете подождать одного или нескольких подтверждений.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Сгенерировать</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Новости</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Помощь</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>О программе</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Порт</translation>
     </message>
 </context>
 <context>
@@ -776,396 +971,439 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Неверный пароль</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Адрес демона</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Управление кошельком</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Закрыть кошелек</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Создать кошелек только для просмотра</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Управление демоном</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Запустить демон</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Остановить демон</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Флаги запуска демона</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(необязательно)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished">Ошибка: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished">Информация</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished">Успешно пересканированые потраченые выходы</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Логин (необязательно)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Имя пользователя</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Подключить</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Настройки макета</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Пользовательские украшения</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Уровень логирования</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(Например, *: WARNING, net.p2p: DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Версия</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Версия GUI</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Версия встроенного Monero</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
-        <source>Daemon log</source>
-        <translation>Логи демона</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
+        <source>Daemon log</source>
+        <translation>Логи демона</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished">Отмена</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Имя хоста / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Показать статус</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Порт</translation>
     </message>
 </context>
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Провереная подпись</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Это провереная подпись</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Непровереная подпись</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Эта подпись не проверена</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Подпишите сообщение или содержимое файла с помощью своего адреса:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Любое сообщение:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Сообщение для подписи</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Подпись</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Пожалуйста выберите файл для подписи</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Проверить</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Или файл</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Имя файла с сообщением для подписи</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Подпись</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Проверьте сообщение или подпись файла с адреса:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Сообщение для подтверждения</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Выберите файл для подтверждения</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Имя файла с сообщением для подтверждения</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Подписывающий адрес &lt;font size=&apos;2&apos;&gt;  ( Вставить или выбрать из &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Адресная книга&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
     </message>
 </context>
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>ОК</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Низкая (х1 комиссия)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Средняя (х20 комиссия)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Высокая (х166 комиссия)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished">Стандартная (x4 комиссия) {1 ?}</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Отправить</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Получить</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Нормальный</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Средний</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Высокий</translation>
     </message>
@@ -1237,12 +1470,12 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Количество</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Приоритет транзакции</translation>
     </message>
@@ -1252,256 +1485,246 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Стоимость транзакции</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Подписать файл транзакции</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Отправить файл транзакции</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Кошелек не подключен к демону</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Ожидание синхронизации с демоном</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID платежа &lt;font size=&apos;2&apos;&gt;( Необязательно )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Запустить демон</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>Ошибка OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished">Стандартная (x4 комиссия) {1 ?}</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Адрес</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Не найдено действительного адреса на этом OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Адрес найден, но подписи DNSSEC не могут быть проверены, поэтому этот адрес может быть подделан</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>На этом адресе OpenAlias не найден действительный адрес, подписи DNSSEC не могут быть проверены, поэтому это может быть подделано</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Внутренняя ошибка</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Адрес не найден</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 или 64 шестнадцатеричных символа</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Описание &lt;font size=&apos;2&apos;&gt;( Необязательно )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Сохранено в локальной истории кошелька.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Уровень конфиденциальности (размер кольца %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Запустить демон&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Низкая (x1 комиссия)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Средняя (x20 комиссия)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Высокая (x166 комиссия)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Адрес &lt;font size=&apos;2&apos;&gt;  ( Вставить или выбрать из &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Адресная книга&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Решить</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Отправить</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Показать расширенные настройки</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Убрать несмешиваемые</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>создать файл транзакции</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Пожалуйста выберите файл</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Невозможно загрузить неподписанную транзакцию: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Число транзакций: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Танзакция #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Получатель: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 ID платежа: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Количество: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Комиссия: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Размер кольца: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Подтверждение</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Невозможно отправить транзакцию: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Деньги успешно отправлены</translation>
     </message>
@@ -1509,62 +1732,75 @@ Ringsize: </source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Убедитесь, что третье лицо осуществило платеж, предоставив:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - адрес получателя</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - ID транзакции</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - секретный ключ транзакции, предоставленный отправителем</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Адрес кошелька получателя</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>ID транзакции</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Вставить ID транзакции</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Вставить ключ транзакции</translation>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Сгенерировать</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Подпись</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Проверить</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Ключ транзакции</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Если в платеже было несколько транзакций, каждая из них должна быть проверена и результаты объединены.</translation>
     </message>
@@ -1621,6 +1857,39 @@ Ringsize: </source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Создать новый кошелек</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(необязательно)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1726,43 +1995,43 @@ Ringsize: </source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Кошелек с таким именем уже существует. Измените имя кошелька.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Символы не из таблицы ASCII не разрешены в пути к кошельку или имени аккаунта</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>ПОЛЬЗУЙТЕСЬ MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Создать кошелек</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Успешно</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Прервать</translation>
     </message>
@@ -1770,47 +2039,52 @@ Ringsize: </source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Имя кошелька</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Восстановить из seed-фразы</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Восстановить из ключей</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Адрес кошелька (публичный ключ)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Просмотреть приватный ключ</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Израсходовать приватный ключ</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Восстановление высоты (опционально)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Ваш кошелек сохранен в</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Пожалуйста выберите папку</translation>
     </message>
@@ -1823,7 +2097,12 @@ Ringsize: </source>
         <translation>Введите свою мнемоническую seed-фразу из 25 слов</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Эту seed-фразу очень важно записать и хранить в тайне. Это все что нужно для резервной копии и восстановления вашого кошелька.</translation>
     </message>
@@ -1831,37 +2110,32 @@ Ringsize: </source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Добро пожаловать в Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Выберите один из следующих вариантов:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Создать новый кошелек</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Восстановить кошелек из ключей или мнемонической seed-фразы</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Открыть кошелек из файла</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Пользовательский адрес демона (опционально)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Тестовая сеть</translation>
     </message>
@@ -1875,7 +2149,7 @@ Ringsize: </source>
         <translation>Введите НОВЫЙ пароль для вашего кошелька</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt; Примечание: этот пароль не может быть восстановлен. Если вы его забудете, то кошелек должен быть восстановлен из своей мнемонической seed-фразы с 25 словосочетаниями. &lt;br/&gt;&lt;br/&gt;
@@ -1885,12 +2159,12 @@ Ringsize: </source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Подтвердить пароль</translation>
     </message>
@@ -1898,7 +2172,7 @@ Ringsize: </source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Восстановить кошелек</translation>
     </message>
@@ -1906,12 +2180,12 @@ Ringsize: </source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Добро подаловать в Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Пожалуйста выберите язык и региональный формат.</translation>
     </message>
@@ -1919,56 +2193,58 @@ Ringsize: </source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Невозможно открыть кошелек</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Не удалось запустить демона</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Пожалуйста, проверьте ваш журнал кошелька и демона на наличие ошибок. Вы также можете попробовать запустить %1 вручную.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Невозможно создать транзакцию: Неверная версия демона</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Нет несмешиваемых выходов для развертки</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Пожалуйста подтвердите транзакцию:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -1977,7 +2253,7 @@ Amount: </source>
 Количество: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -1986,14 +2262,14 @@ Ringsize: </source>
 Размер кольца: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Количество транзакций: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2002,161 +2278,247 @@ Description: </source>
 Описание: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Сумма неправильная: ожидаемое число от %1 до %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Демон запущен</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Демон будет все еще запущен в фоновом режиме после закрытия GUI</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Остановить демона</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Доступна новая версия кошелька с графическим интерфейсом: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Невозможно создать транзакцию</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Доступный баланс (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Доступный баланс</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Ожидание запуска демона...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Ожидание остановки демона...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Подтверждение</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Адрес: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 ID платежа: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Комиссия: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Недостаточно средств. Доступный баланс: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Невозможно отправить деньги</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Транзакция сохранена в файл: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Непровереная подпись</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Этот адрес получил %1 XMR, с %2 подтверждениями</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Провереная подпись</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Баланс (синхронизация)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Баланс</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Неверный пароль</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Ошибка: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Пожалуйста, подождите...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Деньги успешно отправлены: %1 подтверждений </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Проверка платежа</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Этот адрес получил %1 XMR, но транзакции еще не подтверждены майнерами</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Этот адрес ничего не получил </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Мастер настройки программы</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>отправить тому же получателю</translation>
     </message>

--- a/translations/monero-core_ru.ts
+++ b/translations/monero-core_ru.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 подтверждений) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 подтверждений)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 подтверждений) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 подтверждений)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>
@@ -1380,7 +1380,7 @@ The old wallet cache file will be renamed and can be restored later.
     <message>
         <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
-        <translation type="unfinished">Стандартная (x4 комиссия) {1 ?}</translation>
+        <translation type="unfinished">Стандартная (x1 комиссия)</translation>
     </message>
     <message>
         <location filename="../components/StandardDropdown.qml" line="208"/>
@@ -1538,7 +1538,7 @@ The old wallet cache file will be renamed and can be restored later.
     <message>
         <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
-        <translation type="unfinished">Стандартная (x4 комиссия) {1 ?}</translation>
+        <translation type="unfinished">Стандартная (x1 комиссия)</translation>
     </message>
     <message>
         <location filename="../pages/Transfer.qml" line="196"/>

--- a/translations/monero-core_sk.ts
+++ b/translations/monero-core_sk.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 potvrdení) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 potvrdení)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 potvrdení) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 potvrdení)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_sk.ts
+++ b/translations/monero-core_sk.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Pridať novú položku</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QR kód</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>ID platby &lt;font size=&apos;2&apos;&gt;(Nepovinné)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Vložte 64 hexadecimálnych znakov</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Popis &lt;font size=&apos;2&apos;&gt;(Nepovinné)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Zadajte tejto položke názov alebo popis</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Pridať</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Neplatná adresa</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Nie je možné vytvoriť položku</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>ID platby:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Spustenie Monero démona za %1 sekúnd</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>Filtrovať históriu transakcií</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Píšte sem pre inkrementálne vyhľadávanie...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Dátum od</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Rozšírené filtrovanie</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Typ transakcie</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Suma od</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>ID platby:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Žiadne ďalšie výsledky</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Detaily</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Výška bloku:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 potvrdení)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 potvrdení) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>NEPOTVRDENÉ</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>ČAKÁ SA</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Poplatok</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">ID transakcie:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">ID platby:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Kľúč transakcie:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Poznámka transakcie:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Ciele:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Žiadne ďalšie výsledky</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 potvrdení) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">NEPOTVRDENÉ</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">ČAKÁ SA</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Tajný kľúč na zobrazenie</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Verejný kľúč na zobrazenie</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Tajný kľúč na platenie</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Verejný kľúč na platenie</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Zostatok</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Odomknutý zostatok</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Odoslať</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Prijať</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>História</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Adresár</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Pokročilé</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Ťažba</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Skontrolovať platbu</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Podpísať/overiť</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Zostatok</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Odomknutý zostatok</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Sólo ťažba</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(k dispozícii iba pre lokálnych démonov)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Ťažba s Vašim počítačom pomáha posilniť sieť Monero. Čím viac ľudí ťaží, tým je náročnejšie zaútočiť na sieť, a každý malý kúsok pomáha.&lt;br&gt; &lt;br&gt;Ťažba Vám taktiež dáva malú šancu zarobiť nejaké Monero. Váš počítač bude vytvárať haše hľadaním riešenia v bloku. Ak nájdete blok, dostanete s tým súvisiacu odmenu. Veľa šťastia!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>Vlákna procesora</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(nepovinné)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Ťažba na pozadí (experimentálna)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Povoliť ťažbu pri behu na batériu</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Spravovať ťažbu</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Spustiť ťažbu</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Chyba pri spúšťaní ťažby</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Nepodarilo sa spustiť ťažbu.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Ťažba k dispozícii iba pre lokálnych démonov. Spustite lokálneho démona, aby ste mohli ťažiť.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Zastaviť ťažbu</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Stav: neťaží sa</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Ťaží sa rýchlosťou %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Neťaží sa</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Stav:</translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Odomknutý Zostatok:</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Synchronizuje sa</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Pripojené</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Nesprávna verzia</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Odpojené</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Neplatný stav pripojenia</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Stav siete</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušiť</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Zadajte prosím heslo pre peňaženku</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Zadajte prosím heslo pre peňaženku:</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Vytváranie pripojenia...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Zostávajúcich blokov: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Synchronizácia blokov</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Neplatné ID platby</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>VAROVANIE: žiadne pripojenie k démonovi</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>v txpool-e: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 potvrdení: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 potvrdenie: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Zatiaľ sa nenašli žiadne transakcie...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Transakcia bola nájdená</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 nájdených transakcií</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> s viac peniazmi (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> s nedostatkom peňazí (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Tu sa zobrazuje (ReadOnly) adresa peňaženky</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 hexadecimálnych znakov</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Vymazať</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Integrovaná adresa</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Suma na prijatie</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Sledovanie &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;pomoc&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Sledovanie platieb</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Jedná sa o jednoduché sledovanie predaja:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Kliknutím na Generovať vytvoríte náhodné ID platby pre nového zákazníka&lt;/p&gt; &lt;p&gt;Nechajte Vášho zákazníka oskenovať tento QR kód, aby vykonal platbu (ak má tento zákazník softvér, ktorý podporuje skenovanie QR kódu).&lt;/p&gt;&lt;p&gt;Táto stránka bude automaticky prehľadávať blockchain a transakčný pool kôli prichádzajúcim transakciám vykonaných s týmto QR kódom. Ak zadáte čiastku, taktiež skontroluje, či prichádzajúca transakcia dosiahla túto sumu.&lt;/p&gt;je na Vás, či akceptujete nepotvrdené transakcie alebo nie. je pravdepodobné, že budú potvrdené v krátkom čase, ale stále existuje možnosť, že nemusia byť, takže pri väčších sumách možno budete chcieť počkať na jedno alebo viac potvrdení.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Uložiť QR kód</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Nepodarilo sa uložiť QR kód</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Uložiť Ako</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>ID platby</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generovať</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generovať ID platby pre integrovanú adresu</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Správy</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Pomoc</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>O aplikácii</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Vytvoriť peňaženku len na sledovanie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Správa démona</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Spustenie démona</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Zastavenie démona</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Zobraziť stav</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Štartovacie flag-y démona</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(nepovinné)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Zobraziť seed &amp; kľúče</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Znovu načítať zostatok na peňaženke</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Chyba: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Informácie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Úspešne načítané minuté výstupy</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Umiestnenie blockchain-u</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Adresa démona</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Názov hostiteľa / IP</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Prihlasovacie meno (nepovinné)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Meno používateľa</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Heslo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Pripojiť</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Nastavenia rozloženia</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Vlastné dekorácie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Úroveň logovania</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(napr. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Verzia</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>Verzia GUI: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Verzia integrovaného Monero: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Záznamy démona</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Prosím, vyberte priečinok</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Varovanie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Chyba: Súborový systém je iba na čítanie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Varovanie: Na zariadení je k dispozícii iba %1 GB. Blockchain vyžaduje ~%2 GB dát.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Poznámka: Na zariadení je k dispozícii %1 GB. Blockchain vyžaduje ~%2 GB dát.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Poznámka: priečinok lmdb nebol nájdený. Bude vytvorený nový priečinok.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Seed &amp; kľúče peňaženky</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Tajný kľúč na zobrazenie</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Verejný kľúč na zobrazenie</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>Tajný kľúč na platenie</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>Verejný kľúč na platenie</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Zlé heslo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Správa peňaženky</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Zatvoriť peňaženku</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Dobrý podpis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Toto je dobrý podpis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Zlý podpis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Tento podpis nebol overený</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Podpísať správu alebo obsah súboru s Vašou adresou:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Alebo správu:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Správa na podpis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Podpísať</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Vyberte súbor, ktorý chcete podpísať</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Overiť</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Vyberte súbor, ktorý chcete overiť</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Podpisová adresa &lt;font size=&apos;2&apos;&gt;  ( Vložte alebo vyberte z &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresára&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Alebo súbor:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Názov súboru so správou na podpísanie</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Overenie správy alebo podpisu súboru z adresy:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Správa na overenie</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Názov súboru so správou na overenie</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Nízky (x1 poplatok)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Stredný (x20 poplatok)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Vysoký (x166 poplatok)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Pomalý (x0.25 poplatok)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>Štandardný (x1 poplatok)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>Rýchly (x5 poplatok)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Najrýchlejší (x41.5 poplatok)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Všetko</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Odoslané</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Prijaté</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normálna</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Stredná</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Vysoká</translation>
     </message>
@@ -1237,232 +1470,222 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Spustiť démona&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAlias chyba</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Úroveň súkromia (ringsize %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Priorita transakcie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Všteko</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Nízka (x1 poplatok)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Stredná (x20 poplatok)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Vysoká (x166 poplatok)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adresa &lt;font size=&apos;2&apos;&gt;  ( Vložte alebo vyberte z &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresára&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Vyriešiť</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Na tejto adrese OpenAlias sa nenašla platná adresa</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adresa sa našla, ale podpisy DNSSEC sa nepodarilo overiť, takže táto adresa môže byť falošná</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Na tejto adrese OpenAlias sa nenašla žiadna platná adresa, ale podpisy DNSSEC sa nedali overiť, takže to môže byť falošné</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Vnútorná chyba</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Adresa nebola nájdená</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Popis &lt;font size=&apos;2&apos;&gt;( Nepovinné )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Uložené do histórie lokálnej peňaženky</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Odoslať</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Zobraziť rozšírené možnosti</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Vyčistiť nezmiešateľné čiastky</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Vytvoriť transakčný súbor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Podpísať transakčný súbor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Odoslať transakčný súbor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Informácie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Prosím, vyberte súbor</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Spustenie démona</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adresa</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Nemožno načítať nepodpísané transakcie: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Počet transakcií: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transakcia #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Príjemca: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 ID platby: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Suma: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Poplatok:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringsize: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Potvrdenie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Nemožno odoslať transakciu: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Peniaze boli úspešne odoslané</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Peňaženka nie je pripojená k démonovi.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Pripojený démon nie je kompatibilný s GUI. 
 Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Čakanie na dokončenie synchronizácie démona</translation>
     </message>
@@ -1472,37 +1695,37 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Transakčné náklady</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>ID platby &lt;font size=&apos;2&apos;&gt;( Nepovinné )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Pomalý (x0.25 poplatok)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Štandardný (x1 poplatok)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Rýchly (x5 poplatok)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Najrýchlejší (x41.5 poplatok)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 alebo 64 hexadecimálnych znakov</translation>
     </message>
@@ -1510,64 +1733,77 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Overte, či tretia strana uskutočnila platbu poskytnutím:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - adresa príjemcu</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - ID transakcie</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - tajný kľúč transakcie poskytnutý odosielateľom</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Ak má platba niekoľko transakcií, potom je potrebné každú skontrolovať a skombinovať výsledky.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Adresa peňaženky príjemcu</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Generovať</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Podpis</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>ID transakcie</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Vložte ID transakcie</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Vložte kľúč transakcie</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Skontrolovať</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Kľúč transakcie</translation>
     </message>
 </context>
 <context>
@@ -1622,6 +1858,39 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Vytvoriť novú peňaženku</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Umiestnenie blockchain-u</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(nepovinné)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1996,44 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>Peňaženka s rovnakým názvom už existuje. Zmeňte prosím názov peňaženky</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Znaky iné ako ASCII nie sú povolené v ceste peňaženky alebo v názve konta</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>POUŽIŤ MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Vytvoriť peňaženku</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Úspešné</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>Peňaženka len na zobrazenie bola vytvorená. Otvoriť ju môžete zatvorením aktuálnej peňaženky, kliknutím na možnosť &quot;Otvoriť peňaženku zo súboru&quot;, a vybratím peňaženky len na zobrazenie v: 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Prerušiť</translation>
     </message>
@@ -1772,47 +2041,52 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Názov peňaženky</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Obnoviť zo seed-u</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Obnoviť z kľúčov</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Adresa konta (verejná)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Kľúč na zobrazenie (súkromný)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Kľúč na platenie (súkromný)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Obnoviť výšku (nepovinné)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Vaša peňaženka je uložená v</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Prosím, vyberte priečinok</translation>
     </message>
@@ -1825,7 +2099,12 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
         <translation>Zadajte svoj 25 slovný mnemotechnický seed</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>tento seed je &lt;b&gt;veľmi&lt;/b&gt; dôležité si zapísať a uchovať v tajnosti. Je to všetko, čo potrebujete na zálohovanie a obnovenie peňaženky.</translation>
     </message>
@@ -1833,37 +2112,32 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Vitajte v Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Vyberte prosím jednu z nasledujúcich možností:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Vytvoriť novú peňaženku</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Obnoviť peňaženku z kľúčov alebo mnemotechnického seed-u</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Otvoriť peňaženku zo súboru</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Vlastná adresa démona (nepovinné)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
@@ -1877,7 +2151,7 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
         <translation>Dajte Vašej peňaženke heslo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Poznámka: toto heslo nie je možné obnoviť. Ak ho zabudnete, bude potrebné obnoviť peňaženku z jej 25 slovného mnemotechnického seed-u.&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2161,12 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Heslo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Potvrďte heslo</translation>
     </message>
@@ -1900,7 +2174,7 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Obnoviť peňaženku</translation>
     </message>
@@ -1908,12 +2182,12 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Vitajte v Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Prosím, vyberte jazyk a regionálny formát.</translation>
     </message>
@@ -1921,107 +2195,114 @@ Prosím aktualizujte, alebo pripojte k inému démonovi</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Nepodarilo sa otvoriť peňaženku: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Odomknutý zostatok (čaká na blok)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Odomknutý zostatok (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Odomknutý zostatok</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Čakanie na spustenie démona...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Čaká sa na zastavenie démona...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Démon sa nepodarilo spustiť</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Prosím, skontrolujte chyby v log-och peňaženky a démona. Môžete sa tiež pokúsiť spustiť %1 ručne.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Nemožno vytvoriť transakciu: Chybná verzia démona: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Nemožno vytvoriť transakciu: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Žiadne nezmiešateľné čiastky na vyčistenie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Potvrdenie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Prosím potvrďte transakciu:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adresa: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 ID platby: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2030,15 +2311,15 @@ Amount: </source>
 Suma: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Poplatok: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2047,39 +2328,124 @@ Ringsize: </source>
 Ringsize: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Zlý podpis</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Táto adresa prijala %1 monero, s %2 potvrdeniami.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Dobrý podpis</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Zlé heslo</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Varovanie</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Chyba: Súborový systém je iba na čítanie</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Varovanie: Na zariadení je k dispozícii iba %1 GB. Blockchain vyžaduje ~%2 GB dát.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Poznámka: Na zariadení je k dispozícii %1 GB. Blockchain vyžaduje ~%2 GB dát.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Poznámka: priečinok lmdb nebol nájdený. Bude vytvorený nový priečinok.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Zrušiť</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Chyba: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Démon beží</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Démon bude stále bežať na pozadí, keď sa GUI zavrie.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Zastavenie démona</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>K dispozícii je nová verzia monero-wallet-gui: %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Počet transakcií: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2088,77 +2454,73 @@ Description: </source>
 Popis: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Suma je nesprávna: očakávané číslo od %1 do %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Nedostatok prostriedkov. Odomknutý zostatok: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Peniaze nebolo možné poslať: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Informácie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Peniaze boli úspešne odoslané: %1 transakcií</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transakcia bola uložená do súboru: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>Kontrola platby</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Táto adresa prijala %1 monero, ale transakcia ešte nebola vyťažená</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Táto adresa neprijala nič</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Zostatok (synchronizácia)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Zostatok</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Prosím čakajte...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Sprievodca nastavením programu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>odoslať do rovnakého cieľa</translation>
     </message>

--- a/translations/monero-core_sv.ts
+++ b/translations/monero-core_sv.ts
@@ -1,65 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="sv_SE">
+<TS version="2.1" language="sv_SE">
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>Lägg till post</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QRKOD</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Betalnings-ID &lt;font size=&apos;2&apos;&gt;(Valfritt)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Klistra in 64 hexadecimala tecken</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Beskrivning &lt;font size=&apos;2&apos;&gt;(Valfritt)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>Ge den här posten ett namn eller beskrivning</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>Ogiltig adress</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>Kan inte skapa post</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>Betalnings-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>Monero-nod startar om %1 sekunder</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation> vald: </translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>Filtrera</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>Skriv för inkrementell sökning...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>Datum från</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>Till</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>Avancerad filtrering</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>Typ av överföring</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>Belopp från</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>Betalnings-ID:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>Mottagare:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>Blockhöjd:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
+        <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
         <translation>(%1/%2 bekräftelser)</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>OBEKRÄFTAD</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>VÄNTAR</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>Avgift</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>Belopp</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">Tx-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">Betalnings-ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">Tx-nyckel:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">Tx-notering:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">Mottagare:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">Inga fler resultat</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/%2 bekräftelser)</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">OBEKRÄFTAD</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">VÄNTAR</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">Hemlig läsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">Publik läsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">Hemlig spenderingsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">Publik spenderingsnyckel</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>Olåst saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>Skicka</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>Ta emot</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>Historik</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>Adressbok</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>Avancerat</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>Utvinning</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>Kontrollera betalning</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>Signera/verifiera</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>Olåst saldo</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>Enskild utvinning</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(endast tillgängligt för lokala noder)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Utvinning med din dator hjälper till att stärka Monero-nätverket. Ju mer som folk utvinner, ju svårare blir det för nätverket att angripas, och varje litet bidrag hjälper till.&lt;br&gt; &lt;br&gt;Utvinning ger dig även en liten möjlighet att tjäna några Monero. Din dator kommer att leta efter lösningar för block genom att skapa hashar. Om du hittar ett block får du den tillhörande belöningen. Lycka till!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU-trådar</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(valfritt)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>Bakgrundsutvinning (experimentell)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>Aktivera utvinning vid batteridrift</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>Hantera utvinnare</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>Starta utvinning</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>Fel vid start av utvinning</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Kunde inte starta utvinning.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Utvinning är endast tillgängligt för lokala noder. Kör en lokal nod för att kunna utvinna.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>Stoppa utvinning</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>Status: ingen utvinning</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>Utvinner med %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>Ingen utvinning</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>Status: </translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>Olåst saldo:</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>Synkroniserar</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>Ansluten</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>Fel version</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>Frånkopplad</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>Ogiltig anslutningsstatus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>Nätverksstatus</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>Ange plånbokslösenord</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>Ange plånbokslösenord för:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>Upprättar anslutning...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>Återstående block: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>Synkroniserar block</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>Ogiltigt betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>VARNING: ingen anslutning till nod</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>i tx-poolen: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 bekräftelser: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 bekräftelse: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>Ingen överföring har hittats ännu...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>Överföring hittad</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>%1 överföring hittad</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation> med mer pengar (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation> med för lite pengar (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>Adress för endast läsbar plånbok visas här</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 hexadecimala tecken</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>Integrerad adress</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>Misslyckade att spara QR-kod till </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>Spara som</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>Rensa</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>Generera betalnings-ID för integrerad adress</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>Spåra betalningar</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Detta är en enkel försäljningsspårare:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klicka för att generera ett slumpmässigt betalnings-id för en ny kund&lt;/p&gt; &lt;p&gt;Låt din kund läsa in den där QR-koden för att göra en betalning (om den kunden har programvara som stödjer inläsning av QR-koder).&lt;/p&gt;&lt;p&gt;Denna sida kommer automatiskt läsa in blockkedjan och tx-poolen för inkommande överföringar till dig oavsett du accepterar obekräftade överföringar eller inte. Det är troligt de blir bekräftade inom kort, men det är fortfarande en möjlighet att de inte blir det, så för större belopp vill du nog vänta på en eller fler bekräftelser.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>Spara QR-kod</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>Betalnings-ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>Belopp</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>Belopp att ta emot</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Spårning &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>Generera</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>Twitter</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>Nyheter</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>Hjälp</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>Om</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">Port</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>Adress för nod</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>Hantera plånbok</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>Stäng plånbok</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>Skapa plånbok för endast läsning</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>Visa frö &amp; nycklar</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>Läs om plånbokens saldo</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>Fel: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>Spenderade utgångar har lästs om</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>Hantera nod</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>Starta lokal nod</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>Stoppa lokal nod</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>Blockkedjans plats</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>Startflaggor för nod</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>Värdnamn / IP</translation>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>Lösenord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>Inbäddad Monero-version:</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>Nodlogg</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>Välj en katalog</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>Fel: Filsystem är endast läsbart</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Varning: Det är endast %1 GB tillgängligt på enheten. Blockkedjan kräver ~%2 GB av data.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Notera: Det är %1 GB tillgängligt på enheten. Blockkedjan kräver ~%2 GB av data.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>Notera: lmdb katalog hittades inte. En ny katalog kommer att skapas.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>Plånboksfrö &amp; nycklar</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>Hemlig läsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>Publik läsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>Hemlig spenderingsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>Publik spenderingsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>Fel lösenord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>Visa status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>Port</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(valfritt)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>Inloggning (valfritt)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>Användarnamn</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>Anslut</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>Inställningar för utformning</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>Anpassade dekorationer</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>Loggnivå</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(t. ex. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>Version</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI-version:</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>Godkänd signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>Detta är en godkänd signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>Felaktig signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>Denna signatur kunde inte verifieras</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>Signera ett meddelande eller fil-innehåll med din adress:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>Antingen meddelande:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>Meddelande att signera</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>Signera</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>Välj en fil att signera</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>Välj</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>Verifiera</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>Välj en fil att verifiera</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signeringsadress &lt;font size=&apos;2&apos;&gt;  ( Klistra in eller välj från &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adressbok&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>Eller fil:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>Filnamn med meddelande att signera</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>Signatur</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>Verifiera ett meddelande eller fil-signatur från en adress:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>Meddelande att verifiera</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>Filnamn med meddelande att verifiera</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>Ok</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>Låg (x1 avgift)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>Medel (x20 avgift)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>Hög (x166 avgift)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Långsam (x0.25 avgift)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>Standard (x1 avgift)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>Snabb (x5 avgift)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Snabbast (x41.5 avgift)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>Alla</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>Skickade</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>Mottagna</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>Normal</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>Medel</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>Hög</translation>
     </message>
@@ -1237,12 +1470,12 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>Belopp</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>Överföringsprioritet</translation>
     </message>
@@ -1252,257 +1485,247 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>Överföringskostnad</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAlias-fel</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>Integritetsnivå (ringstorlek %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Starta lokal nod&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>Låg (x1 avgift)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>Medel (x20 avgift)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>Hög (x166 avgift)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Långsam (x0.25 avgift)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>Standard (x1 avgift)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>Snabb (x5 avgift)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Snabbast (x41.5 avgift)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Adress &lt;font size=&apos;2&apos;&gt;  ( Klistra in eller välj från &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adressbok&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR-kod</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>Lös</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Ingen giltig adress hittades vid denna OpenAlias-adress</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adress hittad, men DNSSEC-signaturer kunde inte verifieras, så denna adress kan vara förfalskad</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Ingen giltig adress hittades vid denna OpenAlias-adress, men DNSSEC-signaturer kunde inte verifieras, så den kan vara förfalskad</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>Internt fel</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>Ingen adress hittad</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Beskrivning &lt;font size=&apos;2&apos;&gt;( Valfritt )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>Sparad till historik för lokal plånbok</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>Skicka</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>Visa avancerade inställningar</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>Städa bort omixbara</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>Skapa tx-fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>Allt</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>Signera tx-fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>Sänd tx-fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>Välj en fil</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">Starta lokal nod</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">Adress</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Kan inte läsa in osignerade överföringar: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 Antal överföringar: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 Överföring #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 Mottagare:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 Belopp: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 Avgift: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringstorlek:</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>Bekräftelse</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Kan inte sända överföring: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>Lyckades skicka pengar</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="699"/>
-        <location filename="../pages/Transfer.qml" line="711"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Plånboken är inte ansluten till nod.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="714"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Ansluten nod är inte kompatibel med GUI.
 Uppgradera eller anslut till en annan nod</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Väntar på att nod-synkronisering blir färdig</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Betalnings-ID &lt;font size=&apos;2&apos;&gt;( Valfritt )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 eller 64 hexadecimala tecken</translation>
     </message>
@@ -1510,72 +1733,77 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>Verifiera att en tredje part genomfört en betalning genom att tillhandahålla:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - mottagaradressen</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - överföringens id</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Om en betalning har flera överföringar måste var och en kontrolleras och resultaten läggas samman.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Adress till mottagarens plånbok</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">Generera</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">Signatur</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>Överförings-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>Klistra in tx-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>Klistra in tx-nyckeln</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - den hemliga överföringsnyckeln som tillhandahölls av avsändaren</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>Överföringsnyckel</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>Kontrollera</translation>
-    </message>
-</context>
-<context>
-    <name>WalletManager</name>
-    <message>
-        <location filename="../src/libwalletqt/WalletManager.cpp" line="153"/>
-        <source>Unknown error</source>
-        <translation>Okänt fel</translation>
     </message>
 </context>
 <context>
@@ -1630,6 +1858,39 @@ Uppgradera eller anslut till en annan nod</translation>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>Skapa en ny plånbok</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">Blockkedjans plats</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(valfritt)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1735,44 +1996,44 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>En plånbok med samma namn finns redan. Byt namn på plånbok</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>ANVÄND MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>Endast ASCII-tecken är tillåtna i plånbokens sökväg och kontonamn</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>Skapa plånbok</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>Lyckades</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>Plånboken för endast läsning har skapats. Du kan öppna den genom att stänga den nuvarande plånboken, klicka på &quot;Öppna en plånbok från fil&quot; alternativet, och välja plånboken: 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>Avbryt</translation>
     </message>
@@ -1780,47 +2041,52 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>Din plånbok lagras i</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>Välj en katalog</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>Plånboksnamn</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>Återskapa från frö</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>Återställ från nycklar</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>Kontoadress (publikt)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>Läsnyckel (privat)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Spenderarnyckel (privat)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>Återställningshöjd (valfritt)</translation>
     </message>
@@ -1833,7 +2099,12 @@ Uppgradera eller anslut till en annan nod</translation>
         <translation>Ange ditt 25-ords minnesfrö</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Detta frö är &lt;b&gt;väldigt&lt;/b&gt; viktigt att skriva ner och att hålla hemligt. Det är allt du behöver för att säkerhetskopiera och återställa din plånbok.</translation>
     </message>
@@ -1841,39 +2112,34 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>Välkommen till Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>Välj en av följande inställningar:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>Skapa en ny plånbok</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Återskapa plånbok från nycklar eller minnesfrö</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>Öppna en plånbok från fil</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>Anpassad adress för nod (valfritt)</translation>
     </message>
 </context>
 <context>
@@ -1885,7 +2151,7 @@ Uppgradera eller anslut till en annan nod</translation>
         <translation>Ge din plånbok ett lösenord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation> &lt;br&gt;Notera: detta lösenord kan inte återställas. Om du glömmer det måste plånboken återställas från sitt 25-ords minnesfrö.&lt;br/&gt;&lt;br/&gt;
@@ -1895,12 +2161,12 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>Lösenord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>Bekräfta lösenord</translation>
     </message>
@@ -1908,7 +2174,7 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>Återskapa plånbok</translation>
     </message>
@@ -1916,12 +2182,12 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>Välkommen till Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>Vänligen ange ett språk och regionalt format.</translation>
     </message>
@@ -1929,38 +2195,40 @@ Uppgradera eller anslut till en annan nod</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="329"/>
-        <location filename="../main.qml" line="497"/>
-        <location filename="../main.qml" line="509"/>
-        <location filename="../main.qml" line="559"/>
-        <location filename="../main.qml" line="571"/>
-        <location filename="../main.qml" line="613"/>
-        <location filename="../main.qml" line="622"/>
-        <location filename="../main.qml" line="674"/>
-        <location filename="../main.qml" line="712"/>
-        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="330"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Kunde inte öppna plånbok:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="499"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Kan inte skapa överföring: Felaktig nod-version: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="510"/>
-        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Inga omixbara utgångar att städa bort</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="526"/>
-        <location filename="../main.qml" line="637"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -1969,14 +2237,14 @@ Amount: </source>
 Belopp: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="529"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 Antal överföringar: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="530"/>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -1985,111 +2253,107 @@ Description: </source>
 Beskrivning: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="560"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Beloppet är felaktigt: borde varit mellan %1 och %2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="684"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation>Lyckades skicka pengar: %1 överföring(ar)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="724"/>
-        <source>Payment check</source>
-        <translation>Betalningskontroll</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="501"/>
-        <location filename="../main.qml" line="614"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Kan inte skapa överföring: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
-        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>Bekräftelse</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 Adress: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="525"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 Betalnings-ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="527"/>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>
 Avgift: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="361"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Olåst saldo (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Otillräckliga tillgångar. Olåst saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="675"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Kunde inte skicka pengar: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="419"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Väntar på att noden ska avsluta...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="444"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>Noden misslyckades att starta</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="445"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Kontrollera din plånbok och nod-logg efter fel. Du kan också försöka starta %1 manuellt.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="985"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>Vänta...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1009"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>Konfigurationsguide</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1024"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1072"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>skicka till samma mottagare</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="528"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2098,75 +2362,165 @@ Ringsize: </source>
 Ringstorlek:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="729"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Denna adress tog emot %1 monero, men överföringen har ännu inte bekräftats</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>Denna adress tog emot ingenting</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="684"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>Överföring sparad till fil: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="361"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>Olåst saldo (väntar på block)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="361"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>Olåst saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>Vänta på att nod startar...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
-        <location filename="../main.qml" line="636"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>Bekräfta överföring:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="734"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">Felaktig signatur</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Denna adress tog emot %1 monero, med %2 bekräftelse(r).</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="750"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">Godkänd signatur</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>Saldo (synkroniserar)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="750"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1324"/>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">Fel lösenord</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">Varning</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">Fel: Filsystem är endast läsbart</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Varning: Det är endast %1 GB tillgängligt på enheten. Blockkedjan kräver ~%2 GB av data.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">Notera: Det är %1 GB tillgängligt på enheten. Blockkedjan kräver ~%2 GB av data.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">Notera: lmdb katalog hittades inte. En ny katalog kommer att skapas.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">Fel: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>Nod körs</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1325"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Noden kommer fortfarande att köras i bakgrunden när applikationen stängts ner.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1327"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>Stoppa nod</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1361"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Ny version av monero-wallet-gui finns tillgänglig: %1&lt;br&gt;%2</translation>
     </message>

--- a/translations/monero-core_zh-cn.ts
+++ b/translations/monero-core_zh-cn.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 次确认) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 次确认)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 次确认) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 次确认)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>

--- a/translations/monero-core_zh-cn.ts
+++ b/translations/monero-core_zh-cn.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>新增付款地址</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>二维码</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>付款ID &lt;font size=&apos;2&apos;&gt;(可选填)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>粘贴上16进制字符串的地址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>描述 &lt;font size=&apos;2&apos;&gt;(选填)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>给予这个地址一个名称或描述</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>无效的地址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>无法新增地址</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>付款ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>在 %1 秒后启动Monero区块同步程序</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>交易纪录查询</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>输入查询条件...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>查询</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>日期从</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>到</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>高级查询</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>交易类型</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>金额从</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>付款ID:</translation>
     </message>
@@ -255,150 +260,294 @@
         <translation>没有更多了</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>详情</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>区块高度:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 次确认)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 次确认) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>未确认的交易</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>待确认的交易</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>手续费</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">转账ID(Tx ID):</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">付款ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">转账密钥(Tx key):</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">转账备注:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">目标:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">没有更多了</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 次确认) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">未确认的交易</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">待确认的交易</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>余额</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>可用余额</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>收款</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>历史纪录</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>连接到测试网络</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>地址簿</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>高级功能</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>挖矿</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>交易检查</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>签名/验证</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>钱包设置</translation>
     </message>
@@ -406,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>总余额</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>可用余额</translation>
     </message>
@@ -419,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>独立挖矿(Solo mining)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(仅限于使用本地区块同步程序)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>挖矿可增进 Monero 网络的安全性，只要越多使用者在挖矿，Monero 网络就会越难以被攻击。&lt;br&gt; &lt;br&gt;挖矿同时能让您有机会赚取额外的门罗币，因为在挖矿时，您的计算机将被用来寻找 Monero 区块的解答，每当您找到一个区块的解答，您即可以获得其附带的门罗币奖励，祝您好运！</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU线程数量</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(选填)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>后台挖矿(实验性功能)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>允许在使用电池时挖矿</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>挖矿管理</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>开始挖矿</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>启动挖矿时发生错误</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>无法启动挖矿&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>仅能使用本地区块同步程序进行挖矿，请先执行本地区块同步程序&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>停止挖矿</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>状态: 没有在进行挖矿</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>目前挖矿速率为 %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>没有在进行挖矿</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>状态:</translation>
     </message>
@@ -507,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation type="unfinished">可用余额:</translation>
     </message>
@@ -520,40 +669,68 @@
         <translation>同步区块中</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>已连接</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>版本错误</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>已断开连接</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>无效的连接状态</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>网络同步状态</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>请输入钱包的密码</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>请输入以下钱包的密码:&lt;br&gt;</translation>
     </message>
@@ -563,9 +740,9 @@
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>确定</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -589,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>建立连接中...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>剩余区块数量: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>同步区块中</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -612,152 +797,162 @@
         <translation>无效的付款ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>警告: 没有与区块同步程序(daemon)建立连接</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>在交易池中(txpool): %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 交易确认: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 交易确认: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>目前没有交易...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>已找到交易信息</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>已找到 %1 笔交易信息</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>尚有金额 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>金额不足 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>只读钱包的地址会显示在这</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16个十六进制字符</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>清除</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>整合地址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>欲接收的金额</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           追踪中 &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>追踪支付款</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;这是一个简易的收款追踪功能:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;在每次交易时请点击&quot;产生&quot;一个随机的付款ID&lt;/p&gt; &lt;p&gt;让您的付款对象扫描二维码 (如果对象的软件支持QR扫描的话)&lt;/p&gt;&lt;p&gt;这个页面将会自动寻找您在区块链或交易池里即将收到的款项，如果您有输入金额，本功能亦会进行确认即将收到款项的总金额&lt;/p&gt;您可以自行决定是否要在确认完成前认可此份交易，通常交易在短时间都能完成确认，但有时则否，所以当您在交易比较大金额的款项时最好能等待至少一个或数个确认次数。&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>储存 二维码</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>无法储存 二维码至</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>付款ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>产生</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>按下产生付款ID以获得整合地址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>推特</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>最新消息</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>帮助</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>关于</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">通讯端口</translation>
     </message>
 </context>
 <context>
@@ -776,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>创建只读钱包(view only wallet)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>管理区块同步程序(daemon)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>启动区块同步程序</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>停止区块同步程序</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>显示状态</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>区块同步程序启动flags</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(选填)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation type="unfinished">错误: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation type="unfinished">重新扫描付款成功</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>区块同步程序位置</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>主机名/IP地址</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>通讯端口</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>登入(选填)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>用户名</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>密码</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>连接</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>版面设置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>窗口化自定义</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>日志级别</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>版本</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI 版本: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>内嵌Monero版本: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
-        <source>Daemon log</source>
-        <translation>区块同步程序日志</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="573"/>
-        <source>Please choose a folder</source>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
-        <source>Warning</source>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
-        <source>Error: Filesystem is read only</source>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
-        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
-        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
-        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
+        <source>Daemon log</source>
+        <translation>区块同步程序日志</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="618"/>
+        <source>Please choose a folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="627"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="630"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="634"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="636"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="640"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>密码错误</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>管理钱包</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>关闭钱包</translation>
     </message>
@@ -1001,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>签名正确</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>这份签名正确</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>签名不正确</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>这份签名无法通过验证</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>用你的地址签名一份信息或文件内容:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>签名信息:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>欲签名的信息</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>签名</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>请选择一个欲签名的文件</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>选择文件</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>验证</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>请选择一个欲验证的文件</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            签名来源之地址&lt;font size=&apos;2&apos;&gt; ( 粘帖上或从&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;地址簿&lt;/a&gt; &lt;font size=&apos;2&apos;&gt; 中选择 )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>或文件:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>要签名信息的文件名</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>签名结果</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>验证从某个地址所签名的信息或文件:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>欲验证的信息</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>附带签名信息的文件名</translation>
     </message>
@@ -1107,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>确定</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>低 (1倍手续费)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>中 (20倍手续费)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>高 (166倍手续费)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>收款</translation>
     </message>
@@ -1220,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>正常</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>中</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>高</translation>
     </message>
@@ -1237,252 +1470,242 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAlias 错误</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>隐私等级 (环签名大小: %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;启动区块同步程序&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>交易优先级</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>低 (1倍手续费)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>中 (20倍手续费)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>高 (166倍手续费)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      地址&lt;font size=&apos;2&apos;&gt; ( 粘帖上或从&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;地址簿&lt;/a&gt; &lt;font size=&apos;2&apos;&gt; 中选择 )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>解析</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>无效的 OpenAlias 地址</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>已找到地址，但无法验证其 DNSSEC 的签名，此地址有可能受到欺骗攻击的风险</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>无法找到有效地址，但无法验证其 DNSSEC 的签名，此地址有可能受到欺骗攻击的风险</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>内部错误</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>没有找到地址</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>描述 &lt;font size=&apos;2&apos;&gt;( 选填 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>储存至本机钱包纪录</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>显示高级选项</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>去除无法混淆的金额</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>创建交易文件(tx file)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>签名一个交易文件</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>提交交易文件</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>请选择一个文件</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">启动区块同步程序</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">地址</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>无法加载未签名的交易: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 交易数量: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 交易 #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 接收方: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 付款ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 金额: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 手续费: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 环签名大小: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>无法提交交易: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>付款成功</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>钱包没有与区块同步程序(daemon)建立连接。</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>已连接的区块同步程序与此GUI钱包不兼容
 请升级区块同步程序或是连接至另一个区块同步程序</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>正在等待区块同步程序完成同步</translation>
     </message>
@@ -1492,17 +1715,17 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>交易所需的花费</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>付款ID &lt;font size=&apos;2&apos;&gt;(可不填)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16或64个十六进制字符</translation>
     </message>
@@ -1510,64 +1733,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>提供以下信息来验证第三方支付的款项:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - 接受方的地址</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - 交易 ID (transaction ID)</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - 由付款方提供的交易私钥 (secret transaction key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>如果该付款包含数个交易，则检查结果将会合并在一起。</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>接受方的钱包地址</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">产生</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">签名结果</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>交易ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>粘帖上交易 ID (tx ID)</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>粘帖上交易密钥 (tx key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>检查</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>交易密钥</translation>
     </message>
 </context>
 <context>
@@ -1622,6 +1858,39 @@ Please upgrade or connect to another daemon</source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>创建一个新的钱包</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(选填)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1727,44 +1996,44 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>已有重复的钱包名称存在，请更改钱包名称</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>钱包的路径与名称只能使用字母，数字和下划线</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>使用 MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>创建钱包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>成功</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>只读钱包已被创建，您可以在关闭此钱包后使用&quot;以文件打开钱包&quot;的选项，并选择以下的文件: 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>中止</translation>
     </message>
@@ -1772,47 +2041,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>钱包名称</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>从种子码(seed)恢复</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>从密钥恢复</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>帐户地址 (公开)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>View key (私钥)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Spend key (私钥)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>恢复特定区块高度 (可选)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>您的钱包被储存在</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>请选择一个目录</translation>
     </message>
@@ -1825,7 +2099,12 @@ Please upgrade or connect to another daemon</source>
         <translation>请输入您的 25个种子码(seed)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>这种子码是&lt;b&gt;非常重要&lt;/b&gt;必须要抄写下来并妥善保管的信息，这是你恢复钱包时所需要的所有信息。</translation>
     </message>
@@ -1833,37 +2112,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>欢迎使用 Monero！</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>请于下面选择您需要的功能:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>创建一个新的钱包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>从密钥或种子码恢复钱包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>以文件打开钱包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>使用远程区块同步程序的IP或网址 (选填)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>连接到测试网络</translation>
     </message>
@@ -1877,7 +2151,7 @@ Please upgrade or connect to another daemon</source>
         <translation>为您的钱包设置一个密码</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation>注意: 这个密码无法被恢复，如果您忘记了这个密码，则必须使用25个种子码恢复您的钱包。&lt;br/&gt;&lt;br/&gt;
@@ -1887,12 +2161,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>密码</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>确认密码</translation>
     </message>
@@ -1900,7 +2174,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>恢复钱包</translation>
     </message>
@@ -1908,12 +2182,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>欢迎使用 Monero！</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>请选择您的语言和地区格式。</translation>
     </message>
@@ -1921,107 +2195,114 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>无法打开这个钱包:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>可用余额 (等待区块确认中)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>可用余额 (约需 ~%1 分钟确认)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>可用余额</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>等待区块同步程序启动中...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>等待区块同步程序停止中...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>区块同步程序启动失败</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>请查看您的钱包与区块同步程序日志获得错误信息，您亦可尝试手动重新启动%1。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>无法创建此项交易: 区块同步程序版本错误:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>无法创建此项交易:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>没有无法混淆的输出需要去除</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>请确认此项交易:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 地址: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 付款ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2030,14 +2311,14 @@ Amount: </source>
 金额: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>手续费: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2046,39 +2327,124 @@ Ringsize: </source>
 环签名大小: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">签名不正确</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>这个地址接收了 %1 monero，并通过 %2 次的确认。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">签名正确</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">密码错误</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">错误: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>区块同步程序正在执行中</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>区块同步程序将在钱包接口关闭后于后台执行。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>停止区块同步程序</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>有可用的新版本 Monero 钱包:  %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 交易数量: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2087,77 +2453,73 @@ Description: </source>
 描述: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>金额错误: 金额需介于 %1 到 %2 之间</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>资金不足，可用余额仅有: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>无法付款: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation> %1 笔款项已成功发送</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>已储存 %1 笔交易至文件</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>付款确认</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>这个地址已收到 %1 monero币，但这笔交易尚未被矿工确认</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>这个地址没有收到款项</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>总余额 (同步中)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>总余额</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>请稍后...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>程序设置向导</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>付款至相同地址</translation>
     </message>

--- a/translations/monero-core_zh-tw.ts
+++ b/translations/monero-core_zh-tw.ts
@@ -4,62 +4,62 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="52"/>
-        <source>Add new entry</source>
-        <translation>增加付款位址</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="61"/>
+        <location filename="../pages/AddressBook.qml" line="50"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="71"/>
-        <source>QRCODE</source>
-        <translation>QR碼</translation>
+        <location filename="../pages/AddressBook.qml" line="56"/>
+        <source>Qr Code</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="102"/>
+        <location filename="../pages/AddressBook.qml" line="80"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>付款 ID &lt;font size=&apos;2&apos;&gt;(可選填)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="114"/>
+        <location filename="../pages/AddressBook.qml" line="81"/>
+        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/AddressBook.qml" line="88"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>貼上16進位字元之位址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="93"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>標記 &lt;font size=&apos;2&apos;&gt;(選填)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="135"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Give this entry a name or description</source>
         <translation>給予這個地址一個名稱或標記</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="151"/>
+        <location filename="../pages/AddressBook.qml" line="111"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="156"/>
+        <location filename="../pages/AddressBook.qml" line="116"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="159"/>
+        <location filename="../pages/AddressBook.qml" line="119"/>
         <source>Invalid address</source>
         <translation>無效的位址</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="163"/>
+        <location filename="../pages/AddressBook.qml" line="123"/>
         <source>Can&apos;t create entry</source>
         <translation>無法新增位址</translation>
     </message>
@@ -75,6 +75,11 @@
         <location filename="../components/AddressBookTable.qml" line="104"/>
         <source>Payment ID:</source>
         <translation>付款 ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -117,8 +122,8 @@
     <name>DaemonManagerDialog</name>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="93"/>
-        <source>Starting Monero daemon in %1 seconds</source>
-        <translation>在 %1 秒後啟動 Monero 區塊同步</translation>
+        <source>Starting local node in %1 seconds</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/DaemonManagerDialog.qml" line="115"/>
@@ -185,38 +190,38 @@
         <translation>交易紀錄篩選</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="183"/>
+        <location filename="../pages/History.qml" line="159"/>
         <source>Type for incremental search...</source>
         <translation>輸入篩選條件...</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="276"/>
+        <location filename="../pages/History.qml" line="252"/>
         <source>Filter</source>
         <translation>篩選</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="223"/>
+        <location filename="../pages/History.qml" line="199"/>
         <source>Date from</source>
         <translation>日期從</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="249"/>
-        <location filename="../pages/History.qml" line="403"/>
+        <location filename="../pages/History.qml" line="225"/>
+        <location filename="../pages/History.qml" line="379"/>
         <source>To</source>
         <translation>到</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="314"/>
+        <location filename="../pages/History.qml" line="290"/>
         <source>Advanced filtering</source>
         <translation>進階篩選</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="334"/>
+        <location filename="../pages/History.qml" line="310"/>
         <source>Type of transaction</source>
         <translation>交易種類</translation>
     </message>
     <message>
-        <location filename="../pages/History.qml" line="370"/>
+        <location filename="../pages/History.qml" line="346"/>
         <source>Amount from</source>
         <translation>金額從</translation>
     </message>
@@ -230,7 +235,7 @@
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="203"/>
+        <location filename="../components/HistoryTable.qml" line="195"/>
         <source>Payment ID:</source>
         <translation>付款 ID:</translation>
     </message>
@@ -255,160 +260,294 @@
         <translation>沒有更多了</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="110"/>
+        <location filename="../components/HistoryTable.qml" line="102"/>
         <source>Details</source>
         <translation>細節</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="251"/>
+        <location filename="../components/HistoryTable.qml" line="243"/>
         <source>BlockHeight:</source>
         <translation>區塊高度:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="266"/>
-        <source>(%1/10 confirmations)</source>
-        <translation>(%1/10 次確認)</translation>
+        <location filename="../components/HistoryTable.qml" line="258"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 次確認) {1/%2 ?}</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="270"/>
+        <location filename="../components/HistoryTable.qml" line="262"/>
         <source>UNCONFIRMED</source>
         <translation>未確認的交易</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="271"/>
+        <location filename="../components/HistoryTable.qml" line="264"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="265"/>
         <source>PENDING</source>
         <translation>待確認的交易</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="300"/>
+        <location filename="../components/HistoryTable.qml" line="294"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="357"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="392"/>
+        <location filename="../components/HistoryTable.qml" line="386"/>
         <source>Fee</source>
         <translation>手續費</translation>
     </message>
 </context>
 <context>
+    <name>HistoryTableMobile</name>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <source>Tx ID:</source>
+        <translation type="unfinished">轉帳ID (Tx ID):</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished">付款 ID:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <source>Tx key:</source>
+        <translation type="unfinished">轉帳金鑰 (Tx key):</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <source>Tx note:</source>
+        <translation type="unfinished">轉帳附註:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <source>Destinations:</source>
+        <translation type="unfinished">目標:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <source>No more results</source>
+        <translation type="unfinished">沒有更多了</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <source>(%1/%2 confirmations)</source>
+        <translation type="unfinished">(%1/10 次確認) {1/%2 ?}</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <source>UNCONFIRMED</source>
+        <translation type="unfinished">未確認的交易</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <source>FAILED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <source>PENDING</source>
+        <translation type="unfinished">待確認的交易</translation>
+    </message>
+</context>
+<context>
+    <name>Keys</name>
+    <message>
+        <location filename="../pages/Keys.qml" line="62"/>
+        <source>Mnemonic seed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="78"/>
+        <location filename="../pages/Keys.qml" line="112"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="85"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="95"/>
+        <source>Keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="119"/>
+        <source>Keys copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="129"/>
+        <source>Export wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="142"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>Spendable Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="150"/>
+        <location filename="../pages/Keys.qml" line="181"/>
+        <source>View Only Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="191"/>
+        <source>Secret view key</source>
+        <translation type="unfinished">查看私鑰 (Secret view key)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="192"/>
+        <source>Public view key</source>
+        <translation type="unfinished">查看公鑰 (Public view key)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="193"/>
+        <source>Secret spend key</source>
+        <translation type="unfinished">花費私鑰 (Secret spend key)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="194"/>
+        <source>Public spend key</source>
+        <translation type="unfinished">花費公鑰 (Public spend key)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <source>(View Only Wallet -  No mnemonic seed available)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="132"/>
+        <location filename="../LeftPanel.qml" line="147"/>
         <source>Balance</source>
         <translation>餘額</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="177"/>
-
-
-
-
-
+        <location filename="../LeftPanel.qml" line="192"/>
         <source>Unlocked balance</source>
         <translation>總餘額</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="279"/>
-
-
-
-
-
+        <location filename="../LeftPanel.qml" line="295"/>
         <source>Send</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="329"/>
+        <location filename="../LeftPanel.qml" line="345"/>
         <source>Receive</source>
         <translation>收款</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="330"/>
+        <location filename="../LeftPanel.qml" line="346"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="423"/>
+        <location filename="../LeftPanel.qml" line="439"/>
+        <source>Prove/check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="440"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="353"/>
+        <location filename="../LeftPanel.qml" line="369"/>
         <source>History</source>
         <translation>歷史紀錄</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="93"/>
+        <location filename="../LeftPanel.qml" line="96"/>
+        <source>View Only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="108"/>
         <source>Testnet</source>
         <translation>連接到測試網路</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="304"/>
+        <location filename="../LeftPanel.qml" line="320"/>
         <source>Address book</source>
         <translation>位址簿</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="305"/>
+        <location filename="../LeftPanel.qml" line="321"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="354"/>
+        <location filename="../LeftPanel.qml" line="370"/>
         <source>H</source>
         <translation>H</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="376"/>
+        <location filename="../LeftPanel.qml" line="392"/>
         <source>Advanced</source>
         <translation>進階功能</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="377"/>
+        <location filename="../LeftPanel.qml" line="393"/>
         <source>D</source>
         <translation>D</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="398"/>
+        <location filename="../LeftPanel.qml" line="415"/>
         <source>Mining</source>
         <translation>挖礦</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="399"/>
+        <location filename="../LeftPanel.qml" line="416"/>
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="422"/>
-        <source>Check payment</source>
-        <translation>交易檢查</translation>
+        <location filename="../LeftPanel.qml" line="508"/>
+        <source>Seed &amp; Keys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="446"/>
+        <location filename="../LeftPanel.qml" line="509"/>
+        <source>Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="463"/>
         <source>Sign/verify</source>
         <translation>簽署 / 驗證</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="470"/>
+        <location filename="../LeftPanel.qml" line="487"/>
         <source>E</source>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="280"/>
+        <location filename="../LeftPanel.qml" line="296"/>
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="447"/>
+        <location filename="../LeftPanel.qml" line="464"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="469"/>
+        <location filename="../LeftPanel.qml" line="486"/>
         <source>Settings</source>
         <translation>錢包設定</translation>
     </message>
@@ -416,12 +555,12 @@
 <context>
     <name>MiddlePanel</name>
     <message>
-        <location filename="../MiddlePanel.qml" line="46"/>
+        <location filename="../MiddlePanel.qml" line="47"/>
         <source>Balance</source>
         <translation>總餘額</translation>
     </message>
     <message>
-        <location filename="../MiddlePanel.qml" line="48"/>
+        <location filename="../MiddlePanel.qml" line="49"/>
         <source>Unlocked Balance</source>
         <translation>可用餘額</translation>
     </message>
@@ -429,87 +568,87 @@
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="73"/>
+        <location filename="../pages/Mining.qml" line="70"/>
         <source>Solo mining</source>
         <translation>獨立挖礦 (Solo mining)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="80"/>
+        <location filename="../pages/Mining.qml" line="77"/>
         <source>(only available for local daemons)</source>
         <translation>(僅限於使用本地端區塊同步程式)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="86"/>
+        <location filename="../pages/Mining.qml" line="83"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>挖礦可增進 Monero 網路的安全性，只要越多使用者在挖礦，Monero 網路就會越難以被攻擊。&lt;br&gt; &lt;br&gt;挖礦也同時提供您機會賺取一些額外的 Monero 幣，因為在挖礦時，您的電腦將被用來尋找 Monero 區塊的解答，每當您找到一個區塊的解答，您即可以獲得其附帶的獎勵金，祝您好運！</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="96"/>
+        <location filename="../pages/Mining.qml" line="93"/>
         <source>CPU threads</source>
         <translation>CPU執行緒數量</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="104"/>
+        <location filename="../pages/Mining.qml" line="101"/>
         <source>(optional)</source>
         <translation>(選填)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="116"/>
+        <location filename="../pages/Mining.qml" line="113"/>
         <source>Background mining (experimental)</source>
         <translation>背景挖礦 (實驗性功能)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="132"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Enable mining when running on battery</source>
         <translation>允許在使用電池時挖礦</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="142"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Manage miner</source>
         <translation>挖礦管理</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="151"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Start mining</source>
         <translation>開始挖礦</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="158"/>
         <source>Error starting mining</source>
         <translation>啟動挖礦時發生錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="162"/>
+        <location filename="../pages/Mining.qml" line="159"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>無法啟動挖礦&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="164"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>僅能使用本地端區塊同步程式以進行挖礦，請先執行本地端區塊同步程式&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="176"/>
+        <location filename="../pages/Mining.qml" line="173"/>
         <source>Stop mining</source>
         <translation>停止挖礦</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="192"/>
+        <location filename="../pages/Mining.qml" line="188"/>
         <source>Status: not mining</source>
         <translation>狀態: 沒有在進行挖礦</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="203"/>
+        <location filename="../pages/Mining.qml" line="199"/>
         <source>Mining at %1 H/s</source>
         <translation>目前挖礦速率為 %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="206"/>
+        <location filename="../pages/Mining.qml" line="202"/>
         <source>Not mining</source>
         <translation>沒有在進行挖礦</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="208"/>
+        <location filename="../pages/Mining.qml" line="204"/>
         <source>Status: </source>
         <translation>狀態:</translation>
     </message>
@@ -517,7 +656,7 @@
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="94"/>
+        <location filename="../components/MobileHeader.qml" line="92"/>
         <source>Unlocked Balance:</source>
         <translation>可用餘額:</translation>
     </message>
@@ -530,40 +669,68 @@
         <translation>同步區塊中</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="54"/>
+        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NetworkStatusItem.qml" line="56"/>
         <source>Connected</source>
         <translation>已連接</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="57"/>
+        <location filename="../components/NetworkStatusItem.qml" line="59"/>
         <source>Wrong version</source>
         <translation>版本錯誤</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="61"/>
         <source>Disconnected</source>
         <translation>已離線</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="60"/>
+        <location filename="../components/NetworkStatusItem.qml" line="62"/>
         <source>Invalid connection status</source>
         <translation>無效的連接狀態</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="85"/>
+        <location filename="../components/NetworkStatusItem.qml" line="91"/>
         <source>Network status</source>
         <translation>網路同步狀態</translation>
     </message>
 </context>
 <context>
+    <name>NewPasswordDialog</name>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <source>Please enter new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <source>Please confirm new password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password</source>
         <translation>請輸入錢包的密碼</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="79"/>
+        <location filename="../components/PasswordDialog.qml" line="88"/>
         <source>Please enter wallet password for:&lt;br&gt;</source>
         <translation>請輸入以下錢包的密碼:&lt;br&gt;</translation>
     </message>
@@ -573,9 +740,9 @@
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="171"/>
-        <source>Ok</source>
-        <translation>確定</translation>
+        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -599,19 +766,27 @@
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="43"/>
+        <location filename="../components/ProgressBar.qml" line="41"/>
         <source>Establishing connection...</source>
         <translation>建立連線中...</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="57"/>
+        <location filename="../components/ProgressBar.qml" line="58"/>
         <source>Blocks remaining: %1</source>
         <translation>剩餘區塊數量: %1</translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="100"/>
+        <location filename="../components/ProgressBar.qml" line="109"/>
         <source>Synchronizing blocks</source>
         <translation>同步區塊中</translation>
+    </message>
+</context>
+<context>
+    <name>QRCodeScanner</name>
+    <message>
+        <location filename="../components/QRCodeScanner.qml" line="129"/>
+        <source>QrCode Scanned</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -622,152 +797,162 @@
         <translation>無效的付款ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="107"/>
+        <location filename="../pages/Receive.qml" line="113"/>
         <source>WARNING: no connection to daemon</source>
         <translation>警告: 沒有與區塊同步程式(daemon)建立連線</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="129"/>
+        <location filename="../pages/Receive.qml" line="135"/>
         <source>in the txpool: %1</source>
         <translation>在交易池中(txpool): %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="136"/>
+        <location filename="../pages/Receive.qml" line="142"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 交易確認: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="138"/>
+        <location filename="../pages/Receive.qml" line="144"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 交易確認: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="146"/>
+        <location filename="../pages/Receive.qml" line="152"/>
         <source>No transaction found yet...</source>
         <translation>目前沒有交易...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>Transaction found</source>
         <translation>已找到交易資訊</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="150"/>
+        <location filename="../pages/Receive.qml" line="156"/>
         <source>%1 transactions found</source>
         <translation>已找到 %1 筆交易資訊</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="162"/>
         <source> with more money (%1)</source>
         <translation>尚有金額 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="158"/>
+        <location filename="../pages/Receive.qml" line="164"/>
         <source> with not enough money (%1)</source>
         <translation>不足金額 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="190"/>
+        <location filename="../pages/Receive.qml" line="195"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="197"/>
+        <location filename="../pages/Receive.qml" line="202"/>
         <source>ReadOnly wallet address displayed here</source>
         <translation>唯讀錢包的位址會顯示在這</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="230"/>
+        <location filename="../pages/Receive.qml" line="214"/>
+        <source>Address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="235"/>
         <source>16 hexadecimal characters</source>
         <translation>16 十六進位字元</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="266"/>
+        <location filename="../pages/Receive.qml" line="247"/>
+        <source>Payment ID copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="270"/>
         <source>Clear</source>
         <translation>清除</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="276"/>
+        <location filename="../pages/Receive.qml" line="279"/>
         <source>Integrated address</source>
         <translation>整合位址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="317"/>
+        <location filename="../pages/Receive.qml" line="300"/>
+        <source>Integrated address copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="320"/>
         <source>Amount to receive</source>
         <translation>欲接收的金額</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="338"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           Tracking &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                           追蹤中 &lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;help&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+        <location filename="../pages/Receive.qml" line="341"/>
+        <source>Tracking</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../pages/Receive.qml" line="343"/>
+        <source>help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="348"/>
         <source>Tracking payments</source>
         <translation>追蹤支付款</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="344"/>
+        <location filename="../pages/Receive.qml" line="349"/>
         <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;這是一個簡易的收款追蹤功能:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;在每次交易時請點擊&quot;產生&quot;一個隨機的付款ID&lt;/p&gt; &lt;p&gt;讓您的付款對象掃描QR碼 (如果對象的軟體支援QR掃描的話)&lt;/p&gt;&lt;p&gt;這個頁面將會自動尋找您在區塊鏈或交易池裡即將收到的款項，如果您有輸入金額，本功能亦會進行確認即將收到款項的總金額&lt;/p&gt;您可以自行決定是否要在確認完成前認可此份交易，通常交易在短時間都能完成確認，但有時則否，所以當您在交易比較大金額的款項時最好能等待至少一個或數個確認次數。&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="388"/>
+        <location filename="../pages/Receive.qml" line="393"/>
         <source>Save QrCode</source>
         <translation>儲存 QR 碼</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="389"/>
+        <location filename="../pages/Receive.qml" line="394"/>
         <source>Failed to save QrCode to </source>
         <translation>無法儲存 QR 碼至</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="400"/>
+        <location filename="../pages/Receive.qml" line="405"/>
         <source>Save As</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="222"/>
+        <location filename="../pages/Receive.qml" line="227"/>
         <source>Payment ID</source>
         <translation>付款 ID</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="254"/>
+        <location filename="../pages/Receive.qml" line="259"/>
         <source>Generate</source>
         <translation>產生</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="285"/>
+        <location filename="../pages/Receive.qml" line="288"/>
         <source>Generate payment ID for integrated address</source>
         <translation>按下產生付款ID以獲得整合地址</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="309"/>
+        <location filename="../pages/Receive.qml" line="312"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
 </context>
 <context>
-    <name>RightPanel</name>
+    <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../RightPanel.qml" line="61"/>
-        <source>Twitter</source>
-        <translation>推特</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <source>Remote Node Hostname / IP</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RightPanel.qml" line="62"/>
-        <source>News</source>
-        <translation>最新消息</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="63"/>
-        <source>Help</source>
-        <translation>說明</translation>
-    </message>
-    <message>
-        <location filename="../RightPanel.qml" line="64"/>
-        <source>About</source>
-        <translation>關於</translation>
+        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <source>Port</source>
+        <translation type="unfinished">通訊埠</translation>
     </message>
 </context>
 <context>
@@ -786,224 +971,252 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="103"/>
+        <location filename="../pages/Settings.qml" line="96"/>
         <source>Create view only wallet</source>
         <translation>創建唯讀錢包(view only wallet)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="193"/>
-        <source>Manage daemon</source>
-        <translation>管理區塊同步程式(daemon)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="212"/>
-        <source>Start daemon</source>
-        <translation>啟動區塊同步程式</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="226"/>
-        <source>Stop daemon</source>
-        <translation>停止區塊同步程式</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="285"/>
         <source>Show status</source>
         <translation>顯示狀態</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="286"/>
-        <source>Daemon startup flags</source>
-        <translation>區塊同步程式啟動flags</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="265"/>
-        <location filename="../pages/Settings.qml" line="294"/>
+        <location filename="../pages/Settings.qml" line="310"/>
+        <location filename="../pages/Settings.qml" line="340"/>
         <source>(optional)</source>
         <translation>(選填)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="120"/>
-        <source>Show seed &amp; keys</source>
-        <translation>顯示種子碼與金鑰</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="163"/>
+        <location filename="../pages/Settings.qml" line="145"/>
         <source>Rescan wallet balance</source>
         <translation>重新掃描錢包餘額</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="172"/>
+        <location filename="../pages/Settings.qml" line="154"/>
         <source>Error: </source>
         <translation>錯誤: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="177"/>
+        <location filename="../pages/Settings.qml" line="159"/>
         <source>Information</source>
         <translation>資訊</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="178"/>
-        <source>Sucessfully rescanned spent outputs</source>
-        <translation>已成功重新掃描交易輸出</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="303"/>
         <source>Blockchain location</source>
         <translation>區塊鏈檔案儲存位置</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="306"/>
-        <source>Daemon address</source>
-        <translation>區塊同步程式位置</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="322"/>
-        <source>Hostname / IP</source>
-        <translation>主機名稱 / IP位置</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="331"/>
-        <source>Port</source>
-        <translation>通訊埠</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="342"/>
-        <source>Login (optional)</source>
-        <translation>登入 (選填)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="355"/>
+        <location filename="../pages/Settings.qml" line="363"/>
         <source>Username</source>
         <translation>使用者名稱</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="364"/>
+        <location filename="../pages/Settings.qml" line="372"/>
         <source>Password</source>
         <translation>密碼</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="397"/>
         <source>Connect</source>
         <translation>連接</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="398"/>
+        <location filename="../pages/Settings.qml" line="421"/>
         <source>Layout settings</source>
         <translation>版面設定</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="415"/>
+        <location filename="../pages/Settings.qml" line="439"/>
         <source>Custom decorations</source>
         <translation>視窗化自訂</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="426"/>
+        <location filename="../pages/Settings.qml" line="450"/>
         <source>Log level</source>
         <translation>日誌層級</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="460"/>
+        <location filename="../pages/Settings.qml" line="482"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="476"/>
-        <source>Version</source>
-        <translation>版本</translation>
+        <location filename="../pages/Settings.qml" line="160"/>
+        <source>Successfully rescanned spent outputs.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="492"/>
+        <location filename="../pages/Settings.qml" line="170"/>
+        <source>Change password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="201"/>
+        <source>Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="215"/>
+        <source>Remote Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="233"/>
+        <source>Manage Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="239"/>
+        <source>Show advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <source>Start Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="272"/>
+        <source>Stop Local Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="333"/>
+        <source>Local daemon startup flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="351"/>
+        <source>Node login (optional)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="382"/>
+        <source>Remote node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="498"/>
+        <source>Debug info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="512"/>
         <source>GUI version: </source>
         <translation>GUI 版本: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="499"/>
+        <location filename="../pages/Settings.qml" line="517"/>
         <source>Embedded Monero version: </source>
         <translation>內嵌 Monero 版本: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="509"/>
+        <location filename="../pages/Settings.qml" line="523"/>
+        <source>Wallet creation height: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="524"/>
+        <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="550"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="563"/>
+        <source>Rescan wallet cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="564"/>
+        <source>Are you sure you want to rebuild the wallet cache?
+The following information will be deleted
+- Recipient addresses
+- Tx keys
+- Tx descriptions
+
+The old wallet cache file will be renamed and can be restored later.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="592"/>
+        <source>Wallet log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="596"/>
+        <source>Wallet Name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="600"/>
+        <source>Daemon log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="609"/>
         <source>Daemon log</source>
         <translation>區塊同步程式日誌</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="573"/>
+        <location filename="../pages/Settings.qml" line="618"/>
         <source>Please choose a folder</source>
         <translation>請選擇一個資料夾</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="582"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="585"/>
+        <location filename="../pages/Settings.qml" line="630"/>
         <source>Error: Filesystem is read only</source>
         <translation>錯誤: 沒有寫入權限</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="589"/>
+        <location filename="../pages/Settings.qml" line="634"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>警告: 此裝置剩餘 %1 GB 可用裝置，區塊鏈需要約 %2 GB 存放空間。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="591"/>
+        <location filename="../pages/Settings.qml" line="636"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>注意: 此裝置尚有 %1 GB可用空間。 區塊鏈需要約 %2 GB的存放空間。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="595"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>注意: 找不到lmdb資料夾。 將會建立一個新的。</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="572"/>
+        <location filename="../pages/Settings.qml" line="644"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="171"/>
-        <location filename="../pages/Settings.qml" line="539"/>
+        <location filename="../pages/Settings.qml" line="153"/>
+        <location filename="../pages/Settings.qml" line="180"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="525"/>
-        <source>Wallet seed &amp; keys</source>
-        <translation>錢包種子碼與金鑰</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="527"/>
-        <source>Secret view key</source>
-        <translation>查看私鑰 (Secret view key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="528"/>
-        <source>Public view key</source>
-        <translation>查看公鑰 (Public view key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="529"/>
-        <source>Secret spend key</source>
-        <translation>花費私鑰 (Secret spend key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="530"/>
-        <source>Public spend key</source>
-        <translation>花費公鑰 (Public spend key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="540"/>
+        <location filename="../pages/Settings.qml" line="181"/>
         <source>Wrong password</source>
         <translation>密碼錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="72"/>
+        <location filename="../pages/Settings.qml" line="66"/>
         <source>Manage wallet</source>
         <translation>管理錢包</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="88"/>
+        <location filename="../pages/Settings.qml" line="81"/>
         <source>Close wallet</source>
         <translation>關閉錢包</translation>
     </message>
@@ -1011,105 +1224,110 @@
 <context>
     <name>Sign</name>
     <message>
-        <location filename="../pages/Sign.qml" line="68"/>
+        <location filename="../pages/Sign.qml" line="64"/>
         <source>Good signature</source>
         <translation>良好的簽署</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
+        <location filename="../pages/Sign.qml" line="65"/>
         <source>This is a good signature</source>
         <translation>這份簽署沒有問題</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="73"/>
+        <location filename="../pages/Sign.qml" line="69"/>
         <source>Bad signature</source>
         <translation>有問題的簽署</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="74"/>
+        <location filename="../pages/Sign.qml" line="70"/>
         <source>This signature did not verify</source>
         <translation>這份簽署無法通過驗證</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="111"/>
+        <location filename="../pages/Sign.qml" line="106"/>
         <source>Sign a message or file contents with your address:</source>
         <translation>用你的位址簽署一份訊息或檔案內容:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="122"/>
-        <location filename="../pages/Sign.qml" line="294"/>
+        <location filename="../pages/Sign.qml" line="115"/>
+        <location filename="../pages/Sign.qml" line="272"/>
         <source>Either message:</source>
         <translation>簽署訊息:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="128"/>
         <source>Message to sign</source>
         <translation>欲簽署的訊息</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="156"/>
-        <location filename="../pages/Sign.qml" line="231"/>
+        <location filename="../pages/Sign.qml" line="145"/>
+        <location filename="../pages/Sign.qml" line="215"/>
         <source>Sign</source>
         <translation>簽署</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="184"/>
+        <location filename="../pages/Sign.qml" line="171"/>
         <source>Please choose a file to sign</source>
         <translation>請選擇一個欲簽署的檔案</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <location filename="../pages/Sign.qml" line="368"/>
+        <location filename="../pages/Sign.qml" line="183"/>
+        <location filename="../pages/Sign.qml" line="340"/>
         <source>Select</source>
         <translation>選擇檔案</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="327"/>
-        <location filename="../pages/Sign.qml" line="401"/>
+        <location filename="../pages/Sign.qml" line="302"/>
+        <location filename="../pages/Sign.qml" line="371"/>
         <source>Verify</source>
         <translation>驗證</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="355"/>
+        <location filename="../pages/Sign.qml" line="328"/>
         <source>Please choose a file to verify</source>
         <translation>請選擇一個欲驗證的檔案</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="419"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            Signing address &lt;font size=&apos;2&apos;&gt;  ( Paste in  or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                            簽署來源之位址&lt;font size=&apos;2&apos;&gt; ( 貼上或從&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;位址簿&lt;/a&gt; &lt;font size=&apos;2&apos;&gt; 中選擇 )&lt;/font&gt;</translation>
+        <location filename="../pages/Sign.qml" line="387"/>
+        <source>Signing address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="172"/>
-        <location filename="../pages/Sign.qml" line="343"/>
+        <location filename="../pages/Sign.qml" line="389"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="160"/>
+        <location filename="../pages/Sign.qml" line="317"/>
         <source>Or file:</source>
         <translation>或檔案:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="212"/>
+        <location filename="../pages/Sign.qml" line="197"/>
         <source>Filename with message to sign</source>
         <translation>要簽署訊息的檔案名稱</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="251"/>
-        <location filename="../pages/Sign.qml" line="257"/>
-        <location filename="../pages/Sign.qml" line="445"/>
-        <location filename="../pages/Sign.qml" line="452"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="239"/>
+        <location filename="../pages/Sign.qml" line="415"/>
+        <location filename="../pages/Sign.qml" line="420"/>
         <source>Signature</source>
         <translation>簽署結果</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="282"/>
+        <location filename="../pages/Sign.qml" line="262"/>
         <source>Verify a message or file signature from an address:</source>
         <translation>驗證從某個位址所簽署的訊息或檔案:</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="309"/>
+        <location filename="../pages/Sign.qml" line="285"/>
         <source>Message to verify</source>
         <translation>欲驗證的訊息</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="383"/>
+        <location filename="../pages/Sign.qml" line="354"/>
         <source>Filename with message to verify</source>
         <translation>附帶簽署訊息的檔案名稱</translation>
     </message>
@@ -1117,65 +1335,75 @@
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="135"/>
-        <source>Ok</source>
-        <translation>確定</translation>
+        <location filename="../components/StandardDialog.qml" line="122"/>
+        <source>Double tap to copy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="120"/>
+        <location filename="../components/StandardDialog.qml" line="129"/>
+        <source>Content copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../components/StandardDialog.qml" line="160"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="197"/>
+        <location filename="../components/StandardDropdown.qml" line="203"/>
         <source>Low (x1 fee)</source>
         <translation>低 (1倍手續費)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="198"/>
+        <location filename="../components/StandardDropdown.qml" line="204"/>
         <source>Medium (x20 fee)</source>
         <translation>中 (20倍手續費)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="199"/>
+        <location filename="../components/StandardDropdown.qml" line="205"/>
         <source>High (x166 fee)</source>
         <translation>高 (166倍手續費)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="200"/>
+        <location filename="../components/StandardDropdown.qml" line="206"/>
         <source>Slow (x0.25 fee)</source>
         <translation>較慢 ( x0.25 手續費 )</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="201"/>
+        <location filename="../components/StandardDropdown.qml" line="207"/>
         <source>Default (x1 fee)</source>
         <translation>預設 ( x1 手續費 )</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="202"/>
+        <location filename="../components/StandardDropdown.qml" line="208"/>
         <source>Fast (x5 fee)</source>
         <translation>快速 ( x5 手續費 )</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="209"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>優先 ( x41.5 手續費 )</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="210"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="211"/>
         <source>Sent</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="212"/>
         <source>Received</source>
         <translation>收款</translation>
     </message>
@@ -1230,16 +1458,11 @@
     <name>TickDelegate</name>
     <message>
         <location filename="../components/TickDelegate.qml" line="55"/>
-        <source>Normal</source>
-        <translation>正常</translation>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../components/TickDelegate.qml" line="56"/>
-        <source>Medium</source>
-        <translation>中</translation>
-    </message>
-    <message>
-        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>High</source>
         <translation>高</translation>
     </message>
@@ -1247,252 +1470,242 @@
 <context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="66"/>
+        <location filename="../pages/Transfer.qml" line="69"/>
         <source>OpenAlias error</source>
         <translation>OpenAlias 錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="78"/>
+        <location filename="../pages/Transfer.qml" line="81"/>
         <source>Privacy level (ringsize %1)</source>
         <translation>隱私等級 (環簽大小: %1)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="44"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;啟動區塊同步程式&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="125"/>
+        <location filename="../pages/Transfer.qml" line="129"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="135"/>
+        <location filename="../pages/Transfer.qml" line="181"/>
         <source>Transaction priority</source>
         <translation>交易優先程度</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
-        <source>Low (x1 fee)</source>
-        <translation>低 (1倍手續費)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="198"/>
-        <source>Medium (x20 fee)</source>
-        <translation>中 (20倍手續費)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="199"/>
-        <source>High (x166 fee)</source>
-        <translation>高 (166倍手續費)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="206"/>
+        <location filename="../pages/Transfer.qml" line="194"/>
         <source>Slow (x0.25 fee)</source>
         <translation>較慢 ( x0.25 手續費 )</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="207"/>
+        <location filename="../pages/Transfer.qml" line="195"/>
         <source>Default (x1 fee)</source>
         <translation>預設 ( x1 手續費 )</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="208"/>
+        <location filename="../pages/Transfer.qml" line="196"/>
         <source>Fast (x5 fee)</source>
         <translation>快速 ( x5 手續費 )</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="209"/>
+        <location filename="../pages/Transfer.qml" line="197"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>優先 ( x41.5 手續費 )</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="237"/>
-        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      Address &lt;font size=&apos;2&apos;&gt;  ( Paste in or select from &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
-        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;                      位址&lt;font size=&apos;2&apos;&gt; ( 貼上或從&lt;/font&gt; &lt;a href=&apos;#&apos;&gt;位址簿&lt;/a&gt; &lt;font size=&apos;2&apos;&gt; 中選擇 )&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="255"/>
+        <location filename="../pages/Transfer.qml" line="235"/>
         <source>QR Code</source>
         <translation>QR碼</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="259"/>
         <source>Resolve</source>
         <translation>解析OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="303"/>
+        <location filename="../pages/Transfer.qml" line="277"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>無效的 OpenAlias address 位址</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="308"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>已找到位址，但無法驗證其 DNSSEC 的簽署，此位址有可能受到欺騙攻擊的風險</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="310"/>
+        <location filename="../pages/Transfer.qml" line="284"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>無法找到有效位址，但無法驗證其 DNSSEC 的簽署，此位址有可能受到欺騙攻擊的風險</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="313"/>
-        <location filename="../pages/Transfer.qml" line="316"/>
+        <location filename="../pages/Transfer.qml" line="287"/>
+        <location filename="../pages/Transfer.qml" line="290"/>
         <source>Internal error</source>
         <translation>內部錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="319"/>
+        <location filename="../pages/Transfer.qml" line="293"/>
         <source>No address found</source>
         <translation>沒有找到位址</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="359"/>
+        <location filename="../pages/Transfer.qml" line="312"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>標記 &lt;font size=&apos;2&apos;&gt;( 選填 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="371"/>
+        <location filename="../pages/Transfer.qml" line="318"/>
         <source>Saved to local wallet history</source>
         <translation>儲存至本機錢包紀錄</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="401"/>
+        <location filename="../pages/Transfer.qml" line="326"/>
         <source>Send</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="447"/>
+        <location filename="../pages/Transfer.qml" line="391"/>
         <source>Show advanced options</source>
         <translation>顯示進階選項</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="499"/>
+        <location filename="../pages/Transfer.qml" line="454"/>
         <source>Sweep Unmixable</source>
         <translation>去除無法混幣的金額</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="513"/>
+        <location filename="../pages/Transfer.qml" line="468"/>
         <source>Create tx file</source>
         <translation>建立交易檔案(tx file)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="175"/>
+        <location filename="../pages/Transfer.qml" line="164"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="535"/>
+        <location filename="../pages/Transfer.qml" line="490"/>
         <source>Sign tx file</source>
         <translation>簽署一個交易檔案</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="504"/>
         <source>Submit tx file</source>
         <translation>提交交易檔案</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="582"/>
-        <location filename="../pages/Transfer.qml" line="638"/>
+        <location filename="../pages/Transfer.qml" line="537"/>
+        <location filename="../pages/Transfer.qml" line="593"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="644"/>
+        <location filename="../pages/Transfer.qml" line="599"/>
         <source>Information</source>
         <translation>資訊</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="571"/>
-        <location filename="../pages/Transfer.qml" line="632"/>
+        <location filename="../pages/Transfer.qml" line="526"/>
+        <location filename="../pages/Transfer.qml" line="587"/>
         <source>Please choose a file</source>
         <translation>請選擇一個檔案</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="583"/>
+        <location filename="../pages/Transfer.qml" line="45"/>
+        <source>Start daemon</source>
+        <translation type="unfinished">啟動區塊同步程式</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="220"/>
+        <source>Address</source>
+        <translation type="unfinished">位址</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="222"/>
+        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="538"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>無法載入未簽署的交易: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="590"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>
 Number of transactions: </source>
         <translation>
 交易數量: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="592"/>
+        <location filename="../pages/Transfer.qml" line="547"/>
         <source>
 Transaction #%1</source>
         <translation>
 交易 #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="548"/>
         <source>
 Recipient: </source>
         <translation>
 接收方: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="549"/>
         <source>
 payment ID: </source>
         <translation>
 付款 ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="595"/>
+        <location filename="../pages/Transfer.qml" line="550"/>
         <source>
 Amount: </source>
         <translation>
 金額: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="596"/>
+        <location filename="../pages/Transfer.qml" line="551"/>
         <source>
 Fee: </source>
         <translation>
 手續費: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="597"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Ringsize: </source>
         <translation>
 環簽大小: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="611"/>
+        <location filename="../pages/Transfer.qml" line="566"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="639"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>無法送出交易: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="645"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Money sent successfully</source>
         <translation>已成功完成 Monero 付款</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="704"/>
-        <location filename="../pages/Transfer.qml" line="716"/>
+        <location filename="../pages/Transfer.qml" line="654"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>錢包沒有與區塊同步程式(daemon)建立連線。</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="719"/>
+        <location filename="../pages/Transfer.qml" line="669"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>已連接的區塊同步程式與此GUI錢包不相容
 請升級區塊同步程式或是連接至另一個同步程式</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="724"/>
+        <location filename="../pages/Transfer.qml" line="674"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>正在等待區塊同步程式完成同步</translation>
     </message>
@@ -1502,17 +1715,17 @@ Please upgrade or connect to another daemon</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="474"/>
+        <location filename="../pages/Transfer.qml" line="419"/>
         <source>Transaction cost</source>
         <translation>交易所需的花費</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="334"/>
+        <location filename="../pages/Transfer.qml" line="301"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>付款ID &lt;font size=&apos;2&apos;&gt;( 可不填 )&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="346"/>
+        <location filename="../pages/Transfer.qml" line="307"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 或 64 十六進位字元</translation>
     </message>
@@ -1520,64 +1733,77 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="90"/>
-        <source>Verify that a third party made a payment by supplying:</source>
-        <translation>藉由提供以下資訊來驗證第三方支付的款項:</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="95"/>
-        <source> - the recipient address</source>
-        <translation> - 接受方的位址</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="100"/>
-        <source> - the transaction ID</source>
-        <translation> - 交易 ID (transaction ID)</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="105"/>
-        <source> - the secret transaction key supplied by the sender</source>
-        <translation> - 由付款方提供的交易私鑰 (secret transaction key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="110"/>
+        <location filename="../pages/TxKey.qml" line="349"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>如果該付款包含數個交易，則檢查結果將會合併在一起。</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="123"/>
+        <location filename="../pages/TxKey.qml" line="133"/>
+        <location filename="../pages/TxKey.qml" line="245"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="130"/>
+        <location filename="../pages/TxKey.qml" line="97"/>
+        <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
+For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <location filename="../pages/TxKey.qml" line="252"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>接受方的錢包位址</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="152"/>
+        <location filename="../pages/TxKey.qml" line="159"/>
+        <location filename="../pages/TxKey.qml" line="271"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="166"/>
+        <location filename="../pages/TxKey.qml" line="278"/>
+        <source>Optional message against which the signature is signed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="186"/>
+        <source>Generate</source>
+        <translation type="unfinished">產生</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="209"/>
+        <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
+For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="297"/>
+        <source>Signature</source>
+        <translation type="unfinished">簽署結果</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="305"/>
+        <source>Paste tx proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="106"/>
+        <location filename="../pages/TxKey.qml" line="218"/>
         <source>Transaction ID</source>
         <translation>交易ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="161"/>
+        <location filename="../pages/TxKey.qml" line="113"/>
+        <location filename="../pages/TxKey.qml" line="225"/>
         <source>Paste tx ID</source>
         <translation>貼上交易 ID (tx ID)</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="193"/>
-        <source>Paste tx key</source>
-        <translation>貼上交易金鑰 (tx key)</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="216"/>
+        <location filename="../pages/TxKey.qml" line="326"/>
         <source>Check</source>
         <translation>檢查</translation>
-    </message>
-    <message>
-        <location filename="../pages/TxKey.qml" line="185"/>
-        <source>Transaction key</source>
-        <translation>交易金鑰</translation>
     </message>
 </context>
 <context>
@@ -1632,6 +1858,39 @@ Please upgrade or connect to another daemon</source>
         <location filename="../wizard/WizardCreateWallet.qml" line="100"/>
         <source>Create a new wallet</source>
         <translation>創建一個新的錢包</translation>
+    </message>
+</context>
+<context>
+    <name>WizardDaemonSettings</name>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="114"/>
+        <source>To be able to communicate with the Monero network your wallet needs to be connected to a Monero node. For best privacy it&apos;s recommended to run your own node.                         &lt;br&gt;&lt;br&gt;                         If you don&apos;t have the option to run an own node there&apos;s an option to connect to a remote node.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="126"/>
+        <source>Start a node automatically in background (recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <source>Blockchain location</source>
+        <translation type="unfinished">區塊鏈檔案儲存位置</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <source>(optional)</source>
+        <translation type="unfinished">(選填)</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
+        <source>Connect to a remote node until my own node has finished syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <source>Connect to a remote node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1737,44 +1996,44 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardMain</name>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="176"/>
+        <location filename="../wizard/WizardMain.qml" line="183"/>
         <source>A wallet with same name already exists. Please change wallet name</source>
         <translation>已有重複的錢包名稱存在，請更改錢包名稱</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="184"/>
+        <location filename="../wizard/WizardMain.qml" line="191"/>
         <source>Non-ASCII characters are not allowed in wallet path or account name</source>
         <translation>錢包的路徑與名稱不得使用非ASCII字元</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="366"/>
+        <location filename="../wizard/WizardMain.qml" line="375"/>
         <source>USE MONERO</source>
         <translation>使用 MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="383"/>
+        <location filename="../wizard/WizardMain.qml" line="392"/>
         <source>Create wallet</source>
         <translation>創建錢包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="393"/>
+        <location filename="../wizard/WizardMain.qml" line="402"/>
         <source>Success</source>
         <translation>成功</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="394"/>
+        <location filename="../wizard/WizardMain.qml" line="403"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translation>唯讀錢包已被建立，您可以在關閉此錢包後使用&quot;以檔案開啟錢包&quot;的選項，並選擇以下的檔案: 
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="411"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="415"/>
+        <location filename="../wizard/WizardMain.qml" line="424"/>
         <source>Abort</source>
         <translation>中止</translation>
     </message>
@@ -1782,47 +2041,52 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="133"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
         <source>Wallet name</source>
         <translation>錢包名稱</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="152"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
         <source>Restore from seed</source>
         <translation>從種子碼(seed)回復</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="166"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
         <source>Restore from keys</source>
         <translation>從金鑰回復</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="203"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <source>From QR Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
         <source>Account address (public)</source>
         <translation>帳戶位址 (公開)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="211"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
         <source>View key (private)</source>
         <translation>View key (私鑰)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="220"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
         <source>Spend key (private)</source>
         <translation>Spend key (私鑰)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="232"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
         <source>Restore height (optional)</source>
         <translation>回復特定區塊高度 (可選)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
         <source>Your wallet is stored in</source>
         <translation>您的錢包被儲存在</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="271"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
         <source>Please choose a directory</source>
         <translation>請選擇一個目錄</translation>
     </message>
@@ -1835,7 +2099,12 @@ Please upgrade or connect to another daemon</source>
         <translation>請輸入您的 25字種子碼(seed)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="88"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <source>Seed copied to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>這種子碼是&lt;b&gt;非常重要&lt;/b&gt;必須要抄寫下來並妥善保管的資訊，這是你回復錢包時所需要的所有資訊。</translation>
     </message>
@@ -1843,37 +2112,32 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="87"/>
+        <location filename="../wizard/WizardOptions.qml" line="74"/>
         <source>Welcome to Monero!</source>
         <translation>歡迎使用 Monero！</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="98"/>
+        <location filename="../wizard/WizardOptions.qml" line="85"/>
         <source>Please select one of the following options:</source>
         <translation>請於下面選擇您需要的功能:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="155"/>
+        <location filename="../wizard/WizardOptions.qml" line="141"/>
         <source>Create a new wallet</source>
         <translation>創建一個新的錢包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="197"/>
+        <location filename="../wizard/WizardOptions.qml" line="182"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>從金鑰或種子碼回復錢包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="241"/>
+        <location filename="../wizard/WizardOptions.qml" line="225"/>
         <source>Open a wallet from file</source>
         <translation>以檔案開啟錢包</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="262"/>
-        <source>Custom daemon address (optional)</source>
-        <translation>使用遠端區塊同步程式的IP或網址 (選填)</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardOptions.qml" line="295"/>
+        <location filename="../wizard/WizardOptions.qml" line="245"/>
         <source>Testnet</source>
         <translation>連接到測試網路</translation>
     </message>
@@ -1887,7 +2151,7 @@ Please upgrade or connect to another daemon</source>
         <translation>為您的錢包加上一個密碼</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPassword.qml" line="127"/>
+        <location filename="../wizard/WizardPassword.qml" line="126"/>
         <source> &lt;br&gt;Note: this password cannot be recovered. If you forget it then the wallet will have to be restored from its 25 word mnemonic seed.&lt;br/&gt;&lt;br/&gt;
                         &lt;b&gt;Enter a strong password&lt;/b&gt; (using letters, numbers, and/or symbols):</source>
         <translation>注意: 這個密碼無法被回復，如果您忘記了這個密碼，則必須使用25字種子碼回復您的錢包。&lt;br/&gt;&lt;br/&gt;
@@ -1897,12 +2161,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardPasswordUI</name>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="70"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="73"/>
         <source>Password</source>
         <translation>密碼</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardPasswordUI.qml" line="82"/>
+        <location filename="../wizard/WizardPasswordUI.qml" line="85"/>
         <source>Confirm password</source>
         <translation>確認密碼</translation>
     </message>
@@ -1910,7 +2174,7 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardRecoveryWallet</name>
     <message>
-        <location filename="../wizard/WizardRecoveryWallet.qml" line="112"/>
+        <location filename="../wizard/WizardRecoveryWallet.qml" line="118"/>
         <source>Restore wallet</source>
         <translation>回復錢包</translation>
     </message>
@@ -1918,12 +2182,12 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>WizardWelcome</name>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="79"/>
+        <location filename="../wizard/WizardWelcome.qml" line="73"/>
         <source>Welcome to Monero!</source>
         <translation>歡迎使用 Monero！</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWelcome.qml" line="89"/>
+        <location filename="../wizard/WizardWelcome.qml" line="83"/>
         <source>Please choose a language and regional format.</source>
         <translation>請選擇您的語言和地區格式。</translation>
     </message>
@@ -1931,107 +2195,114 @@ Please upgrade or connect to another daemon</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="323"/>
-        <location filename="../main.qml" line="491"/>
-        <location filename="../main.qml" line="503"/>
-        <location filename="../main.qml" line="553"/>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="607"/>
-        <location filename="../main.qml" line="616"/>
-        <location filename="../main.qml" line="668"/>
-        <location filename="../main.qml" line="706"/>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="352"/>
+        <location filename="../main.qml" line="561"/>
+        <location filename="../main.qml" line="573"/>
+        <location filename="../main.qml" line="623"/>
+        <location filename="../main.qml" line="635"/>
+        <location filename="../main.qml" line="677"/>
+        <location filename="../main.qml" line="686"/>
+        <location filename="../main.qml" line="738"/>
+        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="1032"/>
+        <location filename="../main.qml" line="1177"/>
+        <location filename="../main.qml" line="1280"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="324"/>
+        <location filename="../main.qml" line="353"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>無法開啟這個錢包:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (waiting for block)</source>
         <translation>可用餘額 (等待區塊確認中)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>可用餘額 (約需 ~%1 分鐘確認)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="355"/>
+        <location filename="../main.qml" line="382"/>
         <source>Unlocked balance</source>
         <translation>可用餘額</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="407"/>
+        <location filename="../main.qml" line="435"/>
+        <source>Remaining blocks (local node):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="475"/>
         <source>Waiting for daemon to start...</source>
         <translation>等待區塊同步程式啟動中...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="413"/>
+        <location filename="../main.qml" line="481"/>
         <source>Waiting for daemon to stop...</source>
         <translation>等待區塊同步程式停止中...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="438"/>
+        <location filename="../main.qml" line="506"/>
         <source>Daemon failed to start</source>
         <translation>區塊同步程式啟動失敗</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="439"/>
+        <location filename="../main.qml" line="507"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>請查看您的錢包與區塊同步程式日誌獲得錯誤訊息，您亦可嘗試手動重新啟動%1。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="493"/>
+        <location filename="../main.qml" line="563"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>無法建立此項交易: 區塊同步程式版本錯誤:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="495"/>
-        <location filename="../main.qml" line="608"/>
+        <location filename="../main.qml" line="565"/>
+        <location filename="../main.qml" line="678"/>
         <source>Can&apos;t create transaction: </source>
         <translation>無法建立此項交易:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="504"/>
-        <location filename="../main.qml" line="617"/>
+        <location filename="../main.qml" line="574"/>
+        <location filename="../main.qml" line="687"/>
         <source>No unmixable outputs to sweep</source>
         <translation>沒有無法混幣的輸出需要去除</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="516"/>
-        <location filename="../main.qml" line="629"/>
+        <location filename="../main.qml" line="586"/>
+        <location filename="../main.qml" line="699"/>
         <source>Confirmation</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="517"/>
-        <location filename="../main.qml" line="630"/>
+        <location filename="../main.qml" line="587"/>
+        <location filename="../main.qml" line="700"/>
         <source>Please confirm transaction:
 </source>
         <translation>請確認此項交易:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="518"/>
+        <location filename="../main.qml" line="588"/>
         <source>
 Address: </source>
         <translation>
 位址: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="519"/>
+        <location filename="../main.qml" line="589"/>
         <source>
 Payment ID: </source>
         <translation>
 付款 ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="520"/>
-        <location filename="../main.qml" line="631"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="701"/>
         <source>
 
 Amount: </source>
@@ -2040,14 +2311,14 @@ Amount: </source>
 金額: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="521"/>
-        <location filename="../main.qml" line="632"/>
+        <location filename="../main.qml" line="591"/>
+        <location filename="../main.qml" line="702"/>
         <source>
 Fee: </source>
         <translation>手續費: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="522"/>
+        <location filename="../main.qml" line="592"/>
         <source>
 
 Ringsize: </source>
@@ -2056,39 +2327,124 @@ Ringsize: </source>
 環簽大小: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="728"/>
+        <location filename="../main.qml" line="778"/>
+        <source>Payment proof</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="781"/>
+        <source>Couldn&apos;t generate a proof because of the following reason: 
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="811"/>
+        <location filename="../main.qml" line="831"/>
+        <source>Payment proof check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="814"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Bad signature</source>
+        <translation type="unfinished">有問題的簽署</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="822"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>這個位址收入了 %1 monero，並通過 %2 次的確認。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="833"/>
+        <source>Good signature</source>
+        <translation type="unfinished">良好的簽署</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1033"/>
+        <location filename="../main.qml" line="1281"/>
+        <source>Wrong password</source>
+        <translation type="unfinished">密碼錯誤</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1108"/>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1111"/>
+        <source>Error: Filesystem is read only</source>
+        <translation type="unfinished">錯誤: 沒有寫入權限</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1113"/>
+        <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">警告: 此裝置剩餘 %1 GB 可用裝置，區塊鏈需要約 %2 GB 存放空間。</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1115"/>
+        <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
+        <translation type="unfinished">注意: 此裝置尚有 %1 GB可用空間。 區塊鏈需要約 %2 GB的存放空間。</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1117"/>
+        <source>Note: lmdb folder not found. A new folder will be created.</source>
+        <translation type="unfinished">注意: 找不到lmdb資料夾。 將會建立一個新的。</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1121"/>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1174"/>
+        <source>Password changed successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1178"/>
+        <source>Error: </source>
+        <translation type="unfinished">錯誤: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1599"/>
+        <source>Tap again to close...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1612"/>
         <source>Daemon is running</source>
         <translation>區塊同步程式正在執行中</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1318"/>
+        <location filename="../main.qml" line="1613"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>區塊同步程式將在錢包介面關閉後於背景執行。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1320"/>
+        <location filename="../main.qml" line="1615"/>
         <source>Stop daemon</source>
         <translation>停止區塊同步程式</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1355"/>
+        <location filename="../main.qml" line="1650"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>有可用的新版本 Monero 錢包:  %1&lt;br&gt;%2</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="523"/>
+        <location filename="../main.qml" line="593"/>
         <source>
 Number of transactions: </source>
         <translation>
 交易數量: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="524"/>
+        <location filename="../main.qml" line="313"/>
+        <location filename="../main.qml" line="314"/>
+        <source>HIDDEN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="594"/>
         <source>
 
 Description: </source>
@@ -2097,77 +2453,73 @@ Description: </source>
 描述: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="554"/>
+        <location filename="../main.qml" line="624"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>金額錯誤: 數字需介於 %1 到 %2 之間</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="566"/>
+        <location filename="../main.qml" line="636"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>資金不足，總餘額僅有: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="669"/>
+        <location filename="../main.qml" line="739"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>無法付款: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="672"/>
+        <location filename="../main.qml" line="742"/>
+        <location filename="../main.qml" line="1173"/>
         <source>Information</source>
         <translation>資訊</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Money sent successfully: %1 transaction(s) </source>
         <translation> %1 筆款項已成功發送</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="748"/>
         <source>Transaction saved to file: %1</source>
         <translation>已儲存 %1 筆交易至檔案</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="718"/>
-        <source>Payment check</source>
-        <translation>付款確認</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="723"/>
+        <location filename="../main.qml" line="819"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>這個位址已收到 %1 monero幣，但這筆交易尚未被礦工確認</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="732"/>
+        <location filename="../main.qml" line="826"/>
         <source>This address received nothing</source>
         <translation>這個位址沒有收到款項</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance (syncing)</source>
         <translation>總餘額 (同步中)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="744"/>
+        <location filename="../main.qml" line="845"/>
         <source>Balance</source>
         <translation>總餘額</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="978"/>
+        <location filename="../main.qml" line="1203"/>
         <source>Please wait...</source>
         <translation>請稍後...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1002"/>
+        <location filename="../main.qml" line="1227"/>
         <source>Program setup wizard</source>
         <translation>程式設定精靈</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1017"/>
+        <location filename="../main.qml" line="1243"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1065"/>
+        <location filename="../main.qml" line="1317"/>
         <source>send to the same destination</source>
         <translation>付款至相同位址</translation>
     </message>

--- a/translations/monero-core_zh-tw.ts
+++ b/translations/monero-core_zh-tw.ts
@@ -272,7 +272,7 @@
     <message>
         <location filename="../components/HistoryTable.qml" line="258"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 次確認) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 次確認)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTable.qml" line="262"/>
@@ -340,7 +340,7 @@
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="150"/>
         <source>(%1/%2 confirmations)</source>
-        <translation type="unfinished">(%1/10 次確認) {1/%2 ?}</translation>
+        <translation type="unfinished">(%1/%2 次確認)</translation>
     </message>
     <message>
         <location filename="../components/HistoryTableMobile.qml" line="152"/>


### PR DESCRIPTION
Refresh translations since #981 has been merged.
Command: `lupdate -no-obsolete -pro monero-wallet-gui.pro`
(also picked up a number of additional strings which were added in the last few months)

I added a second commit which contains manual fixes for a few situations where `lupdate` got confused about numbers.
Example:
```
(%1/10 次確認) {1/%2 ?}
```

Translations system was confused that we now have `%1` and `%2` parameters.  So I fixed as:
```
(%1/%2 次確認)
```

@erciccione - Care to have a look?