### PR TITLE
UnsignedTransaction: Removing the Priority enum accordingly to libwalletapi update

### DIFF
--- a/src/libwalletqt/UnsignedTransaction.h
+++ b/src/libwalletqt/UnsignedTransaction.h
@@ -26,13 +26,6 @@ public:
     };
     Q_ENUM(Status)
 
-    enum Priority {
-        Priority_Low    = Monero::UnsignedTransaction::Priority_Low,
-        Priority_Medium = Monero::UnsignedTransaction::Priority_Medium,
-        Priority_High   = Monero::UnsignedTransaction::Priority_High
-    };
-    Q_ENUM(Priority)
-
     Status status() const;
     QString errorString() const;
     Q_INVOKABLE quint64 amount(int index) const;


### PR DESCRIPTION
Since `UnsignedTransaction::Priority` enum has been removed from Monero Core Wallet API, removing it from *monero-gui* as well.
Conflicts with : https://github.com/monero-project/monero-gui/pull/1098