### PR TITLE
Update README.md with  new Ubuntu dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
   - For Ubuntu 16.04+ x64
 
-    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qt-labs-settings libqt5qml-graphicaleffects`
+    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings libqt5qml-graphicaleffects`
 
   - For Linux Mint 18 "Sarah" - Cinnamon x64
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
   - For Ubuntu 16.04+ x64
 
-    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-dialogs qml-module-qt-labs-settings libqt5qml-graphicaleffects`
+    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-xmllistmodel qttools5-dev-tools qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qt-labs-settings libqt5qml-graphicaleffects`
 
   - For Linux Mint 18 "Sarah" - Cinnamon x64
 


### PR DESCRIPTION
Updated README.md with new dependency for Ubuntu 16.04+:
+ qml-module-qtquick-controls2

as per issue #1242