### PR TITLE
startsWith is unsupported for Qt < 5.8, use indexOf instead

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -783,10 +783,10 @@ ApplicationWindow {
         var result;
         if (address.length > 0)
             result = currentWallet.getTxProof(txid, address, message);
-        if (!result || result.startsWith("error|"))
+        if (!result || result.indexOf("error|") === 0)
             result = currentWallet.getSpendProof(txid, message);
         informationPopup.title  = qsTr("Payment proof") + translationManager.emptyString;
-        if (result.startsWith("error|")) {
+        if (result.indexOf("error|") === 0) {
             var errorString = result.split("|")[1];
             informationPopup.text = qsTr("Couldn't generate a proof because of the following reason: \n") + errorString + translationManager.emptyString;
             informationPopup.icon = StandardIcon.Critical;

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -64,15 +64,15 @@ Rectangle {
     }
 
     function checkSignature(signature) {
-        if (signature.startsWith("OutProofV")) {
+        if (signature.indexOf("OutProofV") === 0) {
             if ((signature.length - 10) % 132 != 0)
                 return false;
             return check256(signature, signature.length);
-        } else if (signature.startsWith("InProofV")) {
+        } else if (signature.indexOf("InProofV") === 0) {
             if ((signature.length - 9) % 132 != 0)
                 return false;
             return check256(signature, signature.length);
-        } else if (signature.startsWith("SpendProofV")) {
+        } else if (signature.indexOf("SpendProofV") === 0) {
             if ((signature.length - 12) % 88 != 0)
                 return false;
             return check256(signature, signature.length);
@@ -328,7 +328,7 @@ Rectangle {
             shadowPressedColor: "#B32D00"
             releasedColor: "#FF6C3C"
             pressedColor: "#FF4304"
-            enabled: checkTxID(checkProofTxIdLine.text) && checkSignature(checkProofSignatureLine.text) && ((checkProofSignatureLine.text.startsWith("SpendProofV") && checkProofAddressLine.text.length == 0) || (!checkProofSignatureLine.text.startsWith("SpendProofV") && checkAddress(checkProofAddressLine.text, appWindow.persistentSettings.testnet)))
+            enabled: checkTxID(checkProofTxIdLine.text) && checkSignature(checkProofSignatureLine.text) && ((checkProofSignatureLine.text.indexOf("SpendProofV") === 0 && checkProofAddressLine.text.length == 0) || (checkProofSignatureLine.text.indexOf("SpendProofV") !== 0 && checkAddress(checkProofAddressLine.text, appWindow.persistentSettings.testnet)))
             onClicked: {
                 console.log("checkProof: Check clicked: txid " + checkProofTxIdLine.text + ", address " + checkProofAddressLine.text + ", message " + checkProofMessageLine.text + ", signature " + checkProofSignatureLine.text);
                 root.checkProofClicked(checkProofTxIdLine.text, checkProofAddressLine.text, checkProofMessageLine.text, checkProofSignatureLine.text)


### PR DESCRIPTION
> startsWith(searchString [, position ]) // ECMAScript 6: Added in Qt 5.8

http://doc.qt.io/qt-5/qtqml-javascript-functionlist.html

On some Linux systems like Ubuntu and Debian, the installed Qt version is below 5.8 where startsWith is unsupported.