### PR TITLE
add window icon for linux

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,7 @@
 #include <QQmlApplicationEngine>
 #include <QtQml>
 #include <QStandardPaths>
+#include <QIcon>
 #include <QDebug>
 #include <QObject>
 #include <QDesktopWidget>
@@ -90,6 +91,10 @@ int main(int argc, char *argv[])
     app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");
     app.setOrganizationName("monero-project");
+
+    #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    app.setWindowIcon(QIcon(":/images/appicon.ico"));
+    #endif
 
     filter *eventFilter = new filter;
     app.installEventFilter(eventFilter);

--- a/qml.qrc
+++ b/qml.qrc
@@ -165,5 +165,6 @@
         <file>components/RemoteNodeEdit.qml</file>
         <file>pages/Keys.qml</file>
         <file>images/menu.png</file>
+        <file>images/appicon.ico</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
use setWindowIcon for linux. AFAIK this isn't needed in mac/win where the app icon is embedded in the application. 

 
Before:

![screenshot at 2018-03-14 18 11 32](https://user-images.githubusercontent.com/975883/37419053-ea8107e0-27b3-11e8-8409-02828752ad69.png)

After:

![screenshot at 2018-03-14 18 19 50](https://user-images.githubusercontent.com/975883/37419295-6cca7056-27b4-11e8-8cf8-d6f374e59cda.png)

It is up to your desktop enviroment where those changes are reflected. Targets are: taskbar, window switcher (alt+tab) and window decoration
