### PR TITLE
remove ringdb select/load button anchors

### DIFF
--- a/pages/SharedRingDB.qml
+++ b/pages/SharedRingDB.qml
@@ -151,8 +151,6 @@ Rectangle {
 
             LineEdit {
                 id: loadBlackballFileLine
-                anchors.left: selectBlackballFileButton.right
-                anchors.right: loadBlackballFileButton.left
                 placeholderText: qsTr("Filename with outputs to blackball") + translationManager.emptyString;
                 readOnly: false
                 Layout.fillWidth: true
@@ -169,7 +167,6 @@ Rectangle {
 
             StandardButton {
                 id: loadBlackballFileButton
-                anchors.right: parent.right
                 text: qsTr("Load") + translationManager.emptyString
                 small: true
                 enabled: !!appWindow.currentWallet


### PR DESCRIPTION
The select/load buttons are anchored to the input line way too close

![ringdb-gui-before](https://user-images.githubusercontent.com/29288694/39101833-582f95d2-466c-11e8-8a96-45ec9f8487e9.png)

By removing this anchoring they are given a bit of space

![ringdb-gui-after](https://user-images.githubusercontent.com/29288694/39101859-9bd8356e-466c-11e8-9661-5de85b4488fc.png)

