### PR TITLE
[Don't merge]: send output to easylogger

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -67,13 +67,16 @@
 
 void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    switch (type)
+    (void) context;
+    static const std::string cat = "frontend";
+    const std::string message = msg.toStdString();
+    switch(type)
     {
-        case QtDebugMsg:    Monero::Wallet::debug("frontend", msg.toStdString()); break;
-        case QtInfoMsg:     Monero::Wallet::info("frontend", msg.toStdString()); break;
-        case QtWarningMsg:  Monero::Wallet::warning("frontend", msg.toStdString()); break;
-        case QtCriticalMsg: Monero::Wallet::error("frontend", msg.toStdString()); break;
-        case QtFatalMsg:    Monero::Wallet::error("frontend", msg.toStdString()); break;
+        case QtDebugMsg:    Monero::Wallet::debug(cat, message);   break;
+        case QtInfoMsg:     Monero::Wallet::info(cat, message);    break;
+        case QtWarningMsg:  Monero::Wallet::warning(cat, message); break;
+        case QtCriticalMsg: Monero::Wallet::error(cat, message);   break;
+        case QtFatalMsg:    Monero::Wallet::error(cat, message);   break;
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -67,8 +67,14 @@
 
 void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    // Send all message types to logger
-    Monero::Wallet::debug("qml", msg.toStdString());
+    switch (type)
+    {
+        case QtDebugMsg:    Monero::Wallet::debug("frontend", msg.toStdString()); break;
+        case QtInfoMsg:     Monero::Wallet::info("frontend", msg.toStdString()); break;
+        case QtWarningMsg:  Monero::Wallet::warning("frontend", msg.toStdString()); break;
+        case QtCriticalMsg: Monero::Wallet::error("frontend", msg.toStdString()); break;
+        case QtFatalMsg:    Monero::Wallet::error("frontend", msg.toStdString()); break;
+    }
 }
 
 int main(int argc, char *argv[])
@@ -82,10 +88,11 @@ int main(int argc, char *argv[])
 
     // Log settings
     Monero::Wallet::init(argv[0], "monero-wallet-gui");
-//    qInstallMessageHandler(messageHandler);
 
     MainApp app(argc, argv);
 
+    // log qt/qml stuff to default logger:
+    qInstallMessageHandler(messageHandler);
     qDebug() << "app startd";
 
     app.setApplicationName("monero-core");


### PR DESCRIPTION
install messageHandler after QApplication constructor, so we can see certain error messages returned by qt.

the messageHandler was merged in #463, but I'm not sure why it was removed. Pinging @Jaqueeee 