### PR TITLE
Add libpcsclite to link line if libwallet_merged is linked against it

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -4,7 +4,10 @@ QT += qml quick widgets
 
 WALLET_ROOT=$$PWD/monero
 
-CONFIG += c++11
+CONFIG += c++11 link_pkgconfig
+packagesExist(libpcsclite) {
+    PKGCONFIG += libpcsclite
+}
 QMAKE_CXXFLAGS += -fPIC -fstack-protector
 QMAKE_LFLAGS += -fstack-protector
 


### PR DESCRIPTION
This fixes unresolved dependencies when linking monero-wallet-gui if libwallet_merged was built with HW device support.