### PR TITLE
Restyle daemon dialog window

### DIFF
--- a/components/DaemonConsole.qml
+++ b/components/DaemonConsole.qml
@@ -34,12 +34,13 @@ import QtQuick.Controls.Styles 1.4
 import QtQuick.Window 2.2
 
 import "../components" as MoneroComponents
+import "../js/Windows.js" as Windows
 
 Window {
     id: root
     modality: Qt.ApplicationModal
     color: "black"
-    flags: persistentSettings.customDecorations ? (Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint) : (Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint)
+    flags: persistentSettings.customDecorations ? Windows.flagsCustomDecorations : Windows.flags
     property string title
     property alias text: dialogContent.text
     property alias content: root.text

--- a/components/DaemonConsole.qml
+++ b/components/DaemonConsole.qml
@@ -52,10 +52,12 @@ Window {
     signal rejected()
 
     function open() {
+        inactiveOverlay.visible = true;
         show();
     }
 
     function closeWindow() {
+        inactiveOverlay.visible = false;
         root.close();
         root.accepted();
     }
@@ -63,6 +65,15 @@ Window {
     // TODO: implement without hardcoding sizes
     width:  480
     height: 280
+
+    // background gradient
+    Image {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        source: "../images/middlePanelBg.jpg"
+    }
 
     // Make window draggable
     MouseArea {
@@ -75,6 +86,7 @@ Window {
 
     TitleBar {
         id: titleBar
+        small: true
         anchors.left: parent.left
         anchors.right: parent.right
         x: 0
@@ -116,7 +128,7 @@ Window {
         anchors.topMargin: titleBar.visible ? 80 : 20
 
         anchors.margins: 35 * scaleRatio
-        spacing: 30 * scaleRatio
+        spacing: 20 * scaleRatio
 
         RowLayout {
             visible: !persistentSettings.customDecorations
@@ -152,7 +164,7 @@ Window {
                     textFormat: TextEdit.AutoText
                     wrapMode: TextEdit.Wrap
                     background: Rectangle {
-                        color: "black"
+                        color: "transparent"
                         anchors.fill: parent
                         border.color: Qt.rgba(255, 255, 255, 0.25);
                         border.width: 1
@@ -170,25 +182,17 @@ Window {
             }
         }
 
-        GridLayout {
-            columns: (isMobile)? 1 : 2
+        RowLayout {
             Layout.fillWidth: true
-            columnSpacing: 32
 
-            ColumnLayout {}
-
-            ColumnLayout {
+            MoneroComponents.LineEdit {
+                id: sendCommandText
                 Layout.fillWidth: true
-
-                MoneroComponents.LineEdit {
-                    id: sendCommandText
-                    Layout.fillWidth: true
-                    placeholderText: qsTr("command + enter (e.g help)") + translationManager.emptyString
-                    onAccepted: {
-                        if(text.length > 0)
-                            daemonManager.sendCommand(text, currentWallet.nettype);
-                        text = ""
-                    }
+                placeholderText: qsTr("command + enter (e.g help)") + translationManager.emptyString
+                onAccepted: {
+                    if(text.length > 0)
+                        daemonManager.sendCommand(text, currentWallet.nettype);
+                    text = ""
                 }
             }
         }

--- a/components/DaemonConsole.qml
+++ b/components/DaemonConsole.qml
@@ -31,7 +31,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.1
 import QtQuick.Controls.Styles 1.4
-import QtQuick.Window 2.0
+import QtQuick.Window 2.2
 
 import "../components" as MoneroComponents
 
@@ -51,15 +51,13 @@ Window {
     signal accepted()
     signal rejected()
 
+    onClosing: {
+        inactiveOverlay.visible = false;
+    }
+
     function open() {
         inactiveOverlay.visible = true;
         show();
-    }
-
-    function closeWindow() {
-        inactiveOverlay.visible = false;
-        root.close();
-        root.accepted();
     }
 
     // TODO: implement without hardcoding sizes
@@ -94,7 +92,7 @@ Window {
         showMinimizeButton: false
         showMaximizeButton: false
         showWhatIsButton: false
-        onCloseClicked: closeWindow();
+        onCloseClicked: root.close();
         title: root.title
         visible: persistentSettings.customDecorations ? true : false
 

--- a/components/DaemonConsole.qml
+++ b/components/DaemonConsole.qml
@@ -174,9 +174,14 @@ Window {
                 }
 
                 ScrollBar.vertical: ScrollBar {
-
+                    // TODO
+                    // scrollbar always visible is somewhat buggy
+                    // QT 5.7 introduces `policy: ScrollBar.AlwaysOn`
+                    // but we can't use it yet.
+                    contentItem.opacity: 1
                     anchors.top: flickable.top
                     anchors.left: flickable.right
+                    anchors.leftMargin: 10
                     anchors.bottom: flickable.bottom
                 }
             }

--- a/components/DaemonConsole.qml
+++ b/components/DaemonConsole.qml
@@ -66,10 +66,7 @@ Window {
 
     // background gradient
     Image {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
+        anchors.fill: parent
         source: "../images/middlePanelBg.jpg"
     }
 
@@ -85,12 +82,8 @@ Window {
     ColumnLayout {
         id: mainLayout
 
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        anchors.topMargin: 20
-
+        anchors.fill: parent
+        anchors.topMargin: 20 * scaleRatio
         anchors.margins: 35 * scaleRatio
         spacing: 20 * scaleRatio
 
@@ -110,7 +103,7 @@ Window {
                     selectByKeyboard: true
                     anchors.fill: parent
                     font.family: "Ariel"
-                    font.pixelSize: 14
+                    font.pixelSize: 14 * scaleRatio
                     color: MoneroComponents.Style.defaultFontColor
                     selectionColor: MoneroComponents.Style.dimmedFontColor
                     wrapMode: TextEdit.Wrap
@@ -164,14 +157,12 @@ Window {
                 }
 
                 ScrollBar.vertical: ScrollBar {
-                    // TODO
-                    // scrollbar always visible is somewhat buggy
-                    // QT 5.7 introduces `policy: ScrollBar.AlwaysOn`
-                    // but we can't use it yet.
+                    // TODO: scrollbar always visible is buggy.
+                    // QT 5.9 introduces `policy: ScrollBar.AlwaysOn`
                     contentItem.opacity: 1
                     anchors.top: flickable.top
                     anchors.left: flickable.right
-                    anchors.leftMargin: 10
+                    anchors.leftMargin: 10 * scaleRatio
                     anchors.bottom: flickable.bottom
                 }
             }

--- a/components/DaemonConsole.qml
+++ b/components/DaemonConsole.qml
@@ -40,12 +40,10 @@ Window {
     id: root
     modality: Qt.ApplicationModal
     color: "black"
-    flags: persistentSettings.customDecorations ? Windows.flagsCustomDecorations : Windows.flags
-    property string title
+    flags: Windows.flags
     property alias text: dialogContent.text
     property alias content: root.text
     property alias textArea: dialogContent
-    property alias titleBar: titleBar
     property var icon
 
     // same signals as Dialog has
@@ -83,40 +81,6 @@ Window {
         onMouseYChanged: root.y += (mouseY - lastMousePos.y)
     }
 
-    TitleBar {
-        id: titleBar
-        small: true
-        anchors.left: parent.left
-        anchors.right: parent.right
-        x: 0
-        y: 0
-        showMinimizeButton: false
-        showMaximizeButton: false
-        showWhatIsButton: false
-        onCloseClicked: root.close();
-        title: root.title
-        visible: persistentSettings.customDecorations ? true : false
-
-        MouseArea {
-            enabled: persistentSettings.customDecorations
-            property var previousPosition
-            anchors.fill: parent
-            propagateComposedEvents: true
-            onPressed: previousPosition = globalCursor.getPosition()
-            onPositionChanged: {
-                if (pressedButtons == Qt.LeftButton) {
-                    var pos = globalCursor.getPosition()
-                    var dx = pos.x - previousPosition.x
-                    var dy = pos.y - previousPosition.y
-
-                    root.x += dx
-                    root.y += dy
-                    previousPosition = pos
-                }
-            }
-        }
-    }
-
     ColumnLayout {
         id: mainLayout
 
@@ -124,24 +88,10 @@ Window {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        anchors.topMargin: titleBar.visible ? 80 : 20
+        anchors.topMargin: 20
 
         anchors.margins: 35 * scaleRatio
         spacing: 20 * scaleRatio
-
-        RowLayout {
-            visible: !persistentSettings.customDecorations
-            Layout.fillWidth: true
-            anchors.horizontalCenter: parent.horizontalCenter
-
-            MoneroComponents.Label {
-                id: titleLabel
-                anchors.horizontalCenter: parent.horizontalCenter
-                fontSize: 24
-                text: title
-                z: parent.z + 1
-            }
-        }
 
         RowLayout {
             Layout.fillWidth: true

--- a/components/NewPasswordDialog.qml
+++ b/components/NewPasswordDialog.qml
@@ -38,13 +38,7 @@ import "../components" as MoneroComponents
 Item {
     id: root
     visible: false
-    Rectangle {
-        id: bg
-        z: parent.z + 1
-        anchors.fill: parent
-        color: "black"
-        opacity: 0.8
-    }
+    z: parent.z + 2
 
     property alias password: passwordInput1.text
 

--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -38,6 +38,7 @@ import "../components" as MoneroComponents
 Item {
     id: root
     visible: false
+    z: parent.z + 2
 
     property alias password: passwordInput.text
     property string walletName
@@ -48,6 +49,7 @@ Item {
     signal closeCallback()
 
     function open(walletName) {
+        inactiveOverlay.visible = true // draw appwindow inactive
         root.walletName = walletName ? walletName : ""
         leftPanel.enabled = false
         middlePanel.enabled = false
@@ -59,6 +61,7 @@ Item {
     }
 
     function close() {
+        inactiveOverlay.visible = false
         leftPanel.enabled = true
         middlePanel.enabled = true
         titleBar.enabled = true
@@ -165,12 +168,5 @@ Item {
             }
 
         }
-    }
-    Rectangle {
-        id: bg
-
-        anchors.fill: parent
-        color: "black"
-        opacity: 0.8
     }
 }

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -32,25 +32,32 @@ import QtQuick.Layouts 1.1
 
 Rectangle {
     id: titleBar
-
+    
+    height: customDecorations && !isMobile ? 50 : 0
+    y: -height
+    z: 1
+    
+    property string title
     property int mouseX: 0
     property bool containsMouse: false
     property alias basicButtonVisible: goToBasicVersionButton.visible
     property bool customDecorations: true
+    property bool showWhatIsButton: true
+    property bool showMinimizeButton: false
+    property bool showMaximizeButton: false
+    property bool showCloseButton: true
+    
+    signal closeClicked
+    signal maximizeClicked
+    signal minimizeClicked
     signal goToBasicVersion(bool yes)
-    height: customDecorations && !isMobile ? 50 : 0
-    y: -height
-    property string title
-    property alias maximizeButtonVisible: maximizeButton.visible
-    z: 1
 
     Item {
-        id: test
+        // Background gradient
         width: parent.width
         height: 50
-        z: 1
+        z: parent.z + 1
 
-        // use jpg for gradiency
         Image {
            anchors.fill: parent
            height: parent.height
@@ -65,7 +72,7 @@ Rectangle {
         height: 50
         anchors.centerIn: parent
         visible: customDecorations
-        z: 1
+        z: parent.z + 1
 
         Image {
             anchors.left: parent.left
@@ -88,7 +95,7 @@ Rectangle {
         height: 50 * scaleRatio
         width: height
         visible: isMobile
-        z: 2
+        z: parent.z + 2
 
         Image {
             width: 14
@@ -118,10 +125,11 @@ Rectangle {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         visible: parent.customDecorations
-        z: 2
+        z: parent.z + 2
 
         Rectangle {
             id: whatIsAreaButton
+            visible: showWhatIsButton
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 42
@@ -148,6 +156,7 @@ Rectangle {
 
         Rectangle {
             id: minimizeButton
+            visible: showMinimizeButton
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 42
@@ -165,14 +174,13 @@ Rectangle {
                 cursorShape: Qt.PointingHandCursor
                 onEntered: minimizeButton.color = "#262626";
                 onExited: minimizeButton.color = "transparent";
-                onClicked: {
-                    appWindow.visibility = Window.Minimized
-                }
+                onClicked: minimizeClicked();
             }
         }
 
         Rectangle {
             id: maximizeButton
+            visible: showMaximizeButton
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 42
@@ -193,15 +201,13 @@ Rectangle {
                 cursorShape: Qt.PointingHandCursor
                 onEntered: maximizeButton.color = "#262626";
                 onExited: maximizeButton.color = "transparent";
-                onClicked: {
-                    appWindow.visibility = appWindow.visibility !== Window.FullScreen ? Window.FullScreen :
-                                                                                        Window.Windowed
-                }
+                onClicked: maximizeClicked();
             }
         }
 
         Rectangle {
             id: closeButton
+            visible: showCloseButton
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 42
@@ -216,7 +222,7 @@ Rectangle {
 
             MouseArea {
                 anchors.fill: parent
-                onClicked: appWindow.close();
+                onClicked: closeClicked();
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onEntered: closeButton.color = "#262626";
@@ -225,4 +231,12 @@ Rectangle {
         }
     }
 
+    Rectangle {
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.left: parent.left
+        height:1
+        color: "#2F2F2F"
+        z: 2
+    }
 }

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -41,11 +41,12 @@ Rectangle {
     property int mouseX: 0
     property bool containsMouse: false
     property alias basicButtonVisible: goToBasicVersionButton.visible
-    property bool customDecorations: true
+    property bool customDecorations: persistentSettings.customDecorations
     property bool showWhatIsButton: true
     property bool showMinimizeButton: false
     property bool showMaximizeButton: false
     property bool showCloseButton: true
+    property bool showMoneroLogo: false
     
     signal closeClicked
     signal maximizeClicked
@@ -66,12 +67,12 @@ Rectangle {
         }
     }
 
-    Item{
+    Item {
         id: titlebarlogo
         width: 125
         height: 50
         anchors.centerIn: parent
-        visible: customDecorations
+        visible: customDecorations && showMoneroLogo
         z: parent.z + 1
 
         Image {
@@ -82,6 +83,15 @@ Rectangle {
             height: 28
             source: "../images/titlebarLogo.png"
         }
+    }
+
+    Label {
+        id: titleLabel
+        visible: !showMoneroLogo && customDecorations && titleBar.title !== ''
+        anchors.centerIn: parent
+        fontSize: 24
+        text: titleBar.title
+        z: parent.z + 1
     }
 
     // collapse left panel

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -32,11 +32,18 @@ import QtQuick.Layouts 1.1
 
 Rectangle {
     id: titleBar
-    
-    height: customDecorations && !isMobile ? 50 : 0
+
+    height: {
+        if(!customDecorations || isMobile){
+            return 0;
+        }
+
+        if(small) return 38 * scaleRatio;
+        else return 50 * scaleRatio;
+    }
     y: -height
     z: 1
-    
+
     property string title
     property int mouseX: 0
     property bool containsMouse: false
@@ -47,7 +54,8 @@ Rectangle {
     property bool showMaximizeButton: false
     property bool showCloseButton: true
     property bool showMoneroLogo: false
-    
+    property bool small: false
+
     signal closeClicked
     signal maximizeClicked
     signal minimizeClicked
@@ -56,13 +64,13 @@ Rectangle {
     Item {
         // Background gradient
         width: parent.width
-        height: 50
+        height: s
         z: parent.z + 1
 
         Image {
-           anchors.fill: parent
-           height: parent.height
-           width: parent.width
+           anchors.fill: titleBar
+           height: titleBar.height
+           width: titleBar.width
            source: "../images/titlebarGradient.jpg"
         }
     }
@@ -70,7 +78,7 @@ Rectangle {
     Item {
         id: titlebarlogo
         width: 125
-        height: 50
+        height: parent.height
         anchors.centerIn: parent
         visible: customDecorations && showMoneroLogo
         z: parent.z + 1
@@ -89,7 +97,7 @@ Rectangle {
         id: titleLabel
         visible: !showMoneroLogo && customDecorations && titleBar.title !== ''
         anchors.centerIn: parent
-        fontSize: 24
+        fontSize: 18
         text: titleBar.title
         z: parent.z + 1
     }
@@ -102,7 +110,7 @@ Rectangle {
         anchors.top: parent.top
         anchors.left: parent.left
         color:  "transparent"
-        height: 50 * scaleRatio
+        height: titleBar.height
         width: height
         visible: isMobile
         z: parent.z + 2
@@ -241,12 +249,23 @@ Rectangle {
         }
     }
 
+    // window borders
     Rectangle {
         anchors.bottom: parent.bottom
         anchors.right: parent.right
         anchors.left: parent.left
-        height:1
+        height: 1
         color: "#2F2F2F"
-        z: 2
+        z: parent.z + 1
+    }
+
+    Rectangle {
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.left: parent.left
+        visible: titleBar.small
+        height: 1
+        color: "#2F2F2F"
+        z: parent.z + 1
     }
 }

--- a/js/Utils.js
+++ b/js/Utils.js
@@ -1,0 +1,20 @@
+function formatDate( date, params ) {
+    var options = {
+        weekday: "short",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "UTC",
+        timeZoneName: "short",
+    };
+
+    options = [options, params].reduce(function (r, o) {
+        Object.keys(o).forEach(function (k) { r[k] = o[k]; });
+        return r;
+    }, {});
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
+    return new Date( date ).toLocaleString( 'en-US', options );
+}

--- a/js/Windows.js
+++ b/js/Windows.js
@@ -1,3 +1,6 @@
+var flagsCustomDecorations = (Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint);
+var flags = (Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint);
+
 function setCustomWindowDecorations(custom) {
     var x = appWindow.x
     var y = appWindow.y
@@ -12,11 +15,11 @@ function setCustomWindowDecorations(custom) {
     daemonConsolePopup.titleBar.visible = custom;
 
     if (custom) {
-        appWindow.flags = Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint;
-        daemonConsolePopup.flags = Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint;
+        appWindow.flags = flagsCustomDecorations;
+        daemonConsolePopup.flags = flagsCustomDecorations;
     } else {
-        appWindow.flags = Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint;
-        daemonConsolePopup.flags = Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint;
+        appWindow.flags = flags;
+        daemonConsolePopup.flags = flags;
     }
 
     appWindow.hide()

--- a/js/Windows.js
+++ b/js/Windows.js
@@ -1,0 +1,26 @@
+function setCustomWindowDecorations(custom) {
+    var x = appWindow.x
+    var y = appWindow.y
+    if (x < 0)
+    x = 0
+    if (y < 0)
+    y = 0
+    persistentSettings.customDecorations = custom;
+    
+    // hides custom titlebar based on customDecorations
+    titleBar.visible = custom;
+    daemonConsolePopup.titleBar.visible = custom;
+
+    if (custom) {
+        appWindow.flags = Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint;
+        daemonConsolePopup.flags = Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint;
+    } else {
+        appWindow.flags = Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint;
+        daemonConsolePopup.flags = Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint;
+    }
+
+    appWindow.hide()
+    appWindow.x = x
+    appWindow.y = y
+    appWindow.show()
+}

--- a/main.qml
+++ b/main.qml
@@ -932,27 +932,6 @@ ApplicationWindow {
     flags: persistentSettings.customDecorations ? (Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint) : (Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint)
     onWidthChanged: x -= 0
 
-    function setCustomWindowDecorations(custom) {
-      var x = appWindow.x
-      var y = appWindow.y
-      if (x < 0)
-        x = 0
-      if (y < 0)
-        y = 0
-      persistentSettings.customDecorations = custom;
-      titleBar.visible = custom; // hides custom titlebar based on customDecorations
-
-      if (custom)
-          appWindow.flags = Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint;
-      else
-          appWindow.flags = Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint;
-
-      appWindow.hide()
-      appWindow.x = x
-      appWindow.y = y
-      appWindow.show()
-    }
-
     Component.onCompleted: {
         x = (Screen.width - width) / 2
         y = (Screen.height - maxWindowHeight) / 2

--- a/main.qml
+++ b/main.qml
@@ -1811,4 +1811,13 @@ ApplicationWindow {
             close();
         }
     }
+
+    // background gradient
+    Rectangle {
+        id: inactiveOverlay
+        visible: false
+        anchors.fill: parent
+        color: "black"
+        opacity: 0.8
+    }
 }

--- a/main.qml
+++ b/main.qml
@@ -37,7 +37,6 @@ import moneroComponents.Wallet 1.0
 import moneroComponents.PendingTransaction 1.0
 import moneroComponents.NetworkType 1.0
 
-
 import "components"
 import "wizard"
 
@@ -1278,7 +1277,7 @@ ApplicationWindow {
                 PropertyChanges { target: appWindow; width: (screenWidth < 930 || isAndroid || isIOS)? screenWidth : 930; }
                 PropertyChanges { target: appWindow; height: maxWindowHeight; }
                 PropertyChanges { target: resizeArea; visible: true }
-                PropertyChanges { target: titleBar; maximizeButtonVisible: false }
+                PropertyChanges { target: titleBar; showMaximizeButton: false }
 //                PropertyChanges { target: frameArea; blocked: true }
                 PropertyChanges { target: titleBar; visible: false }
                 PropertyChanges { target: titleBar; y: 0 }
@@ -1294,7 +1293,7 @@ ApplicationWindow {
                 PropertyChanges { target: appWindow; width: (screenWidth < 969 || isAndroid || isIOS)? screenWidth : 969 } //rightPanelExpanded ? 1269 : 1269 - 300;
                 PropertyChanges { target: appWindow; height: maxWindowHeight; }
                 PropertyChanges { target: resizeArea; visible: true }
-                PropertyChanges { target: titleBar; maximizeButtonVisible: true }
+                PropertyChanges { target: titleBar; showMaximizeButton: true }
 //                PropertyChanges { target: frameArea; blocked: true }
                 PropertyChanges { target: titleBar; visible: true }
 //                PropertyChanges { target: titleBar; y: 0 }
@@ -1467,7 +1466,7 @@ ApplicationWindow {
 //            }
 //            PropertyAction {
 //                target: titleBar
-//                properties: "maximizeButtonVisible"
+//                properties: "showMaximizeButton"
 //                value: false
 //            }
 //            PropertyAction {
@@ -1548,7 +1547,7 @@ ApplicationWindow {
 //            }
 //            PropertyAction {
 //                target: titleBar
-//                properties: "maximizeButtonVisible"
+//                properties: "showMaximizeButton"
 //                value: true
 //            }
         }
@@ -1613,11 +1612,20 @@ ApplicationWindow {
 
         TitleBar {
             id: titleBar
-            anchors.left: parent.left
-            anchors.right: parent.right
             x: 0
             y: 0
+            anchors.left: parent.left
+            anchors.right: parent.right
+            showMinimizeButton: true
+            showMaximizeButton: true
+            showWhatIsButton: false
             customDecorations: persistentSettings.customDecorations
+            onCloseClicked: appWindow.close();
+            onMaximizeClicked: {
+                appWindow.visibility = appWindow.visibility !== Window.FullScreen ? Window.FullScreen :
+                                                                                    Window.Windowed
+            }
+            onMinimizeClicked: appWindow.visibility = Window.Minimized
             onGoToBasicVersion: {
                 if (yes) {
                     // basicPanel.currentView = middlePanel.currentView
@@ -1645,15 +1653,6 @@ ApplicationWindow {
                         previousPosition = pos
                     }
                 }
-            }
-
-            Rectangle {
-                anchors.bottom: parent.bottom
-                anchors.right: parent.right
-                anchors.left: parent.left
-                height:1
-                color: "#2F2F2F"
-                z: 2
             }
         }
 

--- a/main.qml
+++ b/main.qml
@@ -39,6 +39,7 @@ import moneroComponents.NetworkType 1.0
 
 import "components"
 import "wizard"
+import "js/Windows.js" as Windows
 
 ApplicationWindow {
     id: appWindow
@@ -929,7 +930,7 @@ ApplicationWindow {
 //    width: screenWidth //rightPanelExpanded ? 1269 : 1269 - 300
 //    height: 900 //300//maxWindowHeight;
     color: "#FFFFFF"
-    flags: persistentSettings.customDecorations ? (Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint) : (Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint)
+    flags: persistentSettings.customDecorations ? Windows.flagsCustomDecorations : Windows.flags
     onWidthChanged: x -= 0
 
     Component.onCompleted: {

--- a/main.qml
+++ b/main.qml
@@ -1598,7 +1598,7 @@ ApplicationWindow {
             showMinimizeButton: true
             showMaximizeButton: true
             showWhatIsButton: false
-            customDecorations: persistentSettings.customDecorations
+            showMoneroLogo: true
             onCloseClicked: appWindow.close();
             onMaximizeClicked: {
                 appWindow.visibility = appWindow.visibility !== Window.FullScreen ? Window.FullScreen :
@@ -1799,7 +1799,16 @@ ApplicationWindow {
             middlePanel.focus = true
             middlePanel.focus = false
         }
+    }
 
-
+    // Daemon console
+    DaemonConsole {
+        id: daemonConsolePopup
+        height:500
+        width:800
+        title: qsTr("Daemon log") + translationManager.emptyString
+        onAccepted: {
+            close();
+        }
     }
 }

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -31,9 +31,9 @@ import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2
+
 import "../version.js" as Version
-
-
+import "../js/Windows.js" as Windows
 import "../components"
 import moneroComponents.Clipboard 1.0
 
@@ -500,7 +500,7 @@ Rectangle {
                 visible: !isMobile
                 id: customDecorationsCheckBox
                 checked: persistentSettings.customDecorations
-                onClicked: appWindow.setCustomWindowDecorations(checked)
+                onClicked: Windows.setCustomWindowDecorations(checked)
                 text: qsTr("Custom decorations") + translationManager.emptyString
             }
         }
@@ -715,17 +715,6 @@ Rectangle {
             Layout.fillWidth: true
             font.pixelSize: 14
             text:  (!currentWallet) ? "" : qsTr("Daemon log path: ") + currentWallet.daemonLogPath + translationManager.emptyString
-        }
-    }
-
-    // Daemon console
-    DaemonConsole {
-        id: daemonConsolePopup
-        height:500
-        width:800
-        title: qsTr("Daemon log") + translationManager.emptyString
-        onAccepted: {
-            close();
         }
     }
 

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -34,6 +34,7 @@ import QtQuick.Dialogs 1.2
 
 import "../version.js" as Version
 import "../js/Windows.js" as Windows
+import "../js/Utils.js" as Utils
 import "../components"
 import moneroComponents.Clipboard 1.0
 
@@ -782,7 +783,7 @@ Rectangle {
 
     function onDaemonConsoleUpdated(message){
         // Update daemon console
-        daemonConsolePopup.textArea.append(message)
+        daemonConsolePopup.textArea.logMessage(message)
     }
 
 

--- a/qml.qrc
+++ b/qml.qrc
@@ -206,5 +206,6 @@
         <file>images/warning.png</file>
         <file>images/checkedBlackIcon.png</file>
         <file>images/rightArrowInactive.png</file>
+        <file>js/Windows.js</file>
     </qresource>
 </RCC>

--- a/qml.qrc
+++ b/qml.qrc
@@ -207,5 +207,6 @@
         <file>images/checkedBlackIcon.png</file>
         <file>images/rightArrowInactive.png</file>
         <file>js/Windows.js</file>
+        <file>js/Utils.js</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Fixes #1278

While on the topic of dialog windows, took the opportunity to:

- Make the `TitleBar` component more modular so we can re-use it for dialog windows
- Move the black overlay (that covers the main window) to `main.qml`, visible when another window is active
- Move Javascript code related to dialogs/windows to `js/Windows.js`
  - Dynamically set Window flags based off `persistentSettings.customDecorations` from this file
- Colored output
- Timestamped output 

![](https://i.imgur.com/v42i8Qu.png)