### PR TITLE
Disable Mining page when connected to remote node

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -409,7 +409,7 @@ Rectangle {
             // ------------- Mining tab ---------------
             MenuButton {
                 id: miningButton
-                visible: !isAndroid && !isIOS
+                visible: !isAndroid && !isIOS && !persistentSettings.useRemoteNode
                 anchors.left: parent.left
                 anchors.right: parent.right
                 text: qsTr("Mining") + translationManager.emptyString

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -70,14 +70,6 @@ Rectangle {
                 text: qsTr("Solo mining") + translationManager.emptyString
             }
 
-            Label {
-                id: soloLocalDaemonsLabel
-                fontSize: 18
-                color: "#D02020"
-                text: qsTr("(only available for local daemons)")
-                visible: !isDaemonLocal()
-            }
-
             Text {
                 id: soloMainLabel
                 text: qsTr("Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.<br> <br>Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!") + translationManager.emptyString
@@ -157,8 +149,6 @@ Rectangle {
                         } else {
                             errorPopup.title  = qsTr("Error starting mining") + translationManager.emptyString;
                             errorPopup.text = qsTr("Couldn't start mining.<br>")
-                            if (!isDaemonLocal())
-                                errorPopup.text += qsTr("Mining is only available on local daemons. Run a local daemon to be able to mine.<br>")
                             errorPopup.icon = StandardIcon.Critical
                             errorPopup.open()
                         }


### PR DESCRIPTION
Mining is only available for local daemons, so disable left panel mining menu when connected to remote daemon. This PR also removes some warnings in mining page since those aren't reached anymore.

I'm not sure if I need to touch any other thing, I tested this in Ubuntu and Windows.

Feedback is welcome.