### PR TITLE
single colour privacy level bar

### DIFF
--- a/components/PrivacyLevel.qml
+++ b/components/PrivacyLevel.qml
@@ -62,11 +62,7 @@ Item {
             //radius: 2
             width: row.x
 
-            color: {
-                if(item.fillLevel < 3) return "#FF6C3C"
-                if(item.fillLevel < 13) return "#AAFFBB"
-                return "#36B25C"
-            }
+            color: "#FF6C3C"
 
             Timer {
                 interval: 500

--- a/components/PrivacyLevelSmall.qml
+++ b/components/PrivacyLevelSmall.qml
@@ -71,11 +71,7 @@ Item {
             //radius: 2
             width: row.x
 
-            color: {
-                if(item.fillLevel < 5) return "#FF6C3C"
-                if(item.fillLevel < 13) return "#AAFFBB"
-                return "#36B25C"
-            }
+            color: "#FF6C3C"
 
             Timer {
                 interval: 500

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -79,7 +79,7 @@ Rectangle {
         var mixin = scaleValueToMixinCount(fillLevel)
         console.log("PrivacyLevel changed:"  + fillLevel)
         console.log("mixin count: "  + mixin)
-        privacyLabel.text = qsTr("Privacy level (ringsize %1)").arg(mixin+1) + translationManager.emptyString
+        privacyLabel.text = qsTr("Ring size: %1").arg(mixin+1) + translationManager.emptyString
     }
 
     function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name) {


### PR DESCRIPTION
Making the privacy level bar go from orange, to light green, to dark green gives the impression (especially to less knowledgable users) that a higher ring size equals better privacy, which isn't always the case. To avoid giving that impression this PR makes the privacy level bar solid orange, regardless of selected ring size, and changes the wording of "privacy level (ring size x)" to just "ring size"

[screenshot](https://imgur.com/AvSir0i)