### PR TITLE
pro: add lmdb to link line for Linux

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -104,6 +104,7 @@ LIBS += -L$$WALLET_ROOT/lib \
         -lepee \
         -lunbound \
         -leasylogging \
+        -llmdb \
 }
 
 android {


### PR DESCRIPTION
Otherwise `undefined symbol mdb_tx_abort` and others.
Possibly same is needed for other platforms. I don't have them, so didn't touch the other lists.