### PR TITLE
qt/qml message logger

### DIFF
--- a/Logger.cpp
+++ b/Logger.cpp
@@ -1,0 +1,49 @@
+#include <QCoreApplication>
+#include <QStandardPaths>
+#include <QFileInfo>
+#include <QString>
+
+#include "Logger.h"
+#include "wallet/api/wallet2_api.h"
+
+// default log path by OS (should be writable)
+static const QString default_name = "monero-wallet-gui.log";
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
+    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation).at(0);
+#elif defined(Q_OS_WIN)
+    static const QString osPath = QCoreApplication::applicationDirPath();
+#elif defined(Q_OS_MAC)
+    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0) + "/Library/Logs";
+#else // linux + bsd
+    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
+#endif
+
+
+// return the absolute path of the logfile
+const QString getLogPath(const QString logPath)
+{
+    const QFileInfo fi(logPath);
+
+    if(!logPath.isEmpty() && !fi.isDir())
+        return fi.absoluteFilePath();
+    else
+        return osPath + "/" + default_name;
+}
+
+
+// custom messageHandler that foward all messages to easylogging
+void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message)
+{
+    (void) context; // context isn't used in release builds
+    const std::string cat = "frontend"; // category displayed in the log
+    const std::string msg = message.toStdString();
+    switch(type)
+    {
+        case QtDebugMsg: Monero::Wallet::debug(cat, msg); break;
+        case QtInfoMsg: Monero::Wallet::info(cat, msg); break;
+        case QtWarningMsg: Monero::Wallet::warning(cat, msg); break;
+        case QtCriticalMsg: Monero::Wallet::error(cat, msg); break;
+        case QtFatalMsg: Monero::Wallet::error(cat, msg); break;
+    }
+}
+

--- a/Logger.h
+++ b/Logger.h
@@ -1,0 +1,8 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+const QString getLogPath(const QString logPath);
+void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message);
+
+#endif // LOGGER_H
+

--- a/main.cpp
+++ b/main.cpp
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
 
 // Exclude daemon manager from IOS
 #ifndef Q_OS_IOS
-    const QStringList arguments = QCoreApplication::arguments();
+    const QStringList arguments = (QStringList) QCoreApplication::arguments().at(0);
     DaemonManager * daemonManager = DaemonManager::instance(&arguments);
     engine.rootContext()->setContextProperty("daemonManager", daemonManager);
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
 
     // Log settings
     const QString logPath = getLogPath(parser.value(logPathOption));
-    Monero::Wallet::init(argv[0], "monero-wallet-gui", logPath.toStdString().c_str());
+    Monero::Wallet::init(argv[0], "monero-wallet-gui", logPath.toStdString().c_str(), true);
     qInstallMessageHandler(messageHandler);
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -294,13 +294,13 @@ int main(int argc, char *argv[])
     QObject *qmlCamera = rootObject->findChild<QObject*>("qrCameraQML");
     if (qmlCamera)
     {
-        qDebug() << "QrCodeScanner : object found";
+        qWarning() << "QrCodeScanner : object found";
         QCamera *camera_ = qvariant_cast<QCamera*>(qmlCamera->property("mediaObject"));
         QObject *qmlFinder = rootObject->findChild<QObject*>("QrFinder");
         qobject_cast<QrCodeScanner*>(qmlFinder)->setSource(camera_);
     }
     else
-        qDebug() << "QrCodeScanner : something went wrong !";
+        qCritical() << "QrCodeScanner : something went wrong !";
 #endif
 
     QObject::connect(eventFilter, SIGNAL(sequencePressed(QVariant,QVariant)), rootObject, SLOT(sequencePressed(QVariant,QVariant)));

--- a/main.cpp
+++ b/main.cpp
@@ -54,6 +54,7 @@
 #include "Subaddress.h"
 #include "model/SubaddressModel.h"
 #include "wallet/api/wallet2_api.h"
+#include "Logger.h"
 #include "MainApp.h"
 
 // IOS exclusions
@@ -69,12 +70,6 @@ bool isIOS = false;
 bool isAndroid = false;
 bool isWindows = false;
 bool isDesktop = false;
-
-void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
-{
-    // Send all message types to logger
-    Monero::Wallet::debug("qml", msg.toStdString());
-}
 
 int main(int argc, char *argv[])
 {
@@ -117,16 +112,24 @@ int main(int argc, char *argv[])
     app.installEventFilter(eventFilter);
 
     QCommandLineParser parser;
+    QCommandLineOption logPathOption(QStringList() << "l" << "log-file",
+        QCoreApplication::translate("main", "Log to specified file"),
+        QCoreApplication::translate("main", "file"));
+    parser.addOption(logPathOption);
     parser.addHelpOption();
     parser.process(app);
 
     Monero::Utils::onStartup();
 
     // Log settings
-    Monero::Wallet::init(argv[0], "monero-wallet-gui");
-//    qInstallMessageHandler(messageHandler);
+    const QString logPath = getLogPath(parser.value(logPathOption));
+    Monero::Wallet::init(argv[0], "monero-wallet-gui", logPath.toStdString().c_str());
+    qInstallMessageHandler(messageHandler);
 
-    qDebug() << "app startd";
+
+    // loglevel is configured in main.qml. Anything lower than
+    // qWarning is not shown here.
+    qWarning().noquote() << "app startd" << "(log: " + logPath + ")";
 
     // screen settings
     // Mobile is designed on 128dpi
@@ -216,6 +219,8 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("mainApp", &app);
 
     engine.rootContext()->setContextProperty("qtRuntimeVersion", qVersion());
+
+    engine.rootContext()->setContextProperty("walletLogPath", logPath);
 
 // Exclude daemon manager from IOS
 #ifndef Q_OS_IOS

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -45,6 +45,7 @@ HEADERS += \
     src/libwalletqt/Subaddress.h \
     src/zxcvbn-c/zxcvbn.h \
     src/libwalletqt/UnsignedTransaction.h \
+    Logger.h \
     MainApp.h
 
 SOURCES += main.cpp \
@@ -70,6 +71,7 @@ SOURCES += main.cpp \
     src/libwalletqt/Subaddress.cpp \
     src/zxcvbn-c/zxcvbn.c \
     src/libwalletqt/UnsignedTransaction.cpp \
+    Logger.cpp \
     MainApp.cpp
 
 CONFIG(DISABLE_PASS_STRENGTH_METER) {

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -730,13 +730,13 @@ Rectangle {
             TextBlock {
                 Layout.fillWidth: true
                 font.pixelSize: 14
-                text:  (!currentWallet) ? "" : qsTr("Wallet log path: ") + translationManager.emptyString
+                text: qsTr("Wallet log path: ") + translationManager.emptyString
             }
 
             TextBlock {
                 Layout.fillWidth: true
                 font.pixelSize: 14
-                text: currentWallet.walletLogPath + translationManager.emptyString
+                text: walletLogPath
             }
         }
     }

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -722,17 +722,6 @@ QString Wallet::getDaemonLogPath() const
     return QString::fromStdString(m_walletImpl->getDefaultDataDir()) + "/bitmonero.log";
 }
 
-QString Wallet::getWalletLogPath() const
-{
-    const QString filename("monero-wallet-gui.log");
-
-#ifdef Q_OS_MACOS
-    return QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0) + "/Library/Logs/" + filename;
-#else
-    return QCoreApplication::applicationDirPath() + "/" + filename;
-#endif
-}
-
 bool Wallet::blackballOutput(const QString &pubkey)
 {
     QList<QString> list;

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -50,7 +50,6 @@ class Wallet : public QObject
     Q_PROPERTY(QString secretSpendKey READ getSecretSpendKey)
     Q_PROPERTY(QString publicSpendKey READ getPublicSpendKey)
     Q_PROPERTY(QString daemonLogPath READ getDaemonLogPath CONSTANT)
-    Q_PROPERTY(QString walletLogPath READ getWalletLogPath CONSTANT)
     Q_PROPERTY(quint64 walletCreationHeight READ getWalletCreationHeight WRITE setWalletCreationHeight NOTIFY walletCreationHeightChanged)
 
 public:

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -377,26 +377,6 @@ bool WalletManager::clearWalletCache(const QString &wallet_path) const
     return walletCache.rename(newFileName);
 }
 
-void WalletManager::debug(const QString &s)
-{
-    Monero::Wallet::debug("qml", s.toStdString());
-}
-
-void WalletManager::info(const QString &s)
-{
-    Monero::Wallet::info("qml", s.toStdString());
-}
-
-void WalletManager::warning(const QString &s)
-{
-    Monero::Wallet::warning("qml", s.toStdString());
-}
-
-void WalletManager::error(const QString &s)
-{
-    Monero::Wallet::error("qml", s.toStdString());
-}
-
 WalletManager::WalletManager(QObject *parent) : QObject(parent)
 {
     m_pimpl =  Monero::WalletManagerFactory::getWalletManager();

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -143,11 +143,6 @@ public:
     // clear/rename wallet cache
     Q_INVOKABLE bool clearWalletCache(const QString &fileName) const;
 
-    Q_INVOKABLE void debug(const QString &s);
-    Q_INVOKABLE void info(const QString &s);
-    Q_INVOKABLE void warning(const QString &s);
-    Q_INVOKABLE void error(const QString &s);
-
 signals:
 
     void walletOpened(Wallet * wallet);


### PR DESCRIPTION
By default qt/qml messages are sent to stdout on X11 (and maybe on osx) and to the debugger on windows. The rest of the messages are stored in a logfile which is saved in the same path of the binary).

This PR moves all qt/qml debug messages to the same file that the rest of logging and adds a cmdline option to specify a custom logfile.

The new behaviour is:
if no custom logpath is specified use OS defined path (in Logger.cpp), which should be writable.
if a custom logfile is specified use that.

default logPath by OS:
win -> same folder of the app
mac -> $HOME/Library/Logs
linux -> $HOME/

I've removed code in WalletManager.h/cpp and Wallet.h/cpp which I think is not used elsewhere.

Fixes #1181 , #1068 