### PR TITLE
main.cpp misc changes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -124,6 +124,20 @@ int main(int argc, char *argv[])
 
     qDebug() << "app startd";
 
+    // screen settings
+    // Mobile is designed on 128dpi
+    qreal ref_dpi = 128;
+    QRect geo = QApplication::desktop()->availableGeometry();
+    QRect rect = QGuiApplication::primaryScreen()->geometry();
+    qreal dpi = QGuiApplication::primaryScreen()->logicalDotsPerInch();
+    qreal physicalDpi = QGuiApplication::primaryScreen()->physicalDotsPerInch();
+    qreal calculated_ratio = physicalDpi/ref_dpi;
+
+    qWarning().nospace() << "Qt:" << QT_VERSION_STR << " | screen: " << rect.width()
+                         << "x" << rect.height() << " - dpi: " << dpi << " - ratio:"
+                         << calculated_ratio;
+
+
     // registering types for QML
     qmlRegisterType<clipboardAdapter>("moneroComponents.Clipboard", 1, 0, "Clipboard");
 
@@ -221,17 +235,6 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("isIOS", isIOS);
     engine.rootContext()->setContextProperty("isAndroid", isAndroid);
 
-    // screen settings
-    // Mobile is designed on 128dpi
-    qreal ref_dpi = 128;
-    QRect geo = QApplication::desktop()->availableGeometry();
-    QRect rect = QGuiApplication::primaryScreen()->geometry();
-    qreal height = qMax(rect.width(), rect.height());
-    qreal width = qMin(rect.width(), rect.height());
-    qreal dpi = QGuiApplication::primaryScreen()->logicalDotsPerInch();
-    qreal physicalDpi = QGuiApplication::primaryScreen()->physicalDotsPerInch();
-    qreal calculated_ratio = physicalDpi/ref_dpi;
-
     engine.rootContext()->setContextProperty("screenWidth", geo.width());
     engine.rootContext()->setContextProperty("screenHeight", geo.height());
 #ifdef Q_OS_ANDROID
@@ -240,9 +243,6 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("scaleRatio", 1);
 #endif
 
-    qWarning().nospace() << "Qt:" << QT_VERSION_STR << " | screen: " << width
-                         << "x" << height << " - dpi: " << dpi << " - ratio:"
-                         << calculated_ratio;
 
     if (!moneroAccountsRootDir.empty()) {
         QString moneroAccountsDir = moneroAccountsRootDir.at(0) + "/Monero/wallets";

--- a/main.cpp
+++ b/main.cpp
@@ -79,7 +79,7 @@ void messageHandler(QtMsgType type, const QMessageLogContext &context, const QSt
 int main(int argc, char *argv[])
 {
     // platform dependant settings
-#if ! defined(Q_OS_ANDROID) && ! defined(Q_OS_IOS)
+#if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)
     bool isDesktop = true;
 #elif defined(Q_OS_ANDROID)
     bool isAndroid = true;
@@ -229,7 +229,7 @@ int main(int argc, char *argv[])
 //  to save the wallet file (.keys, .bin), they have to be user-accessible for
 //  backups - I reckon we save that in My Documents\Monero Accounts\ on
 //  Windows, ~/Monero Accounts/ on nix / osx
-#if defined (Q_OS_WIN) || defined(Q_OS_IOS)
+#if defined(Q_OS_WIN) || defined(Q_OS_IOS)
     QStringList moneroAccountsRootDir = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
 #else
     QStringList moneroAccountsRootDir = QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
@@ -248,7 +248,8 @@ int main(int argc, char *argv[])
 #endif
 
 
-    if (!moneroAccountsRootDir.empty()) {
+    if (!moneroAccountsRootDir.empty())
+    {
         QString moneroAccountsDir = moneroAccountsRootDir.at(0) + "/Monero/wallets";
         engine.rootContext()->setContextProperty("moneroAccountsDir", moneroAccountsDir);
     }
@@ -256,12 +257,10 @@ int main(int argc, char *argv[])
 
     // Get default account name
     QString accountName = qgetenv("USER"); // mac/linux
-    if (accountName.isEmpty()){
+    if (accountName.isEmpty())
         accountName = qgetenv("USERNAME"); // Windows
-    }
-    if (accountName.isEmpty()) {
+    if (accountName.isEmpty())
         accountName = "My monero Account";
-    }
 
     engine.rootContext()->setContextProperty("defaultAccountName", accountName);
     engine.rootContext()->setContextProperty("applicationDirectory", QApplication::applicationDirPath());
@@ -288,14 +287,15 @@ int main(int argc, char *argv[])
 
 #ifdef WITH_SCANNER
     QObject *qmlCamera = rootObject->findChild<QObject*>("qrCameraQML");
-    if( qmlCamera ){
+    if (qmlCamera)
+    {
         qDebug() << "QrCodeScanner : object found";
         QCamera *camera_ = qvariant_cast<QCamera*>(qmlCamera->property("mediaObject"));
         QObject *qmlFinder = rootObject->findChild<QObject*>("QrFinder");
         qobject_cast<QrCodeScanner*>(qmlFinder)->setSource(camera_);
-    } else {
-        qDebug() << "QrCodeScanner : something went wrong !";
     }
+    else
+        qDebug() << "QrCodeScanner : something went wrong !";
 #endif
 
     QObject::connect(eventFilter, SIGNAL(sequencePressed(QVariant,QVariant)), rootObject, SLOT(sequencePressed(QVariant,QVariant)));

--- a/main.cpp
+++ b/main.cpp
@@ -92,6 +92,10 @@ int main(int argc, char *argv[])
 
     // disable "QApplication: invalid style override passed" warning
     if (isDesktop) putenv((char*)"QT_STYLE_OVERRIDE=fusion");
+#ifdef Q_OS_LINUX
+    // force platform xcb
+    if (isDesktop) putenv((char*)"QT_QPA_PLATFORM=xcb");
+#endif
 
 //    // Enable high DPI scaling on windows & linux
 //#if !defined(Q_OS_ANDROID) && QT_VERSION >= 0x050600

--- a/main.cpp
+++ b/main.cpp
@@ -90,6 +90,8 @@ int main(int argc, char *argv[])
     bool isWindows = true;
 #endif
 
+    // disable "QApplication: invalid style override passed" warning
+    if (isDesktop) putenv((char*)"QT_STYLE_OVERRIDE=fusion");
 
     Monero::Utils::onStartup();
 //    // Enable high DPI scaling on windows & linux
@@ -104,8 +106,6 @@ int main(int argc, char *argv[])
 
     MainApp app(argc, argv);
 
-    qDebug() << "app startd";
-
     app.setApplicationName("monero-gui");
     app.setOrganizationDomain("getmonero.org");
     app.setOrganizationName("monero-project");
@@ -116,6 +116,12 @@ int main(int argc, char *argv[])
 
     filter *eventFilter = new filter;
     app.installEventFilter(eventFilter);
+
+    QCommandLineParser parser;
+    parser.addHelpOption();
+    parser.process(app);
+
+    qDebug() << "app startd";
 
     // registering types for QML
     qmlRegisterType<clipboardAdapter>("moneroComponents.Clipboard", 1, 0, "Clipboard");

--- a/main.cpp
+++ b/main.cpp
@@ -93,16 +93,11 @@ int main(int argc, char *argv[])
     // disable "QApplication: invalid style override passed" warning
     if (isDesktop) putenv((char*)"QT_STYLE_OVERRIDE=fusion");
 
-    Monero::Utils::onStartup();
 //    // Enable high DPI scaling on windows & linux
 //#if !defined(Q_OS_ANDROID) && QT_VERSION >= 0x050600
 //    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 //    qDebug() << "High DPI auto scaling - enabled";
 //#endif
-
-    // Log settings
-    Monero::Wallet::init(argv[0], "monero-wallet-gui");
-//    qInstallMessageHandler(messageHandler);
 
     MainApp app(argc, argv);
 
@@ -120,6 +115,12 @@ int main(int argc, char *argv[])
     QCommandLineParser parser;
     parser.addHelpOption();
     parser.process(app);
+
+    Monero::Utils::onStartup();
+
+    // Log settings
+    Monero::Wallet::init(argv[0], "monero-wallet-gui");
+//    qInstallMessageHandler(messageHandler);
 
     qDebug() << "app startd";
 


### PR DESCRIPTION
- refactor some platform dependant code. At least for me is easier to read this way.

- add isDesktop, to differenciate between desktops OSes and mobile OSes. It is useful mainly because android is recognized by qt as linux too.

- add a initial cmdline parser. Move some qDebug  and force style fusion for desktop platforms so don't pollute the output of the parser. It will be useful in the future :smiley: 

- move monero stuff after app constructor + cmdline parser. (We don't want to initialize anything if we're running, for example monero-wallet-gui --version)

- force platform xcb on desktop linux, because on newer systems qt will try to use platform wayland and this isn't supported by our building system yet.

- fixed reported height and width, because it was right only when height > width.