### PR TITLE
add libreadline-dev in ubuntu/mint building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
   - For Ubuntu and Mint
 
-	`sudo apt install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev`
+	`sudo apt install build-essential cmake libboost-all-dev miniupnpc libunbound-dev graphviz doxygen libunwind8-dev pkg-config libssl-dev libzmq3-dev libreadline-dev`
 
   - For Gentoo
 


### PR DESCRIPTION
VM: clean installation of xubuntu-16.04.3-desktop-amd64, no packages added

After installing monero dependencies compilation fails with error:

```
/usr/bin/ld: no se puede encontrar -lwallet_merged
/usr/bin/ld: no se puede encontrar -lepee
/usr/bin/ld: no se puede encontrar -leasylogging
/usr/bin/ld: no se puede encontrar -lreadline
collect2: error: ld returned 1 exit status

Makefile:286: fallo en las instrucciones para el objetivo 'release/bin/monero-wallet-gui'
```

Installing libreadline-dev fixed the error for me.

Related to issue #1078 