### PR TITLE
build: remove readline from dependencies

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -104,7 +104,6 @@ LIBS += -L$$WALLET_ROOT/lib \
         -lepee \
         -lunbound \
         -leasylogging \
-        -lreadline \
 }
 
 android {


### PR DESCRIPTION
Seems like the wallet API's dependency on readline was removed by https://github.com/monero-project/monero/pull/2736