### PR TITLE
[qmake]: add versioning support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.user.*
 translations/*.qm
 build
-version.js
 # IOS stuff below
 moc_*
 *.o

--- a/build.sh
+++ b/build.sh
@@ -96,14 +96,6 @@ elif [ "$platform" == "mingw64" ] || [ "$platform" == "mingw32" ]; then
     MONEROD_EXEC=monerod.exe
 fi
 
-# force version update
-get_tag
-echo "var GUI_VERSION = \"$TAGNAME\"" > version.js
-pushd "$MONERO_DIR"
-get_tag
-popd
-echo "var GUI_MONERO_VERSION = \"$TAGNAME\"" >> version.js
-
 cd build
 if ! QMAKE=$(find_command qmake qmake-qt5); then
     echo "Failed to find suitable qmake command."

--- a/main.cpp
+++ b/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
 
     MainApp app(argc, argv);
 
-    qDebug() << "app startd";
+    qWarning().nospace() << "starting monero-gui " << VERSION_GUI;
 
     app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");
@@ -174,6 +174,10 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("mainApp", &app);
 
     engine.rootContext()->setContextProperty("qtRuntimeVersion", qVersion());
+
+    engine.rootContext()->setContextProperty("guiVersion", VERSION_GUI);
+
+    engine.rootContext()->setContextProperty("coreVersion", VERSION_CORE);
 
 // Exclude daemon manager from IOS
 #ifndef Q_OS_IOS

--- a/monero-core.rc
+++ b/monero-core.rc
@@ -1,1 +1,0 @@
-IDI_ICON1               ICON    DISCARDABLE     "images/appicon.ico"

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -447,6 +447,8 @@ android{
     deploy.commands += make install INSTALL_ROOT=$$DESTDIR && androiddeployqt --input android-libmonero-wallet-gui.so-deployment-settings.json --output $$DESTDIR --deployment bundled --android-platform android-21 --jdk /usr/lib/jvm/java-8-openjdk-amd64 -qmldir=$$PWD
 }
 
+# add version from git tags
+include(version.pri)
 
 OTHER_FILES += \
     .gitignore \
@@ -458,8 +460,12 @@ DISTFILES += \
     components/MobileHeader.qml
 
 
-# windows application icon
-RC_FILE = monero-core.rc
+win32 {
+    # windows application icon
+    RC_ICONS = images/appicon.ico
+}
 
-# mac application icon
-ICON = $$PWD/images/appicon.icns
+macx {
+    # mac application icon
+    ICON = $$PWD/images/appicon.icns
+}

--- a/pages/Keys.qml
+++ b/pages/Keys.qml
@@ -32,7 +32,6 @@ import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2
 import moneroComponents.Clipboard 1.0
-import "../version.js" as Version
 import "../components"
 import "." 1.0
 

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -31,7 +31,6 @@ import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2
-import "../version.js" as Version
 
 
 import "../components"
@@ -624,13 +623,13 @@ Rectangle {
             Layout.topMargin: 8
             font.pixelSize: 14
             Layout.fillWidth: true
-            text: qsTr("GUI version: ") + Version.GUI_VERSION + " (Qt " + qtRuntimeVersion + ")" + translationManager.emptyString
+            text: qsTr("GUI version: ") + guiVersion + " (Qt " + qtRuntimeVersion + ")" + translationManager.emptyString
         }
         TextBlock {
             id: guiMoneroVersion
             Layout.fillWidth: true
             font.pixelSize: 14
-            text: qsTr("Embedded Monero version: ") + Version.GUI_MONERO_VERSION + translationManager.emptyString
+            text: qsTr("Embedded Monero version: ") + coreVersion + translationManager.emptyString
         }
         TextBlock {
             id: restoreHeightText

--- a/qml.qrc
+++ b/qml.qrc
@@ -150,7 +150,6 @@
         <file>components/StandardDialog.qml</file>
         <file>pages/Sign.qml</file>
         <file>components/DaemonManagerDialog.qml</file>
-        <file>version.js</file>
         <file>wizard/WizardPasswordUI.qml</file>
         <file>wizard/WizardCreateViewOnlyWallet.qml</file>
         <file>components/DaemonConsole.qml</file>

--- a/version.pri
+++ b/version.pri
@@ -1,0 +1,40 @@
+RELEASE = "Lithium Luna"
+VERSION = 0.12.0
+
+win32 {
+    NULL = NUL
+} else {
+    NULL = /dev/null
+}
+
+# get tags
+CWD = $$system(pwd)
+GIT_VERSION_GUI = $$system(git --git-dir $$CWD/.git describe --always --tags 2> $$NULL)
+GIT_VERSION_CORE = $$system(git --git-dir $$CWD/monero/.git describe --always --tags 2> $$NULL)
+
+# fallback version
+isEmpty(GIT_VERSION_GUI) GIT_VERSION_GUI = $$VERSION
+isEmpty(GIT_VERSION_CORE) GIT_VERSION_CORE = $$VERSION
+
+# make versions available from C++ code 
+DEFINES += VERSION_GUI=\\\"$$GIT_VERSION_GUI\\\"
+DEFINES += VERSION_CORE=\\\"$$GIT_VERSION_CORE\\\"
+
+# version embedded in the application, without leading "v"
+VERSION = $$GIT_VERSION_GUI
+VERSION ~= s/v/""
+
+win32 { # numerical - short version. Generate rc file
+    VERSION ~= s/-/"."
+    VERSION ~= s/g/""
+    VERSION ~= s/\.\d+\.[a-f0-9]{6,}//
+    QMAKE_TARGET_COMPANY = Monero
+    QMAKE_TARGET_DESCRIPTION = Monero $$RELEASE
+    QMAKE_TARGET_COPYRIGHT = "2014-2018, The Monero Project"
+}
+
+macx { # add version and release to Info.plist
+    INFO_PLIST_PATH = $$shell_quote($${TARGET_FULL_PATH}/Contents/Info.plist)
+    QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Add :CFBundleShortVersionString string $${VERSION}\" $${INFO_PLIST_PATH};
+    QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString $${RELEASE}\" $${INFO_PLIST_PATH};
+}


### PR DESCRIPTION
In order to make the versioning easier and keep a tidy repo I'd like to move versioning related stuff to qmake. 

This PR:

1. moves version information from build.sh/version.js to version.pri
2. adds version to the application for windows/mac
3. removes old monero-core.rc (qmake will generate one for us)
4. makes versions accesible in C++ (VERSION_GUI and VERSION_CORE) and qml
5. supports corner cases (git isn't found or repo not initializated)

version.pri obtains version from git. The first two lines must be changed every major release. (e.g: "Helium Hydra" -> "Lithium Luna" / 0.11.x -> 0.12.x).

Right now we're using the get_tag function from utils.sh to obtain git version and display useful? info at build time. I deleted the call to get_tag in build.sh, but I can revert that if you wish.

Feedback is welcome, specially about git tagging, because I'm not sure if I'm doing this right :package: 