### PR TITLE
Add Qt Runtime version to settings page

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -173,6 +173,8 @@ int main(int argc, char *argv[])
 
     engine.rootContext()->setContextProperty("mainApp", &app);
 
+    engine.rootContext()->setContextProperty("qtRuntimeVersion", qVersion());
+
 // Exclude daemon manager from IOS
 #ifndef Q_OS_IOS
     DaemonManager * daemonManager = DaemonManager::instance(&arguments);

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -623,7 +623,7 @@ Rectangle {
             Layout.topMargin: 8
             font.pixelSize: 14
             Layout.fillWidth: true
-            text: qsTr("GUI version: ") + Version.GUI_VERSION + translationManager.emptyString
+            text: qsTr("GUI version: ") + Version.GUI_VERSION + " (Qt " + qtRuntimeVersion + ")" + translationManager.emptyString
         }
         TextBlock {
             id: guiMoneroVersion


### PR DESCRIPTION
Display Qt runtime version on settings page to help debug issues like #1223, which can be related to upstream Qt bugs.

In static builds qt runtime version should match qt compile time version, so I think we don't need to include both.
 
![screenshot](https://user-images.githubusercontent.com/975883/38177031-ef979b50-35f9-11e8-8cd8-6b3610cec3b2.png)

Please review the translation stuff, I'm not sure if the string is well formed.