### PR TITLE
UTF-8 support for filenames and paths under Windows

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -218,6 +218,13 @@ win32 {
         -lboost_regex-mt-s \
         -lboost_chrono-mt-s \
         -lboost_program_options-mt-s \
+        -lboost_locale-mt-s \
+        -licuio \
+        -licuin \
+        -licuuc \
+        -licudt \
+        -licutu \
+        -liconv \
         -lssl \
         -lcrypto \
         -Wl,-Bdynamic \

--- a/wizard/WizardMain.qml
+++ b/wizard/WizardMain.qml
@@ -185,14 +185,6 @@ ColumnLayout {
             return false;
         }
 
-        // Don't allow non ascii characters in path on windows platforms until supported by Wallet2
-        if (isWindows) {
-            if (!isAscii(path)) {
-                walletErrorDialog.text = qsTr("Non-ASCII characters are not allowed in wallet path or account name")  + translationManager.emptyString;
-                walletErrorDialog.open();
-                return false;
-            }
-        }
         return true;
     }
 


### PR DESCRIPTION
This PR is the second part of a duo of PR's, the Monero GUI one - the one for Monero is [PR #3313](https://github.com/monero-project/monero/pull/3313).

Those 2 PR's fix a long-standing problem with names for files and paths on Windows: Wallets on Windows are not processed properly when either the wallet file names or the names of the containing directories contain any non-ASCII characters. See the following issues: [Monero GUI issue #199](https://github.com/monero-project/monero-gui/issues/199), [Monero GUI issue #1390](https://github.com/monero-project/monero/issues/1390) (late 2016), [Monero issue #938](https://github.com/monero-project/monero/issues/938), and possibly others.

Almost all of the necessary changes are in Monero code. For details and more info about the technical solution approach see [Monero PR #3313](https://github.com/monero-project/monero/pull/3313).

As Qt is fully UTF-8 capable anyway and Wallet2 now supports UTF-8 filenames as well, it's possible to process arbitrary-named wallets anywhere in the file system with the Windows GUI wallet. Even something like 陽葵 is possible now.

It would be best to coordinate the merging of this duo of PR's: With only the Monero one (#3313) merged the GUI wallet won't build anymore because the ICU libraries now needed by Monero will be missing in the GUI wallet's build file, i.e. in `monero-wallet-gui.pro`.

On the other hand merging only this PR alone won't improve anything yet.

After this the GUI wallet EXE references **5 ICU DLL's**, which is more than until now: `libicuioXX.dll`, `libicuinXX.dll`, `libicuucXX.dll`, `libicudtXX.dll` and `libicutuXX.dll`, with `XX` being the ICU version number. Depending on the Boost version and MSYS2 version used to build, this will be either 57 or 58, e.g. `libicuio58.dll`.

Of course this must be considered when packaging the GUI wallet. (There is no PR yet that would adjust that for the InnoSetup Windows installer script.)