### PR TITLE
Bring back wallet name at the password dialog

### DIFF
--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -80,7 +80,7 @@ Item {
             Layout.maximumWidth: 400 * scaleRatio
 
             Label {
-                text: qsTr("Please enter wallet password")
+                text: root.walletName.length > 0 ? qsTr("Please enter wallet password for: ") + root.walletName : qsTr("Please enter wallet password")
                 anchors.left: parent.left
                 Layout.fillWidth: true
 


### PR DESCRIPTION
```
< *> One problem I find when trying to use it, is that the password dialog doesn't display the wallet's file name at the app launch.
< *> This can be confusing, especially if you forget which wallet file you used previously.
```