### PR TITLE
Add libpcsclite to link line if libwallet_merged is linked against it

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -266,6 +266,11 @@ linux {
       LIBS+= -ldl
     }
 
+    if($$(PCSC_FOUND)) {
+        LIBS+= \
+            -lpcsclite
+    }
+
     LIBS+= \
         -lboost_serialization \
         -lboost_thread \


### PR DESCRIPTION
This fixes unresolved dependencies when linking monero-wallet-gui if libwallet_merged was built with HW device support.