### PR TITLE
Mac build: relro, now and noexecstack are unsupported for Mac

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -307,7 +307,7 @@ macx {
         -lcrypto \
         -ldl
 
-    QMAKE_LFLAGS += -pie -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
+    QMAKE_LFLAGS += -pie
 }
 
 


### PR DESCRIPTION
I'm not familiar with these flags, though.