### PR TITLE
Wizard: allow seed without checksum

### DIFF
--- a/wizard/WizardManageWalletUI.qml
+++ b/wizard/WizardManageWalletUI.qml
@@ -83,7 +83,7 @@ ColumnLayout {
     function checkSeed() {
         console.log("Checking seed")
         var wordsArray = Utils.lineBreaksToSpaces(uiItem.wordsTextItem.memoText).split(" ");
-        return wordsArray.length === 25
+        return wordsArray.length === 25 || wordsArray.length === 24
     }
 
     function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name, extra_parameters) {

--- a/wizard/WizardMemoTextInput.qml
+++ b/wizard/WizardMemoTextInput.qml
@@ -41,7 +41,7 @@ Column {
                 font.pixelSize: 16 * scaleRatio
                 anchors.margins: 8 * scaleRatio
                 font.bold:true
-                text: qsTr("Enter your 25 word mnemonic seed") + translationManager.emptyString
+                text: qsTr("Enter your 25 (or 24) word mnemonic seed") + translationManager.emptyString
                 color: "#BABABA"
                 visible: !memoTextInput.text/* && !parent.focus*/
             }


### PR DESCRIPTION
This can be useful when restoring from a seed in the old format (EnglishOld without checksum).