### PR TITLE
Removing legacy whatis (?) button from titlebar

### DIFF
--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -121,32 +121,6 @@ Rectangle {
         z: 2
 
         Rectangle {
-            id: whatIsAreaButton
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            width: 42
-            color: containsMouse ? "#6B0072" : "#00000000"
-
-            Image {
-                anchors.centerIn: parent
-                width: 9
-                height: 16
-                source: "../images/question.png"
-            }
-
-            MouseArea {
-                id: whatIsArea
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onEntered: whatIsAreaButton.color = "#262626";
-                onExited: whatIsAreaButton.color = "transparent";
-                onClicked: {
-
-                }
-            }
-        }
-
-        Rectangle {
             id: minimizeButton
             anchors.top: parent.top
             anchors.bottom: parent.bottom


### PR DESCRIPTION
Hi all,

I noticed that the "Help" button in the custom title bar is no longer functional.

This appears to be by design, as the functionality was largely removed in this commit: https://github.com/monero-project/monero-gui/commit/b35d60db2d8b7508127e8d365d22a82d58bd9dc6

Since the button is a legacy item, I presume it is taking up space and should be removed. This commit performs that.