### PR TITLE
Leftpanel overlay fix

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -252,7 +252,9 @@ Rectangle {
 
         Flickable {
             id:flicker
-            contentHeight: 500 * scaleRatio
+            contentHeight: (progressBar.visible)? menuColumn.height + separator.height + 
+                networkStatus.height + progressBar.height + daemonProgressBar.height : 
+                menuColumn.height + separator.height + networkStatus.height
             anchors.fill: parent
             clip: true
 
@@ -568,15 +570,26 @@ Rectangle {
 
         } // Flickable
 
+        Rectangle {
+            id: separator
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: 0
+            anchors.rightMargin: 0
+            anchors.bottom: networkStatus.top;
+            height: 10 * scaleRatio
+            color: "black"
+        }
+
         NetworkStatusItem {
             id: networkStatus
             anchors.left: parent.left
             anchors.right: parent.right
-            anchors.leftMargin: 4
-            anchors.rightMargin: 4
+            anchors.leftMargin: 0
+            anchors.rightMargin: 0
             anchors.bottom: (progressBar.visible)? progressBar.top : parent.bottom;
             connected: Wallet.ConnectionStatus_Disconnected
-            height: 58 * scaleRatio
+            height: 48 * scaleRatio
         }
 
         ProgressBar {
@@ -584,7 +597,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: daemonProgressBar.top
-            height: 35 * scaleRatio
+            height: 48 * scaleRatio
             syncType: qsTr("Wallet")
             visible: networkStatus.connected
         }

--- a/components/NetworkStatusItem.qml
+++ b/components/NetworkStatusItem.qml
@@ -34,7 +34,7 @@ import "../components" as MoneroComponents
 
 Rectangle {
     id: item
-    color: "transparent"
+    color: "black"
     property var connected: Wallet.ConnectionStatus_Disconnected
 
     function getConnectionStatusString(status) {

--- a/components/ProgressBar.qml
+++ b/components/ProgressBar.qml
@@ -37,7 +37,7 @@ Rectangle {
     property string syncType // Wallet or Daemon
     property string syncText: qsTr("%1 blocks remaining: ").arg(syncType)
     visible: false
-    color: "transparent"
+    color: "black"
 
     function updateProgress(currentBlock,targetBlock, blocksToSync, statusTxt){
         if(targetBlock > 0) {


### PR DESCRIPTION
Temporary fix to #1288 that works in the new black theme. Since the leftpanel menu doesn't have an explicit height and the status elements are on top of the menu I changed two things:

1. statusbar elements (networkStatus and progressBars) have black background
2. made the flickable region dynamic to let us scroll to the menu items hidden by statusbar

![sin nombre](https://user-images.githubusercontent.com/975883/38456511-a3ee168a-3a85-11e8-8c87-9095089226d8.png)
