### PR TITLE
fix OpenAlias resolve

### DIFF
--- a/components/InputMulti.qml
+++ b/components/InputMulti.qml
@@ -58,7 +58,7 @@ TextArea {
     onTextChanged: {
         if(addressValidation){
             // js replacement for `RegExpValidator { regExp: /[0-9A-Fa-f]{95}/g }`
-            textArea.text = textArea.text.replace(/[^a-z0-9]/gi,'');
+            textArea.text = textArea.text.replace(/[^a-z0-9.@]/gi,'');
             var address_ok = TxUtils.checkAddress(textArea.text, appWindow.persistentSettings.nettype);
             if(!address_ok) error = true;
             else error = false;

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -257,40 +257,8 @@ Rectangle {
               labelText: qsTr("<style type='text/css'>a {text-decoration: none; color: #858585; font-size: 14px;}</style>\
                 Address <font size='2'>  ( </font> <a href='#'>Address book</a><font size='2'> )</font>")
                 + translationManager.emptyString
-              labelButtonText: qsTr("Resolve") + translationManager.emptyString
               placeholderText: "4.."
               onInputLabelLinkActivated: { appWindow.showPageRequest("AddressBook") }
-              onLabelButtonClicked: {
-                  var result = walletManager.resolveOpenAlias(addressLine.text)
-                  if (result) {
-                    var parts = result.split("|")
-                    if (parts.length == 2) {
-                      var address_ok = walletManager.addressValid(parts[1], appWindow.persistentSettings.nettype)
-                      if (parts[0] === "true") {
-                        if (address_ok) {
-                          addressLine.text = parts[1]
-                          addressLine.cursorPosition = 0
-                        }
-                        else
-                          oa_message(qsTr("No valid address found at this OpenAlias address"))
-                      } else if (parts[0] === "false") {
-                        if (address_ok) {
-                          addressLine.text = parts[1]
-                          addressLine.cursorPosition = 0
-                          oa_message(qsTr("Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed"))
-                        } else {
-                          oa_message(qsTr("No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed"))
-                        }
-                      } else {
-                        oa_message(qsTr("Internal error"))
-                      }
-                    } else {
-                      oa_message(qsTr("Internal error"))
-                    }
-                  } else {
-                    oa_message(qsTr("No address found"))
-                  }
-              }
           }
 
           StandardButton {
@@ -302,6 +270,52 @@ Rectangle {
               onClicked: {
                   cameraUi.state = "Capture"
                   cameraUi.qrcode_decoded.connect(updateFromQrCode)
+              }
+          }
+      }
+
+      StandardButton {
+          id: resolveButton
+          anchors.left: parent.left
+          width: 80
+          text: qsTr("Resolve") + translationManager.emptyString
+          visible: isValidOpenAliasAddress(addressLine.text)
+          enabled : isValidOpenAliasAddress(addressLine.text)
+          onClicked: {
+              var result = walletManager.resolveOpenAlias(addressLine.text)
+              if (result) {
+                  var parts = result.split("|")
+                  if (parts.length == 2) {
+                      var address_ok = walletManager.addressValid(parts[1], appWindow.persistentSettings.testnet)
+                      if (parts[0] === "true") {
+                          if (address_ok) {
+                              addressLine.text = parts[1]
+                              addressLine.cursorPosition = 0
+                          }
+                          else
+                              oa_message(qsTr("No valid address found at this OpenAlias address"))
+                      }
+                      else if (parts[0] === "false") {
+                            if (address_ok) {
+                                addressLine.text = parts[1]
+                                addressLine.cursorPosition = 0
+                                oa_message(qsTr("Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed"))
+                            }
+                            else
+                            {
+                                oa_message(qsTr("No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed"))
+                            }
+                      }
+                      else {
+                          oa_message(qsTr("Internal error"))
+                      }
+                  }
+                  else {
+                      oa_message(qsTr("Internal error"))
+                  }
+              }
+              else {
+                  oa_message(qsTr("No address found"))
               }
           }
       }


### PR DESCRIPTION
The way the labelbutton was being used was stopping the "resolve" button from showing up when an OpenAlias address was used. Once you got it to show up it would end up replacing the "Address Book" label so this PR changes it to it's own standard button. The regex filter also has to allow '.' and '@' characters otherwise the user can't even enter a proper OpenAlias address