### PR TITLE
Change input address placeholder from '4...' to '4.. / 8..'

### DIFF
--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -63,7 +63,7 @@ Rectangle {
                 id: addressLine
                 labelText: qsTr("Address") + translationManager.emptyString
                 error: true;
-                placeholderText: qsTr("4...") + translationManager.emptyString
+                placeholderText: qsTr("4.. / 8..") + translationManager.emptyString
             }
         }
 

--- a/pages/Sign.qml
+++ b/pages/Sign.qml
@@ -290,7 +290,7 @@ Rectangle {
                         labelText: qsTr("Address")
                         addressValidation: true
                         anchors.topMargin: 5 * scaleRatio
-                        placeholderText: "4..."
+                        placeholderText: "4.. / 8.."
                     }
                 }
             }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -257,7 +257,8 @@ Rectangle {
               labelText: qsTr("<style type='text/css'>a {text-decoration: none; color: #858585; font-size: 14px;}</style>\
                 Address <font size='2'>  ( </font> <a href='#'>Address book</a><font size='2'> )</font>")
                 + translationManager.emptyString
-              placeholderText: "4.."
+              labelButtonText: qsTr("Resolve") + translationManager.emptyString
+              placeholderText: "4.. / 8.."
               onInputLabelLinkActivated: { appWindow.showPageRequest("AddressBook") }
           }
 


### PR DESCRIPTION
Fixes #1332

`4.. / 8..` placeholder for address input fields. Changed on the following pages:

- Transer
- Address Book
- Sign/Verify

![https://i.imgur.com/lkxEKcT.png](https://i.imgur.com/lkxEKcT.png)