### PR TITLE
ProgressBar: fix conversion to percentage

### DIFF
--- a/components/ProgressBar.qml
+++ b/components/ProgressBar.qml
@@ -42,7 +42,7 @@ Rectangle {
     function updateProgress(currentBlock,targetBlock, blocksToSync, statusTxt){
         if(targetBlock > 0) {
             var remaining = (currentBlock < targetBlock) ? targetBlock - currentBlock : 0
-            var progressLevel = (blocksToSync > 0 && blocksToSync != remaining) ? (100*(blocksToSync - remaining)/blocksToSync).toFixed(0) : 100*(currentBlock / targetBlock).toFixed(0)
+            var progressLevel = (blocksToSync > 0 && blocksToSync != remaining) ? (100*(blocksToSync - remaining)/blocksToSync).toFixed(0) : (100*(currentBlock / targetBlock)).toFixed(0)
             fillLevel = progressLevel
             if(typeof statusTxt != "undefined" && statusTxt != "") {
                 progressText.text = statusTxt;


### PR DESCRIPTION
Previously, `progressLevel` was always set to zero when `currentBlock / targetBlock < 0.5` because `100*(currentBlock / targetBlock).toFixed(0)` is evaluated as `100*((currentBlock / targetBlock).toFixed(0)) = 100*0 = 0`.