### PR TITLE
Settings: use checkbox instead of button for daemon mode switching

### DIFF
--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -201,29 +201,29 @@ Rectangle {
             Layout.fillWidth: true
 
             LabelSubheader {
-                text: qsTr("Wallet mode") + translationManager.emptyString
+                text: qsTr("Daemon mode") + translationManager.emptyString
             }
         }
 
-        RowLayout {
-            StandardButton {
+        ColumnLayout {
+            CheckBox {
                 id: remoteDisconnect
-                small: true
-                enabled: persistentSettings.useRemoteNode
-                Layout.fillWidth: false
+                checked: !persistentSettings.useRemoteNode
                 text: qsTr("Local Node") + translationManager.emptyString
                 onClicked: {
+                    persistentSettings.useRemoteNode = false;
+                    remoteConnect.checked = false;
                     appWindow.disconnectRemoteNode();
                 }
             }
 
-            StandardButton {
+            CheckBox {
                 id: remoteConnect
-                small: true
-                enabled: !persistentSettings.useRemoteNode
-                Layout.fillWidth: false
+                checked: persistentSettings.useRemoteNode
                 text: qsTr("Remote Node") + translationManager.emptyString
                 onClicked: {
+                    persistentSettings.useRemoteNode = true;
+                    remoteDisconnect.checked = false;
                     appWindow.connectRemoteNode();
                 }
             }


### PR DESCRIPTION
IMO the current way of using grayed disabled buttons to indicate the selected mode is a bit unintuitive. 

![screen shot 2018-04-07 at 14 23 57](https://user-images.githubusercontent.com/26077532/38451755-ac493270-3a70-11e8-86b1-3de93d828aca.jpg)
