### PR TITLE
qmake: misc changes

### DIFF
--- a/deployment.pri
+++ b/deployment.pri
@@ -1,27 +1,32 @@
-android-no-sdk {
-    target.path = /data/user/qt
-    export(target.path)
-    INSTALLS += target
-} else:android {
-    x86 {
-        target.path = /libs/x86
-    } else: armeabi-v7a {
-        target.path = /libs/armeabi-v7a
-    } else {
-        target.path = /libs/armeabi
-    }
-    export(target.path)
-    INSTALLS += target
-} else:unix {
-    isEmpty(target.path) {
-        qnx {
-            target.path = /tmp/$${TARGET}/bin
-        } else {
-            target.path = /opt/$${TARGET}/bin
-        }
-        export(target.path)
-    }
-    INSTALLS += target
+# Rules for deploying the application. For macos, windows and android use qt tools
+# to add required qt libraries and qml modules to the application bundle.
+
+# This isn't needed for linux where we're using system libraries on $PATH or
+# qt is statically linked.
+
+macx {
+    QMAKE_POST_LINK = macdeployqt $$sprintf("%1/%2/%3.app", $$OUT_PWD, $$DESTDIR, $$TARGET) \
+        -qmldir=$$PWD
 }
 
-export(INSTALLS)
+win32 {
+    QMAKE_POST_LINK = windeployqt $$sprintf("%1/%2/%3.exe", $$OUT_PWD, $$DESTDIR, $$TARGET) \
+        -release -no-translations -qmldir=$$PWD
+
+    # Win64 msys2 deploy settings
+    contains(QMAKE_HOST.arch, x86_64) {
+        QMAKE_POST_LINK = $$PWD/windeploy_helper.sh $$DESTDIR
+    }
+}
+
+linux:!android {
+    TARGET = monero-wallet-gui
+    QMAKE_POST_LINK = $$PWD/linuxdeploy_helper.sh $$sprintf("%1/%2 %3", $$OUT_PWD, $$DESTDIR, $$TARGET)
+}
+
+android {
+    QMAKE_POST_LINK = make install INSTALL_ROOT=$$DESTDIR && androiddeployqt \
+        --input android-libmonero-wallet-gui.so-deployment-settings.json --output $$DESTDIR \
+        --deployment bundled --android-platform android-21 --jdk /usr/lib/jvm/java-8-openjdk-amd64 \
+        -qmldir=$$PWD
+}

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -83,14 +83,6 @@ CONFIG(DISABLE_PASS_STRENGTH_METER) {
     SOURCES += src/daemon/DaemonManager.cpp
 }
 
-lupdate_only {
-SOURCES = *.qml \
-          components/*.qml \
-          pages/*.qml \
-          wizard/*.qml \
-          wizard/*js
-}
-
 
 ios:armv7 {
     message("target is armv7")
@@ -325,78 +317,6 @@ macx {
     QMAKE_LFLAGS += -pie
 }
 
-
-# translation stuff
-TRANSLATIONS = $$files($$PWD/translations/monero-core_*.ts)
-
-CONFIG(release, debug|release) {
-    DESTDIR = release/bin
-    LANGUPD_OPTIONS = -locations relative -no-ui-lines
-    LANGREL_OPTIONS = -compress -nounfinished -removeidentical
-
-} else {
-    DESTDIR = debug/bin
-    LANGUPD_OPTIONS =
-#    LANGREL_OPTIONS = -markuntranslated "MISS_TR "
-}
-
-TRANSLATION_TARGET_DIR = $$OUT_PWD/translations
-
-!ios {
-    isEmpty(QMAKE_LUPDATE) {
-        win32:LANGUPD = $$[QT_INSTALL_BINS]\lupdate.exe
-        else:LANGUPD = $$[QT_INSTALL_BINS]/lupdate
-    }
-
-    isEmpty(QMAKE_LRELEASE) {
-        win32:LANGREL = $$[QT_INSTALL_BINS]\lrelease.exe
-        else:LANGREL = $$[QT_INSTALL_BINS]/lrelease
-    }
-
-    langupd.command = \
-        $$LANGUPD $$LANGUPD_OPTIONS $$shell_path($$_PRO_FILE) -ts $$_PRO_FILE_PWD/$$TRANSLATIONS
-
-
-
-    langrel.depends = langupd
-    langrel.input = TRANSLATIONS
-    langrel.output = $$TRANSLATION_TARGET_DIR/${QMAKE_FILE_BASE}.qm
-    langrel.commands = \
-        $$LANGREL $$LANGREL_OPTIONS ${QMAKE_FILE_IN} -qm $$TRANSLATION_TARGET_DIR/${QMAKE_FILE_BASE}.qm
-    langrel.CONFIG += no_link
-
-    QMAKE_EXTRA_TARGETS += langupd
-    QMAKE_EXTRA_COMPILERS += langrel
-
-    # Compile an initial version of translation files when running qmake
-    # the first time and generate the resource file for translations.
-    !exists($$TRANSLATION_TARGET_DIR) {
-        mkpath($$TRANSLATION_TARGET_DIR)
-    }
-    qrc_entry = "<RCC>"
-    qrc_entry += '  <qresource prefix="/">'
-    write_file($$TRANSLATION_TARGET_DIR/translations.qrc, qrc_entry)
-    for(tsfile, TRANSLATIONS) {
-        qmfile = $$TRANSLATION_TARGET_DIR/$$basename(tsfile)
-        qmfile ~= s/.ts$/.qm/
-        system($$LANGREL $$LANGREL_OPTIONS $$tsfile -qm $$qmfile)
-        qrc_entry = "    <file>$$basename(qmfile)</file>"
-        write_file($$TRANSLATION_TARGET_DIR/translations.qrc, qrc_entry, append)
-    }
-    qrc_entry = "  </qresource>"
-    qrc_entry += "</RCC>"
-    write_file($$TRANSLATION_TARGET_DIR/translations.qrc, qrc_entry, append)
-    RESOURCES += $$TRANSLATION_TARGET_DIR/translations.qrc
-}
-
-
-# Update: no issues with the "slow link process" anymore,
-# for development, just build debug version of libwallet_merged lib
-# by invoking 'get_libwallet_api.sh Debug'
-# so we update translations everytime even for debug build
-
-PRE_TARGETDEPS += langupd compiler_langrel_make_all
-
 RESOURCES += qml.qrc
 CONFIG += qtquickcompiler
 
@@ -409,6 +329,9 @@ CONFIG(release, debug|release) {
 } else {
     DESTDIR = debug/bin
 }
+
+# Rules for building translations.
+include(translations.pri)
 
 # Rules for deploying the application.
 include(deployment.pri)

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -403,8 +403,6 @@ CONFIG += qtquickcompiler
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH =
 
-# Default rules for deployment.
-#include(deployment.pri)
 
 CONFIG(release, debug|release) {
     DESTDIR = release/bin
@@ -412,32 +410,8 @@ CONFIG(release, debug|release) {
     DESTDIR = debug/bin
 }
 
-macx {
-    QMAKE_POST_LINK = macdeployqt $$sprintf("%1/%2/%3.app", $$OUT_PWD, $$DESTDIR, $$TARGET) \
-        -qmldir=$$PWD
-}
-
-win32 {
-    QMAKE_POST_LINK = windeployqt $$sprintf("%1/%2/%3.exe", $$OUT_PWD, $$DESTDIR, $$TARGET) \
-        -release -no-translations -qmldir=$$PWD
-
-    # Win64 msys2 deploy settings
-    contains(QMAKE_HOST.arch, x86_64) {
-        QMAKE_POST_LINK = $$PWD/windeploy_helper.sh $$DESTDIR
-    }
-}
-
-linux:!android {
-    TARGET = monero-wallet-gui
-    QMAKE_POST_LINK = $$PWD/linuxdeploy_helper.sh $$sprintf("%1/%2 %3", $$OUT_PWD, $$DESTDIR, $$TARGET)
-}
-
-android {
-    QMAKE_POST_LINK = make install INSTALL_ROOT=$$DESTDIR && androiddeployqt \
-        --input android-libmonero-wallet-gui.so-deployment-settings.json --output $$DESTDIR \
-        --deployment bundled --android-platform android-21 --jdk /usr/lib/jvm/java-8-openjdk-amd64 \
-        -qmldir=$$PWD
-}
+# Rules for deploying the application.
+include(deployment.pri)
 
 OTHER_FILES += \
     .gitignore \

--- a/translations.pri
+++ b/translations.pri
@@ -1,0 +1,73 @@
+# Rules for building translations.
+
+TRANSLATIONS = $$files($$PWD/translations/monero-core_*.ts)
+TRANSLATION_TARGET_DIR = $$OUT_PWD/translations
+
+CONFIG(release, debug|release) {
+    LANGUPD_OPTIONS = -locations relative -no-ui-lines
+    LANGREL_OPTIONS = -compress -nounfinished -removeidentical
+}
+
+TRANSLATION_TARGET_DIR = $$OUT_PWD/translations
+
+!ios {
+    isEmpty(QMAKE_LUPDATE) {
+        win32:LANGUPD = $$[QT_INSTALL_BINS]\lupdate.exe
+        else:LANGUPD = $$[QT_INSTALL_BINS]/lupdate
+    }
+
+    isEmpty(QMAKE_LRELEASE) {
+        win32:LANGREL = $$[QT_INSTALL_BINS]\lrelease.exe
+        else:LANGREL = $$[QT_INSTALL_BINS]/lrelease
+    }
+
+    langupd.command = \
+        $$LANGUPD $$LANGUPD_OPTIONS $$shell_path($$_PRO_FILE) -ts $$_PRO_FILE_PWD/$$TRANSLATIONS
+
+
+    langrel.depends = langupd
+    langrel.input = TRANSLATIONS
+    langrel.output = $$TRANSLATION_TARGET_DIR/${QMAKE_FILE_BASE}.qm
+    langrel.commands = \
+        $$LANGREL $$LANGREL_OPTIONS ${QMAKE_FILE_IN} -qm $$TRANSLATION_TARGET_DIR/${QMAKE_FILE_BASE}.qm
+    langrel.CONFIG += no_link
+
+    QMAKE_EXTRA_TARGETS += langupd
+    QMAKE_EXTRA_COMPILERS += langrel
+
+    # Compile an initial version of translation files when running qmake
+    # the first time and generate the resource file for translations.
+    !exists($$TRANSLATION_TARGET_DIR) {
+        mkpath($$TRANSLATION_TARGET_DIR)
+    }
+    qrc_entry = "<RCC>"
+    qrc_entry += '  <qresource prefix="/">'
+    write_file($$TRANSLATION_TARGET_DIR/translations.qrc, qrc_entry)
+    for(tsfile, TRANSLATIONS) {
+        qmfile = $$TRANSLATION_TARGET_DIR/$$basename(tsfile)
+        qmfile ~= s/.ts$/.qm/
+        system($$LANGREL $$LANGREL_OPTIONS $$tsfile -qm $$qmfile)
+        qrc_entry = "    <file>$$basename(qmfile)</file>"
+        write_file($$TRANSLATION_TARGET_DIR/translations.qrc, qrc_entry, append)
+    }
+    qrc_entry = "  </qresource>"
+    qrc_entry += "</RCC>"
+    write_file($$TRANSLATION_TARGET_DIR/translations.qrc, qrc_entry, append)
+    RESOURCES += $$TRANSLATION_TARGET_DIR/translations.qrc
+}
+
+
+# Update: no issues with the "slow link process" anymore,
+# for development, just build debug version of libwallet_merged lib
+# by invoking 'get_libwallet_api.sh Debug'
+# so we update translations everytime even for debug build
+
+PRE_TARGETDEPS += langupd compiler_langrel_make_all
+
+lupdate_only {
+SOURCES = *.qml \
+          components/*.qml \
+          pages/*.qml \
+          wizard/*.qml \
+          wizard/*js
+}


### PR DESCRIPTION
move deployment commands to QMAKE_POST_LINK, to don't need to call `make deploy` from build dir. 
( This breaks builbot, because it has its own rules ). In case it is not good the README should be updated because there is a missing step after the ./build.sh for linux/osx

make qmake config modular:
- move deployment stuff to deployment.pri. (deployment.pri was generated as part of the qt project and wasn't changed in 4 years)
- move translation stuff to translations.pri


