### PR TITLE
Additional DLLs in 'windeploy_helper.sh': ICU, stack protection, regexp

### DIFF
--- a/windeploy_helper.sh
+++ b/windeploy_helper.sh
@@ -17,13 +17,13 @@ fi
 
 if [[ "$BUILD_TYPE" == "Release" ]]; then
 	echo "Release build"
-	ICU_FILES=(libicuuc57.dll libicuin57.dll libicudt57.dll)
+	ICU_FILES=(libicudt58.dll libicuin58.dll libicuio58.dll libicutu58.dll libicuuc58.dll)
 else
 	echo "Debug build"
-	ICU_FILES=(libicuucd57.dll libicuind57.dll libicudtd57.dll)
+	ICU_FILES=(libicudtd58.dll libicuind58.dll libicuiod58.dll libicutud58.dll libicuucd58.dll)
 fi
 
-FILES=(zlib1.dll libwinpthread-1.dll libtiff-5.dll libstdc++-6.dll libpng16-16.dll libpcre16-0.dll libpcre-1.dll libmng-2.dll liblzma-5.dll liblcms2-2.dll libjpeg-8.dll libintl-8.dll libiconv-2.dll libharfbuzz-0.dll libgraphite2.dll libglib-2.0-0.dll libfreetype-6.dll libbz2-1.dll)
+FILES=(zlib1.dll libwinpthread-1.dll libtiff-5.dll libstdc++-6.dll libpng16-16.dll libpcre16-0.dll libpcre-1.dll libmng-2.dll liblzma-5.dll liblcms2-2.dll libjpeg-8.dll libintl-8.dll libiconv-2.dll libharfbuzz-0.dll libgraphite2.dll libglib-2.0-0.dll libfreetype-6.dll libbz2-1.dll libssp-0.dll libpcre2-16-0.dll)
 
 platform=$(get_platform)
 


### PR DESCRIPTION
The GUI exe for Windows, built with the latest sources, and with a MSYS2 build environment updated to latest versions of all packages, needs some more DLLs than until now: `libssp-0.dll` (for the recently-introduced stack protection), `libpcre2-16-0.dll` (something about regular expressions?), and 5 ICU libraries (a direct consequence of my own [PR #1141](https://github.com/monero-project/monero-gui/pull/1141).

I updated `windeploy_helper.sh` to copy all those files.

Please note: If with these changes the script does not find the ICU libraries your MSYS2 environment is not updated to the latest version of ICU. Background info about the library rename in question is [here](https://github.com/monero-project/monero/pull/3375).