### PR TITLE
Fix use of persistentSettings.testnet to nettype

### DIFF
--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -51,7 +51,7 @@ Rectangle {
         console.log("Settings page loaded");
 
         if(typeof daemonManager != "undefined"){
-            appWindow.daemonRunning = persistentSettings.useRemoteNode ? false : daemonManager.running(persistentSettings.testnet);
+            appWindow.daemonRunning = persistentSettings.useRemoteNode ? false : daemonManager.running(persistentSettings.nettype);
         }
 
         logLevelDropdown.update()

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -287,7 +287,7 @@ Rectangle {
               if (result) {
                   var parts = result.split("|")
                   if (parts.length == 2) {
-                      var address_ok = walletManager.addressValid(parts[1], appWindow.persistentSettings.testnet)
+                      var address_ok = walletManager.addressValid(parts[1], appWindow.persistentSettings.nettype)
                       if (parts[0] === "true") {
                           if (address_ok) {
                               addressLine.text = parts[1]


### PR DESCRIPTION
After commit #1161 testnet flag was removed and nettype was introduced because of the stagenet flag. This changes the remaining instances of that to nettype.