### PR TITLE
Dutch translation update

### DIFF
--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -4,63 +4,57 @@
 <context>
     <name>AddressBook</name>
     <message>
-        <location filename="../pages/AddressBook.qml" line="50"/>
+        <location filename="../pages/AddressBook.qml" line="64"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="56"/>
+        <location filename="../pages/AddressBook.qml" line="51"/>
         <source>Qr Code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="74"/>
+        <location filename="../pages/AddressBook.qml" line="66"/>
         <source>4...</source>
         <translation>4...</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="80"/>
+        <location filename="../pages/AddressBook.qml" line="73"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Betalings-ID &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="81"/>
-        <source>&lt;b&gt;Payment ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;A unique user name used in&lt;br/&gt;the address book. It is not a&lt;br/&gt;transfer of information sent&lt;br/&gt;during the transfer</source>
-        <translatorcomment>Can we remove hard-coded line breaks within the sentence? In this case, the line breaks after the first two could ruin the formatting.</translatorcomment>
-        <translation>&lt;b&gt;Betalings-ID&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Een unieke gebruikersnaam&lt;br/&gt;voor het adresboek. Het is&lt;br/&gt;geen informatie die wordt&lt;br/&gt;verzonden</translation>
-    </message>
-    <message>
-        <location filename="../pages/AddressBook.qml" line="88"/>
+        <location filename="../pages/AddressBook.qml" line="74"/>
         <source>Paste 64 hexadecimal characters</source>
         <translation>Plak 64 hexadecimale karakters</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="93"/>
+        <location filename="../pages/AddressBook.qml" line="82"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;(Optional)&lt;/font&gt;</source>
         <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="99"/>
+        <location filename="../pages/AddressBook.qml" line="83"/>
         <source>Give this entry a name or description</source>
         <translation>Geef deze vermelding een naam of omschrijving</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="111"/>
+        <location filename="../pages/AddressBook.qml" line="91"/>
         <source>Add</source>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="116"/>
+        <location filename="../pages/AddressBook.qml" line="96"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="119"/>
+        <location filename="../pages/AddressBook.qml" line="99"/>
         <source>Invalid address</source>
         <translation>Ongeldig adres</translation>
     </message>
     <message>
-        <location filename="../pages/AddressBook.qml" line="123"/>
+        <location filename="../pages/AddressBook.qml" line="103"/>
         <source>Can&apos;t create entry</source>
         <translation>Kan vermelding niet opslaan</translation>
     </message>
@@ -73,12 +67,12 @@
         <translation>Verder geen resultaten</translation>
     </message>
     <message>
-        <location filename="../components/AddressBookTable.qml" line="104"/>
+        <location filename="../components/AddressBookTable.qml" line="105"/>
         <source>Payment ID:</source>
         <translation>Betalings-ID:</translation>
     </message>
     <message>
-        <location filename="../components/AddressBookTable.qml" line="149"/>
+        <location filename="../components/AddressBookTable.qml" line="150"/>
         <source>Address copied to clipboard</source>
         <translation>Adres gekopieerd naar klembord</translation>
     </message>
@@ -109,12 +103,12 @@
 <context>
     <name>DaemonConsole</name>
     <message>
-        <location filename="../components/DaemonConsole.qml" line="117"/>
+        <location filename="../components/DaemonConsole.qml" line="113"/>
         <source>Close</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../components/DaemonConsole.qml" line="128"/>
+        <location filename="../components/DaemonConsole.qml" line="124"/>
         <source>command + enter (e.g help)</source>
         <translation>opdracht + enter (b.v. help)</translation>
     </message>
@@ -127,12 +121,12 @@
         <translation>Lokale node wordt over %1 seconden gestart</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="115"/>
+        <location filename="../components/DaemonManagerDialog.qml" line="111"/>
         <source>Start daemon (%1)</source>
         <translation>Start node (%1)</translation>
     </message>
     <message>
-        <location filename="../components/DaemonManagerDialog.qml" line="132"/>
+        <location filename="../components/DaemonManagerDialog.qml" line="124"/>
         <source>Use custom settings</source>
         <translation>Gebruik aangepaste instellingen</translation>
     </message>
@@ -179,253 +173,223 @@
     </message>
 </context>
 <context>
-    <name>History</name>
-    <message>
-        <location filename="../pages/History.qml" line="135"/>
-        <source>Filter transaction history</source>
-        <translation>Filter transactiegeschiedenis</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="70"/>
-        <source> selected: </source>
-        <translation> geselecteerd: </translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="252"/>
-        <source>Filter</source>
-        <translation>Filteren</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="159"/>
-        <source>Type for incremental search...</source>
-        <translation>Begin te typen voor incrementeel zoeken...</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="199"/>
-        <source>Date from</source>
-        <translation>Datum van</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="225"/>
-        <location filename="../pages/History.qml" line="379"/>
-        <source>To</source>
-        <translation>Tot</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="290"/>
-        <source>Advanced filtering</source>
-        <translation>Geavanceerd filteren</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="310"/>
-        <source>Type of transaction</source>
-        <translation>Soort transactie</translation>
-    </message>
-    <message>
-        <location filename="../pages/History.qml" line="346"/>
-        <source>Amount from</source>
-        <translation>Bedrag van</translation>
-    </message>
-</context>
-<context>
     <name>HistoryTable</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="78"/>
+        <location filename="../components/HistoryTable.qml" line="80"/>
         <source>No more results</source>
         <translation>Verder geen resultaten</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="49"/>
-        <location filename="../components/HistoryTable.qml" line="195"/>
+        <location filename="../components/HistoryTable.qml" line="51"/>
         <source>Payment ID:</source>
         <translation>Betalings-ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="48"/>
+        <location filename="../components/HistoryTable.qml" line="50"/>
         <source>Tx ID:</source>
         <translation>Transactie-ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="50"/>
+        <location filename="../components/HistoryTable.qml" line="52"/>
         <source>Tx key:</source>
         <translation>Transactiesleutel:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="51"/>
+        <location filename="../components/HistoryTable.qml" line="53"/>
         <source>Tx note:</source>
         <translation>Transactienotitie:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="52"/>
+        <location filename="../components/HistoryTable.qml" line="54"/>
         <source>Destinations:</source>
         <translation>Bestemmingen:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="102"/>
-        <source>Details</source>
-        <translation>Details</translation>
+        <location filename="../components/HistoryTable.qml" line="55"/>
+        <source>Rings:</source>
+        <translation>Ringen:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="243"/>
-        <source>BlockHeight:</source>
-        <translation>Blokhoogte:</translation>
+        <location filename="../components/HistoryTable.qml" line="244"/>
+        <source>Address copied to clipboard</source>
+        <translation>Adres gekopieerd naar klembord</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="258"/>
+        <location filename="../components/HistoryTable.qml" line="343"/>
+        <source>Blockheight</source>
+        <translation>Blokhoogte</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="368"/>
+        <source>Description</source>
+        <translation>Omschrijving</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTable.qml" line="347"/>
         <source>(%1/%2 confirmations)</source>
         <translation>(%1/%2 bevestigingen)</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="262"/>
+        <location filename="../components/HistoryTable.qml" line="351"/>
         <source>UNCONFIRMED</source>
         <translation>ONBEVESTIGD</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="264"/>
+        <location filename="../components/HistoryTable.qml" line="353"/>
         <source>FAILED</source>
         <translation>MISLUKT</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="265"/>
+        <location filename="../components/HistoryTable.qml" line="354"/>
         <source>PENDING</source>
         <translation>IN AFWACHTING</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTable.qml" line="294"/>
-        <source>Date</source>
-        <translation>Datum</translation>
-    </message>
-    <message>
-        <location filename="../components/HistoryTable.qml" line="386"/>
+        <location filename="../components/HistoryTable.qml" line="309"/>
         <source>Fee</source>
         <translation>Vergoeding</translation>
     </message>
+</context>
+<context>
+    <name>HistoryTableInnerColumn</name>
     <message>
-        <location filename="../components/HistoryTable.qml" line="351"/>
-        <source>Amount</source>
-        <translation>Bedrag</translation>
+        <location filename="../components/HistoryTableInnerColumn.qml" line="87"/>
+        <source>Copied to clipboard</source>
+        <translation>Gekopieerd naar klembord</translation>
     </message>
 </context>
 <context>
     <name>HistoryTableMobile</name>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="47"/>
+        <location filename="../components/HistoryTableMobile.qml" line="49"/>
         <source>Tx ID:</source>
         <translation>Transactie-ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="48"/>
+        <location filename="../components/HistoryTableMobile.qml" line="50"/>
         <source>Payment ID:</source>
         <translation>Betalings-ID:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="49"/>
+        <location filename="../components/HistoryTableMobile.qml" line="51"/>
         <source>Tx key:</source>
         <translation>Transactiesleutel:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="50"/>
+        <location filename="../components/HistoryTableMobile.qml" line="52"/>
         <source>Tx note:</source>
         <translation>Transactienotitie:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="51"/>
+        <location filename="../components/HistoryTableMobile.qml" line="53"/>
         <source>Destinations:</source>
         <translation>Bestemmingen:</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="77"/>
+        <location filename="../components/HistoryTableMobile.qml" line="54"/>
+        <source>Rings:</source>
+        <translation>Ringen:</translation>
+    </message>
+    <message>
+        <location filename="../components/HistoryTableMobile.qml" line="80"/>
         <source>No more results</source>
         <translation>Verder geen resultaten</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="150"/>
+        <location filename="../components/HistoryTableMobile.qml" line="180"/>
         <source>(%1/%2 confirmations)</source>
         <translation>(%1/%2 bevestigingen)</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="152"/>
+        <location filename="../components/HistoryTableMobile.qml" line="182"/>
         <source>UNCONFIRMED</source>
         <translation>ONBEVESTIGD</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="154"/>
+        <location filename="../components/HistoryTableMobile.qml" line="184"/>
         <source>FAILED</source>
         <translation>MISLUKT</translation>
     </message>
     <message>
-        <location filename="../components/HistoryTableMobile.qml" line="155"/>
+        <location filename="../components/HistoryTableMobile.qml" line="185"/>
         <source>PENDING</source>
         <translation>IN AFWACHTING</translation>
     </message>
 </context>
 <context>
+    <name>InputDialog</name>
+    <message>
+        <location filename="../components/InputDialog.qml" line="134"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../components/InputDialog.qml" line="146"/>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
     <name>Keys</name>
     <message>
-        <location filename="../pages/Keys.qml" line="62"/>
+        <location filename="../pages/Keys.qml" line="115"/>
         <source>Mnemonic seed</source>
         <translation>Hersteltekst</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="78"/>
-        <location filename="../pages/Keys.qml" line="112"/>
+        <location filename="../pages/Keys.qml" line="162"/>
         <source>Double tap to copy</source>
         <translation>Dubbeltikken om te kopiëren</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="85"/>
-        <source>Seed copied to clipboard</source>
-        <translation>Hersteltekst gekopieerd naar klembord</translation>
-    </message>
-    <message>
-        <location filename="../pages/Keys.qml" line="95"/>
+        <location filename="../pages/Keys.qml" line="142"/>
         <source>Keys</source>
         <translation>Sleutels</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="119"/>
+        <location filename="../pages/Keys.qml" line="169"/>
         <source>Keys copied to clipboard</source>
         <translation>Sleutels gekopieerd naar klembord</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="129"/>
+        <location filename="../pages/Keys.qml" line="182"/>
         <source>Export wallet</source>
         <translation>Portemonnee exporteren</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="142"/>
-        <location filename="../pages/Keys.qml" line="181"/>
+        <location filename="../pages/Keys.qml" line="197"/>
+        <location filename="../pages/Keys.qml" line="237"/>
         <source>Spendable Wallet</source>
         <translation>Besteedbare portemonnee</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="150"/>
-        <location filename="../pages/Keys.qml" line="181"/>
+        <location filename="../pages/Keys.qml" line="206"/>
+        <location filename="../pages/Keys.qml" line="237"/>
         <source>View Only Wallet</source>
         <translation>Alleen-lezen portemonnee</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="191"/>
+        <location filename="../pages/Keys.qml" line="247"/>
         <source>Secret view key</source>
         <translation>Geheime alleen-lezen sleutel</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="192"/>
+        <location filename="../pages/Keys.qml" line="248"/>
         <source>Public view key</source>
         <translation>Openbare alleen-lezen sleutel</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="193"/>
+        <location filename="../pages/Keys.qml" line="249"/>
         <source>Secret spend key</source>
         <translation>Geheime bestedingssleutel</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="194"/>
+        <location filename="../pages/Keys.qml" line="250"/>
         <source>Public spend key</source>
         <translation>Openbare bestedingssleutel</translation>
     </message>
     <message>
-        <location filename="../pages/Keys.qml" line="206"/>
+        <location filename="../pages/Keys.qml" line="262"/>
         <source>(View Only Wallet -  No mnemonic seed available)</source>
         <translation>(Alleen-lezen portemonnee. Geen hersteltekst beschikbaar)</translation>
     </message>
@@ -433,135 +397,172 @@
 <context>
     <name>LeftPanel</name>
     <message>
-        <location filename="../LeftPanel.qml" line="147"/>
+        <location filename="../LeftPanel.qml" line="212"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="192"/>
+        <location filename="../LeftPanel.qml" line="202"/>
         <source>Unlocked balance</source>
         <translation>Beschikbaar saldo</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="295"/>
+        <location filename="../LeftPanel.qml" line="311"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="345"/>
+        <location filename="../LeftPanel.qml" line="361"/>
         <source>Receive</source>
         <translation>Ontvangen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="346"/>
+        <location filename="../LeftPanel.qml" line="362"/>
         <source>R</source>
-        <translatorcomment>Hotkeys visible when you press Alt Gr: 
-S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
+        <translatorcomment>Hotkey for Receive</translatorcomment>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="439"/>
+        <location filename="../LeftPanel.qml" line="455"/>
         <source>Prove/check</source>
         <translation>Bewijzen/controleren</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="440"/>
+        <location filename="../LeftPanel.qml" line="456"/>
         <source>K</source>
         <translatorcomment>Hotkey for Advanced - Check payment</translatorcomment>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="369"/>
+        <location filename="../LeftPanel.qml" line="385"/>
         <source>History</source>
         <translation>Geschiedenis</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="96"/>
+        <location filename="../LeftPanel.qml" line="137"/>
         <source>View Only</source>
         <translation>Alleen-lezen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="108"/>
+        <location filename="../LeftPanel.qml" line="124"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="320"/>
+        <location filename="../LeftPanel.qml" line="124"/>
+        <source>Stagenet</source>
+        <translation>Stagenet</translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="336"/>
         <source>Address book</source>
         <translation>Adresboek</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="321"/>
+        <location filename="../LeftPanel.qml" line="337"/>
         <source>B</source>
         <translatorcomment>Hotkey for Send - Address book</translatorcomment>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="370"/>
+        <location filename="../LeftPanel.qml" line="386"/>
         <source>H</source>
         <translatorcomment>Hotkey for History</translatorcomment>
         <translation>G</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="392"/>
+        <location filename="../LeftPanel.qml" line="408"/>
         <source>Advanced</source>
         <translation>Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="393"/>
+        <location filename="../LeftPanel.qml" line="409"/>
         <source>D</source>
         <translatorcomment>Hotkey for Advanced</translatorcomment>
-        <translation>G</translation>
+        <translation>V</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="415"/>
+        <location filename="../LeftPanel.qml" line="431"/>
         <source>Mining</source>
         <translation>Minen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="416"/>
+        <location filename="../LeftPanel.qml" line="432"/>
         <source>M</source>
         <translatorcomment>Hotkey for Advanced - Mining</translatorcomment>
         <translation>M</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="508"/>
+        <location filename="../LeftPanel.qml" line="478"/>
+        <source>Shared RingDB</source>
+        <translation>Gedeelde RingDB</translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="479"/>
+        <source>A</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="548"/>
         <source>Seed &amp; Keys</source>
         <translation>Hersteltekst en sleutels</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="509"/>
+        <location filename="../LeftPanel.qml" line="549"/>
         <source>Y</source>
         <translatorcomment>Hotkey for Seed &amp; Keys?</translatorcomment>
         <translation>T</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="463"/>
+        <location filename="../LeftPanel.qml" line="588"/>
+        <source>Wallet</source>
+        <translation>Portemonnee</translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="597"/>
+        <source>Daemon</source>
+        <translation>Node</translation>
+    </message>
+    <message>
+        <location filename="../LeftPanel.qml" line="503"/>
         <source>Sign/verify</source>
         <translation>Ondertekenen/verifiëren</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="464"/>
+        <location filename="../LeftPanel.qml" line="504"/>
         <source>I</source>
         <translatorcomment>Hotkey for Advanced - Sign/verify</translatorcomment>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="486"/>
+        <location filename="../LeftPanel.qml" line="526"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="487"/>
+        <location filename="../LeftPanel.qml" line="527"/>
         <source>E</source>
         <translatorcomment>Hotkey for Settings</translatorcomment>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../LeftPanel.qml" line="296"/>
+        <location filename="../LeftPanel.qml" line="312"/>
         <source>S</source>
         <translatorcomment>Hotkey for Send</translatorcomment>
         <translation>Z</translation>
+    </message>
+</context>
+<context>
+    <name>LineEditMulti</name>
+    <message>
+        <location filename="../components/LineEditMulti.qml" line="84"/>
+        <source>Copy</source>
+        <translation>Kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../components/LineEditMulti.qml" line="91"/>
+        <source>Copied to clipboard</source>
+        <translation>Gekopieerd naar klembord</translation>
     </message>
 </context>
 <context>
@@ -580,87 +581,87 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>Mining</name>
     <message>
-        <location filename="../pages/Mining.qml" line="70"/>
+        <location filename="../pages/Mining.qml" line="61"/>
         <source>Solo mining</source>
         <translation>Solo minen</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="77"/>
+        <location filename="../pages/Mining.qml" line="68"/>
         <source>(only available for local daemons)</source>
         <translation>(alleen beschikbaar voor lokale nodes)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="83"/>
+        <location filename="../pages/Mining.qml" line="74"/>
         <source>Mining with your computer helps strengthen the Monero network. The more that people mine, the harder it is for the network to be attacked, and every little bit helps.&lt;br&gt; &lt;br&gt;Mining also gives you a small chance to earn some Monero. Your computer will create hashes looking for block solutions. If you find a block, you will get the associated reward. Good luck!</source>
         <translation>Minen met uw computer helpt het Monero-netwerk sterker te worden. Hoe meer individuen er minen, des te moeilijker het is om het Monero-netwerk aan te vallen. Ieder beetje helpt dus.&lt;br&gt; &lt;br&gt; Minen geeft u ook een kleine kans om Monero te verdienen. Uw computer zal namelijk specifieke tekenreeksen berekenen en zodoende op zoek gaan naar Monero blok-oplossingen. Als u een blok vindt, ontvangt u de bijbehorende beloning. Veel success!</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="93"/>
+        <location filename="../pages/Mining.qml" line="87"/>
         <source>CPU threads</source>
         <translation>CPU threads</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="101"/>
+        <location filename="../pages/Mining.qml" line="95"/>
         <source>(optional)</source>
         <translation>(optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="113"/>
+        <location filename="../pages/Mining.qml" line="107"/>
         <source>Background mining (experimental)</source>
         <translation>Minen op de achtergrond (experimenteel)</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="129"/>
+        <location filename="../pages/Mining.qml" line="121"/>
         <source>Enable mining when running on battery</source>
         <translation>Start het minen ook indien de accu gebruikt wordt</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="139"/>
+        <location filename="../pages/Mining.qml" line="129"/>
         <source>Manage miner</source>
         <translation>Beheer de miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="148"/>
+        <location filename="../pages/Mining.qml" line="139"/>
         <source>Start mining</source>
         <translation>Start het minen</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="158"/>
+        <location filename="../pages/Mining.qml" line="145"/>
         <source>Error starting mining</source>
         <translation>Fout opgetreden bij het starten van de miner</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="159"/>
+        <location filename="../pages/Mining.qml" line="146"/>
         <source>Couldn&apos;t start mining.&lt;br&gt;</source>
         <translation>Kon niet starten met minen.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="161"/>
+        <location filename="../pages/Mining.qml" line="148"/>
         <source>Mining is only available on local daemons. Run a local daemon to be able to mine.&lt;br&gt;</source>
         <translation>Minen is alleen beschikbaar voor lokale nodes. Start een lokale node om te kunnen minen.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="173"/>
+        <location filename="../pages/Mining.qml" line="161"/>
         <source>Stop mining</source>
         <translation>Stop het minen</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="188"/>
+        <location filename="../pages/Mining.qml" line="172"/>
         <source>Status: not mining</source>
         <translation>Status: er wordt niet gemined</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="199"/>
+        <location filename="../pages/Mining.qml" line="184"/>
         <source>Mining at %1 H/s</source>
         <translation>Er wordt gemined met %1 H/s</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="202"/>
+        <location filename="../pages/Mining.qml" line="187"/>
         <source>Not mining</source>
         <translation>Er wordt niet gemined</translation>
     </message>
     <message>
-        <location filename="../pages/Mining.qml" line="204"/>
+        <location filename="../pages/Mining.qml" line="189"/>
         <source>Status: </source>
         <translation>Status: </translation>
     </message>
@@ -668,7 +669,7 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>MobileHeader</name>
     <message>
-        <location filename="../components/MobileHeader.qml" line="92"/>
+        <location filename="../components/MobileHeader.qml" line="93"/>
         <source>Unlocked Balance:</source>
         <translation>Beschikbaar saldo:</translation>
     </message>
@@ -676,37 +677,37 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>NetworkStatusItem</name>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="91"/>
+        <location filename="../components/NetworkStatusItem.qml" line="102"/>
         <source>Network status</source>
         <translation>Netwerkstatus</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="56"/>
+        <location filename="../components/NetworkStatusItem.qml" line="46"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="53"/>
+        <location filename="../components/NetworkStatusItem.qml" line="43"/>
         <source>Synchronizing</source>
         <translation>Synchroniseren</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="55"/>
+        <location filename="../components/NetworkStatusItem.qml" line="45"/>
         <source>Remote node</source>
         <translation>Externe node</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="59"/>
+        <location filename="../components/NetworkStatusItem.qml" line="49"/>
         <source>Wrong version</source>
         <translation>Verkeerde versie</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="61"/>
+        <location filename="../components/NetworkStatusItem.qml" line="51"/>
         <source>Disconnected</source>
         <translation>Niet verbonden</translation>
     </message>
     <message>
-        <location filename="../components/NetworkStatusItem.qml" line="62"/>
+        <location filename="../components/NetworkStatusItem.qml" line="52"/>
         <source>Invalid connection status</source>
         <translation>Ongeldige verbindingsstatus</translation>
     </message>
@@ -714,22 +715,22 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>NewPasswordDialog</name>
     <message>
-        <location filename="../components/NewPasswordDialog.qml" line="100"/>
+        <location filename="../components/NewPasswordDialog.qml" line="102"/>
         <source>Please enter new password</source>
         <translation>Voer het nieuwe wachtwoord in</translation>
     </message>
     <message>
-        <location filename="../components/NewPasswordDialog.qml" line="157"/>
+        <location filename="../components/NewPasswordDialog.qml" line="160"/>
         <source>Please confirm new password</source>
         <translation>Bevestig uw nieuwe wachtwoord</translation>
     </message>
     <message>
-        <location filename="../components/NewPasswordDialog.qml" line="231"/>
+        <location filename="../components/NewPasswordDialog.qml" line="232"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../components/NewPasswordDialog.qml" line="244"/>
+        <location filename="../components/NewPasswordDialog.qml" line="241"/>
         <source>Continue</source>
         <translation>Doorgaan</translation>
     </message>
@@ -737,22 +738,22 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>PasswordDialog</name>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="88"/>
+        <location filename="../components/PasswordDialog.qml" line="83"/>
         <source>Please enter wallet password</source>
         <translation>Vul het wachtwoord voor de portemonnee in</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="88"/>
-        <source>Please enter wallet password for:&lt;br&gt;</source>
-        <translation>Vul het wachtwoord van de portemonnee in voor:&lt;br&gt;</translation>
+        <location filename="../components/PasswordDialog.qml" line="83"/>
+        <source>Please enter wallet password for: </source>
+        <translation>Vul het wachtwoord in voor de portemonnee: </translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="156"/>
+        <location filename="../components/PasswordDialog.qml" line="147"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../components/PasswordDialog.qml" line="169"/>
+        <location filename="../components/PasswordDialog.qml" line="158"/>
         <source>Continue</source>
         <translation>Doorgaan</translation>
     </message>
@@ -760,17 +761,17 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>PrivacyLevelSmall</name>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="100"/>
+        <location filename="../components/PrivacyLevelSmall.qml" line="96"/>
         <source>Low</source>
         <translation>Laag</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="109"/>
+        <location filename="../components/PrivacyLevelSmall.qml" line="105"/>
         <source>Medium</source>
         <translation>Gemiddeld</translation>
     </message>
     <message>
-        <location filename="../components/PrivacyLevelSmall.qml" line="118"/>
+        <location filename="../components/PrivacyLevelSmall.qml" line="114"/>
         <source>High</source>
         <translation>Hoog</translation>
     </message>
@@ -778,19 +779,16 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>ProgressBar</name>
     <message>
-        <location filename="../components/ProgressBar.qml" line="41"/>
-        <source>Establishing connection...</source>
-        <translation>Bezig met verbinding te maken...</translation>
+        <location filename="../components/ProgressBar.qml" line="38"/>
+        <source>%1 blocks remaining: </source>
+        <translatorcomment>Context? Argument is syncType (Daemon/Wallet)</translatorcomment>
+        <translation>Blokken te gaan in %1: </translation>
     </message>
     <message>
-        <location filename="../components/ProgressBar.qml" line="58"/>
-        <source>Blocks remaining: %1</source>
-        <translation>Blokken resterend: %1</translation>
-    </message>
-    <message>
-        <location filename="../components/ProgressBar.qml" line="109"/>
-        <source>Synchronizing blocks</source>
-        <translation>Blokken synchroniseren</translation>
+        <location filename="../components/ProgressBar.qml" line="70"/>
+        <source>Synchronizing %1</source>
+        <translatorcomment>Context? Argument is syncType (Daemon/Wallet)</translatorcomment>
+        <translation>%1 wordt gesynchroniseerd</translation>
     </message>
 </context>
 <context>
@@ -804,165 +802,135 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>Receive</name>
     <message>
-        <location filename="../pages/Receive.qml" line="64"/>
-        <source>Invalid payment ID</source>
-        <translation>Ongeldige betalings-ID</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="113"/>
+        <location filename="../pages/Receive.qml" line="80"/>
         <source>WARNING: no connection to daemon</source>
         <translation>WAARSCHUWING: er is geen verbinding met een node</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="135"/>
+        <location filename="../pages/Receive.qml" line="103"/>
         <source>in the txpool: %1</source>
         <translation>in de transactiepoel: %1</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="142"/>
+        <location filename="../pages/Receive.qml" line="110"/>
         <source>%2 confirmations: %3 (%1)</source>
         <translation>%2 bevestigingen: %3 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="144"/>
+        <location filename="../pages/Receive.qml" line="112"/>
         <source>1 confirmation: %2 (%1)</source>
         <translation>1 bevestiging: %2 (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="152"/>
+        <location filename="../pages/Receive.qml" line="124"/>
         <source>No transaction found yet...</source>
         <translation>Nog geen transactie gevonden...</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="128"/>
         <source>Transaction found</source>
         <translation>Transactie gevonden</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="156"/>
+        <location filename="../pages/Receive.qml" line="128"/>
         <source>%1 transactions found</source>
         <translation>%1 gevonden transacties</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="162"/>
+        <location filename="../pages/Receive.qml" line="134"/>
         <source> with more money (%1)</source>
         <translation> met meer geld (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="164"/>
+        <location filename="../pages/Receive.qml" line="136"/>
         <source> with not enough money (%1)</source>
         <translation> met onvoldoende geld (%1)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="195"/>
-        <source>Address</source>
-        <translation>Adres</translation>
+        <location filename="../pages/Receive.qml" line="166"/>
+        <source>Addresses</source>
+        <translation>Adressen</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="202"/>
-        <source>ReadOnly wallet address displayed here</source>
-        <translation>Adres alleen-lezen portemonnee wordt hier weergegeven</translation>
+        <location filename="../pages/Receive.qml" line="243"/>
+        <source>Create new address</source>
+        <translation>Nieuw adres aanmaken</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="214"/>
-        <source>Address copied to clipboard</source>
-        <translation>Adres gekopieerd naar klembord</translation>
+        <location filename="../pages/Receive.qml" line="245"/>
+        <source>Set the label of the new address:</source>
+        <translation>Label voor nieuw adres invoeren:</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="235"/>
-        <source>16 hexadecimal characters</source>
-        <translation>16 hexadecimale tekens</translation>
+        <location filename="../pages/Receive.qml" line="246"/>
+        <source>(Untitled)</source>
+        <translation>(Naamloos)</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="247"/>
-        <source>Payment ID copied to clipboard</source>
-        <translation>Betalings-ID gekopieerd naar klembord</translation>
+        <location filename="../pages/Receive.qml" line="258"/>
+        <source>Rename</source>
+        <translation>Naam wijzigen</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="270"/>
-        <source>Clear</source>
-        <translation>Wissen</translation>
+        <location filename="../pages/Receive.qml" line="260"/>
+        <source>Set the label of the selected address:</source>
+        <translation>Label voor geselecteerd adres invoeren:</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="279"/>
-        <source>Integrated address</source>
-        <translation>Geïntegreerd adres</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="288"/>
-        <source>Generate payment ID for integrated address</source>
-        <translation>Genereer betalings-ID voor geïntegreerd adres</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="300"/>
-        <source>Integrated address copied to clipboard</source>
-        <translation>Geïntegreerd adres gekopieerd naar klembord</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="341"/>
+        <location filename="../pages/Receive.qml" line="304"/>
         <source>Tracking</source>
         <translation>Traceren</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="343"/>
+        <location filename="../pages/Receive.qml" line="306"/>
         <source>help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="393"/>
+        <location filename="../pages/Receive.qml" line="312"/>
+        <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Dit is een eenvoudige verkooptracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Laat uw klant deze QR-code scannen om een betaling uit te voeren (als de klant een app voor het scannen van QR-codes heeft).&lt;/p&gt;&lt;p&gt;Deze pagina zoekt automatisch in de blockchain en de transactiepool naar binnenkomende transacties met deze QR-code. Als u een bedrag invult, wordt ook gecontroleerd of dat bedrag wordt betaald door binnenkomende transacties.&lt;/p&gt;Het is uw keuze of u onbevestigde transacties wilt accepteren. Waarschijnlijk worden ze snel bevestigd, maar dat is niet gegarandeerd, dus voor grotere bedragen kunt u beter wachten op een of meer bevestigingen.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/Receive.qml" line="354"/>
         <source>Save QrCode</source>
         <translation>QR-code opslaan</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="394"/>
+        <location filename="../pages/Receive.qml" line="355"/>
         <source>Failed to save QrCode to </source>
         <translation>QR-code niet opgeslagen in </translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="405"/>
+        <location filename="../pages/Receive.qml" line="366"/>
         <source>Save As</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="227"/>
-        <source>Payment ID</source>
-        <translation>Betalings-ID</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="312"/>
+        <location filename="../pages/Receive.qml" line="276"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="320"/>
+        <location filename="../pages/Receive.qml" line="283"/>
         <source>Amount to receive</source>
         <translation>Te ontvangen bedrag</translation>
     </message>
     <message>
-        <location filename="../pages/Receive.qml" line="348"/>
+        <location filename="../pages/Receive.qml" line="311"/>
         <source>Tracking payments</source>
         <translation>Betalingen traceren</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="349"/>
-        <source>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;This is a simple sales tracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Click Generate to create a random payment id for a new customer&lt;/p&gt; &lt;p&gt;Let your customer scan that QR code to make a payment (if that customer has software which supports QR code scanning).&lt;/p&gt;&lt;p&gt;This page will automatically scan the blockchain and the tx pool for incoming transactions using this QR code. If you input an amount, it will also check that incoming transactions total up to that amount.&lt;/p&gt;It&apos;s up to you whether to accept unconfirmed transactions or not. It is likely they&apos;ll be confirmed in short order, but there is still a possibility they might not, so for larger values you may want to wait for one or more confirmation(s).&lt;/p&gt;</source>
-        <translation>&lt;p&gt;&lt;font size=&apos;+2&apos;&gt;Dit is een eenvoudige verkooptracker:&lt;/font&gt;&lt;/p&gt;&lt;p&gt;Klik hier om een willekeurige betalings-ID te maken voor een nieuwe klant&lt;/p&gt; &lt;p&gt;Laat uw klant deze QR-code scannen om een betaling uit te voeren (als die klant over software beschikt die QR-codes kan scannen).&lt;/p&gt;&lt;p&gt;Deze pagina zal automatisch de blockchain en transactiepoel doorzoeken op inkomende transacties met behulp van deze QR-code. Als u een bedrag invult, wordt er ook gecontroleerd of het complete bedrag ontvangen is.&lt;/p&gt;Het is aan u om eventuele onbevestigde transacties te accepteren of niet. Het is zeer waarschijnlijk dat deze op korte termijn bevestigd zullen worden, maar er is nog steeds een mogelijkheid dat dit niet gebeurt. Bij grote bedragen is het dus aan te raden om te wachten op een of meer bevestigingen.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Receive.qml" line="259"/>
-        <source>Generate</source>
-        <translation>Genereer</translation>
     </message>
 </context>
 <context>
     <name>RemoteNodeEdit</name>
     <message>
-        <location filename="../components/RemoteNodeEdit.qml" line="49"/>
+        <location filename="../components/RemoteNodeEdit.qml" line="67"/>
         <source>Remote Node Hostname / IP</source>
         <translation>Hostnaam/IP-adres van externe node</translation>
     </message>
     <message>
-        <location filename="../components/RemoteNodeEdit.qml" line="57"/>
+        <location filename="../components/RemoteNodeEdit.qml" line="83"/>
         <source>Port</source>
         <translation>Poort</translation>
     </message>
@@ -970,12 +938,12 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>SearchInput</name>
     <message>
-        <location filename="../components/SearchInput.qml" line="69"/>
+        <location filename="../components/SearchInput.qml" line="71"/>
         <source>Search by...</source>
         <translation>Zoeken op...</translation>
     </message>
     <message>
-        <location filename="../components/SearchInput.qml" line="228"/>
+        <location filename="../components/SearchInput.qml" line="225"/>
         <source>SEARCH</source>
         <translation>ZOEKEN</translation>
     </message>
@@ -983,109 +951,137 @@ S Send, R Receive, H History, D Advanced, E Settings.</translatorcomment>
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../pages/Settings.qml" line="153"/>
-        <location filename="../pages/Settings.qml" line="180"/>
+        <location filename="../pages/Settings.qml" line="157"/>
+        <location filename="../pages/Settings.qml" line="185"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="181"/>
+        <location filename="../pages/Settings.qml" line="186"/>
         <source>Wrong password</source>
         <translation>Verkeerd wachtwoord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="66"/>
+        <location filename="../pages/Settings.qml" line="74"/>
         <source>Manage wallet</source>
         <translation>Portemonnee beheren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="81"/>
+        <location filename="../pages/Settings.qml" line="95"/>
         <source>Close wallet</source>
         <translation>Portemonnee sluiten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="96"/>
+        <location filename="../pages/Settings.qml" line="107"/>
         <source>Create view only wallet</source>
         <translation>Maak een alleen-lezen portemonnee aan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="609"/>
+        <location filename="../pages/Settings.qml" line="726"/>
         <source>Daemon log</source>
         <translation>Node-log</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="285"/>
+        <location filename="../pages/Settings.qml" line="379"/>
         <source>Show status</source>
         <translation>Bekijk status</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="310"/>
-        <location filename="../pages/Settings.qml" line="340"/>
+        <location filename="../pages/Settings.qml" line="409"/>
+        <location filename="../pages/Settings.qml" line="449"/>
         <source>(optional)</source>
         <translation>(optioneel)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="145"/>
+        <location filename="../pages/Settings.qml" line="153"/>
         <source>Rescan wallet balance</source>
         <translation>Saldo van portemonnee opzoeken</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="154"/>
+        <location filename="../pages/Settings.qml" line="158"/>
         <source>Error: </source>
         <translation>Fout: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="159"/>
+        <location filename="../pages/Settings.qml" line="163"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="303"/>
+        <location filename="../pages/Settings.qml" line="396"/>
         <source>Blockchain location</source>
         <translation>Locatie van blockchain</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="363"/>
+        <location filename="../pages/Settings.qml" line="464"/>
         <source>Username</source>
         <translation>Gebruikersnaam</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="372"/>
+        <location filename="../pages/Settings.qml" line="472"/>
         <source>Password</source>
         <translation>Wachtwoord</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="397"/>
+        <location filename="../pages/Settings.qml" line="309"/>
         <source>Connect</source>
         <translation>Verbinden</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="498"/>
+        <location filename="../pages/Settings.qml" line="204"/>
+        <source>Daemon mode</source>
+        <translatorcomment>Can&apos;t call this &apos;Node-modus&apos; because running as a daemon is a thing.</translatorcomment>
+        <translation>Daemon-modus</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="237"/>
+        <source>Bootstrap node</source>
+        <translation>Externe node</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="256"/>
+        <location filename="../pages/Settings.qml" line="288"/>
+        <source>Address</source>
+        <translation>Adres</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="289"/>
+        <source>Port</source>
+        <translation>Poort</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="420"/>
+        <source>Change location</source>
+        <translation>Locatie veranderen</translation>
+    </message>
+    <message>
+        <location filename="../pages/Settings.qml" line="605"/>
         <source>Debug info</source>
         <translation>Foutgegevens</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="523"/>
+        <location filename="../pages/Settings.qml" line="640"/>
         <source>Wallet creation height: </source>
         <translation>Hoogte waarop portemonnee is gemaakt: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="524"/>
+        <location filename="../pages/Settings.qml" line="641"/>
         <source> &lt;a href=&apos;#&apos;&gt;(Click to change)&lt;/a&gt;</source>
         <translation> &lt;a href=&apos;#&apos;&gt;(Klik om te wijzigen)&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="550"/>
+        <location filename="../pages/Settings.qml" line="668"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="563"/>
+        <location filename="../pages/Settings.qml" line="677"/>
         <source>Rescan wallet cache</source>
         <translation>Portemonneecache opnieuw opzoeken</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="564"/>
+        <location filename="../pages/Settings.qml" line="678"/>
         <source>Are you sure you want to rebuild the wallet cache?
 The following information will be deleted
 - Recipient addresses
@@ -1104,250 +1100,370 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
 </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="592"/>
+        <location filename="../pages/Settings.qml" line="707"/>
         <source>Wallet log path: </source>
         <translation>Pad naar portemonneelog: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="596"/>
+        <location filename="../pages/Settings.qml" line="712"/>
         <source>Wallet Name: </source>
         <translation>Naam van portemonnee: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="600"/>
+        <location filename="../pages/Settings.qml" line="717"/>
         <source>Daemon log path: </source>
         <translation>Pad naar nodelog: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="618"/>
+        <location filename="../pages/Settings.qml" line="735"/>
         <source>Please choose a folder</source>
         <translation>Kies een map</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="627"/>
+        <location filename="../pages/Settings.qml" line="745"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="630"/>
+        <location filename="../pages/Settings.qml" line="748"/>
         <source>Error: Filesystem is read only</source>
         <translation>Fout: het bestandssysteem is alleen-lezen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="634"/>
+        <location filename="../pages/Settings.qml" line="752"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Waarschuwing: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="636"/>
+        <location filename="../pages/Settings.qml" line="754"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Let op: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="640"/>
+        <location filename="../pages/Settings.qml" line="758"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>LMDB-map niet gevonden. Er wordt een nieuwe map gemaakt.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="572"/>
-        <location filename="../pages/Settings.qml" line="644"/>
+        <location filename="../pages/Settings.qml" line="686"/>
+        <location filename="../pages/Settings.qml" line="762"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="160"/>
+        <location filename="../pages/Settings.qml" line="164"/>
         <source>Successfully rescanned spent outputs.</source>
         <translation>Uitgegeven outputs zijn opnieuw opgezocht.</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="170"/>
+        <location filename="../pages/Settings.qml" line="179"/>
         <source>Change password</source>
         <translation>Wachtwoord wijzigen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="201"/>
+        <location filename="../pages/Settings.qml" line="212"/>
         <source>Local Node</source>
         <translation>Lokale node</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="215"/>
+        <location filename="../pages/Settings.qml" line="223"/>
         <source>Remote Node</source>
         <translation>Externe node</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="233"/>
+        <location filename="../pages/Settings.qml" line="331"/>
         <source>Manage Daemon</source>
         <translation>Node beheren</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="239"/>
+        <location filename="../pages/Settings.qml" line="435"/>
         <source>Show advanced</source>
         <translation>Geavanceerde weergave</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="257"/>
+        <location filename="../pages/Settings.qml" line="354"/>
         <source>Start Local Node</source>
         <translation>Lokale node starten</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="272"/>
+        <location filename="../pages/Settings.qml" line="369"/>
         <source>Stop Local Node</source>
         <translation>Lokale node stoppen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="333"/>
+        <location filename="../pages/Settings.qml" line="447"/>
         <source>Local daemon startup flags</source>
         <translation>Startparameters voor lokale node</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="351"/>
-        <source>Node login (optional)</source>
-        <translation>Inloggen bij node (optioneel)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="382"/>
-        <source>Remote node</source>
-        <translation>Externe node</translation>
-    </message>
-    <message>
-        <location filename="../pages/Settings.qml" line="421"/>
+        <location filename="../pages/Settings.qml" line="483"/>
         <source>Layout settings</source>
         <translation>Opmaakinstellingen</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="439"/>
+        <location filename="../pages/Settings.qml" line="504"/>
         <source>Custom decorations</source>
         <translation>Aangepaste decoraties</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="450"/>
+        <location filename="../pages/Settings.qml" line="514"/>
         <source>Log level</source>
         <translation>Logniveau</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="482"/>
+        <location filename="../pages/Settings.qml" line="589"/>
         <source>(e.g. *:WARNING,net.p2p:DEBUG)</source>
         <translation>(b.v. *:WARNING,net.p2p:DEBUG)</translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="512"/>
+        <location filename="../pages/Settings.qml" line="627"/>
         <source>GUI version: </source>
         <translation>GUI-versie: </translation>
     </message>
     <message>
-        <location filename="../pages/Settings.qml" line="517"/>
+        <location filename="../pages/Settings.qml" line="633"/>
         <source>Embedded Monero version: </source>
         <translation>Ingebouwde Monero-versie: </translation>
     </message>
 </context>
 <context>
-    <name>Sign</name>
+    <name>SharedRingDB</name>
     <message>
-        <location filename="../pages/Sign.qml" line="64"/>
-        <source>Good signature</source>
-        <translation>Geldige handtekening</translation>
+        <location filename="../pages/SharedRingDB.qml" line="89"/>
+        <source>This page allows you to interact with the shared ring database.&lt;br&gt;This database is meant for use by Monero wallets as well as wallets from Monero clones which reuse the Monero keys.</source>
+        <translation>Op deze pagina kunt u de database met gedeelde ringen gebruiken.&lt;br&gt;Deze database is bedoeld voor zowel Monero als klonen van Monero waarin Monero-sleutels worden hergebruikt.</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="65"/>
-        <source>This is a good signature</source>
-        <translation>Dit is een geldige handtekening</translation>
+        <location filename="../pages/SharedRingDB.qml" line="99"/>
+        <location filename="../pages/SharedRingDB.qml" line="105"/>
+        <source>Blackballed outputs</source>
+        <translation>Uitgesloten outputs</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="69"/>
-        <source>Bad signature</source>
-        <translation>Ongeldige handtekening</translation>
+        <location filename="../pages/SharedRingDB.qml" line="99"/>
+        <location filename="../pages/SharedRingDB.qml" line="226"/>
+        <source>help</source>
+        <translation>Help</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="70"/>
-        <source>This signature did not verify</source>
-        <translation>Deze handtekening is ongeldig</translation>
+        <location filename="../pages/SharedRingDB.qml" line="100"/>
+        <source>This sets which outputs are known to be spent, and thus not to be used as privacy placeholders in ring signatures.&lt;br&gt;</source>
+        <translation>Hiermee wordt ingesteld van welke outputs bekend is dat ze zijn uitgegeven. Deze worden dus niet gebruikt als afleiding voor privcay in ring-handtekeningen.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="106"/>
-        <source>Sign a message or file contents with your address:</source>
-        <translation>Onderteken een bericht of bestandsinhoud met uw adres:</translation>
+        <location filename="../pages/SharedRingDB.qml" line="101"/>
+        <source>You should only have to load a file when you want to refresh the list. Manual adding/removing is possible if needed.</source>
+        <translation>U hoeft alleen een bestand te laden als u de lijst wilt vernieuwen. Eventueel is handmatig toevoegen/verwijderen mogelijk.</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="115"/>
-        <location filename="../pages/Sign.qml" line="272"/>
-        <source>Either message:</source>
-        <translation>Een bericht:</translation>
+        <location filename="../pages/SharedRingDB.qml" line="106"/>
+        <source>In order to obscure which inputs in a Monero transaction are being spent, a third party should not be able to tell which inputs in a ring are already known to be spent. Being able to do so would weaken the protection afforded by ring signatures. If all but one of the inputs are known to be already spent, then the input being actually spent becomes apparent, thereby nullifying the effect of ring signatures, one of the three main layers of privacy protection Monero uses.&lt;br&gt;To help transactions avoid those inputs, a list of known spent ones can be used to avoid using them in new transactions. Such a list is maintained by the Monero project and is available on the getmonero.org website, and you can import this list here.&lt;br&gt;Alternatively, you can scan the blockchain (and the blockchain of key-reusing Monero clones) yourself using the monero-blockchain-blackball tool to create a list of known spent outputs.&lt;br&gt;</source>
+        <translation>Om te verbergen welke inputs in een Monero-transactie worden uitgegeven, moet een derde niet kunnen zien welke inputs in een ring al zijn uitgegeven. Daardoor zou de privacybescherming van ring-handtekeningen worden verzwakt. Als alle inputs op één na al zijn uitgegeven, is zichtbaar welke input echt wordt uitgegeven. Dan hebben ring-handtekeningen, een van de drie beschermingslagen van Monero, geen effect meer.&lt;br&gt; Met een lijst met bekende uitgegeven inputs kunt u voorkomen dat u ze in nieuwe transacties gebruikt. Deze lijst wordt onderhouden door het Monero-project en is beschikbaar op de website getmonero.org. U kunt de lijst hier importeren.&lt;br&gt; Maar u kunt ook zelf de blockchain doorzoeken (en van Monero gekopieerde blockchains waarop sleutels worden hergebruikt) met de tool monero-blockchain-blackball, om een lijst met bekende uitgegeven outputs te genereren.&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="128"/>
-        <source>Message to sign</source>
-        <translation>Te ondertekenen bericht</translation>
+        <location filename="../pages/SharedRingDB.qml" line="132"/>
+        <source>Please choose a file to load blackballed outputs from</source>
+        <translation>Selecteer een bestand om uitgesloten outputs uit te laden</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="145"/>
-        <location filename="../pages/Sign.qml" line="215"/>
-        <source>Sign</source>
-        <translation>Ondertekenen</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="171"/>
-        <source>Please choose a file to sign</source>
-        <translation>Kies een bestand om te ondertekenen</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="183"/>
-        <location filename="../pages/Sign.qml" line="340"/>
+        <location filename="../pages/SharedRingDB.qml" line="144"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="302"/>
-        <location filename="../pages/Sign.qml" line="371"/>
+        <location filename="../pages/SharedRingDB.qml" line="156"/>
+        <source>Filename with outputs to blackball</source>
+        <translation>Naam van bestand met uit te sluiten outputs</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="173"/>
+        <source>Load</source>
+        <translation>Laden</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="182"/>
+        <source>Or manually blackball or unblackball a single output:</source>
+        <translation>Of sluit één output handmatig uit of neem deze op:</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="190"/>
+        <source>Paste output public key</source>
+        <translation>Openbare sleutel van output plakken</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="207"/>
+        <source>Blackball</source>
+        <translation>Uitsluiten</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="216"/>
+        <source>Unblackball</source>
+        <translation>Opnemen</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="226"/>
+        <location filename="../pages/SharedRingDB.qml" line="231"/>
+        <source>Rings</source>
+        <translation>Ringen</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="227"/>
+        <source>This records rings used by outputs spent on Monero on a key reusing chain, so that the same ring may be reused to avoid privacy issues.</source>
+        <translation>Hier voert u in welke ringen zijn gebruikt voor in Monero uitgegeven outputs op een blockchain met hergebruik van sleutels, zodat dezelfde ring kan worden hergebruikt om uw privacy te beschermen.</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="232"/>
+        <source>In order to avoid nullifying the protection afforded by Monero&apos;s ring signatures, an output should not be spent with different rings on different blockchains. While this is normally not a concern, it can become one when a key-reusing Monero clone allows you do spend existing outputs. In this case, you need to ensure this existing outputs uses the same ring on both chains.&lt;br&gt;This will be done automatically by Monero and any key-reusing software which is not trying to actively strip you of your privacy.&lt;br&gt;If you are using a key-reusing Monero clone too, and this clone does not include this protection, you can still ensure your transactions are protected by spending on the clone first, then manually adding the ring on this page, which allows you to then spend your Monero safely.&lt;br&gt;If you do not use a key-reusing Monero clone without these safety features, then you do not need to do anything as it is all automated.&lt;br&gt;</source>
+        <translation>Om de bescherming door ring-handtekeningen van Monero in stand te houden, mag een output niet met andere ringen worden uitgegeven op andere blockchains. Dit wordt een probleem als u bestaande outputs uitgeeft op een Monero-kloon met hergebruik van sleutels. In dat geval moet u erop letten dat dezelfde ring op beide blockchains wordt gebruikt voor deze outputs.&lt;br&gt; Dit wordt automatisch gedaan door Monero en software die sleutels hergebruikt maar niet actief probeert uw privacy te verminderen.&lt;br&gt; Als u een Monero-kloon zonder deze bescherming gebruikt, kunt u toch uw transacties beschermen door eerst op de kloon te betalen, en vervolgens de ring op deze pagina in te voeren, zodat u uw Monero veilig kunt uitgeven.&lt;br&gt; Als u geen gebruik maakt van een Monero-kloon met hergebruik van sleutels maar zonder deze beveiliging, hoeft u niets te doen, want alles gaat automatisch.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="255"/>
+        <source>Paste key image</source>
+        <translation>Key image plakken</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="274"/>
+        <source>Get Ring</source>
+        <translation>Ring ophalen</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="281"/>
+        <source>No ring found</source>
+        <translation>Geen ring gevonden</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="292"/>
+        <source></source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="312"/>
+        <source>Relative</source>
+        <translation>Relatief</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="334"/>
+        <source>Set Ring</source>
+        <translation>Ring instellen</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="346"/>
+        <source>I intend to spend on key-reusing fork(s)</source>
+        <translation>Ik wil betalen op andere blockchains die sleutels hergebruiken</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="359"/>
+        <source>I might want to spend on key-reusing fork(s)</source>
+        <translation>Misschien wil ik betalen op andere blockchains die sleutels hergebruiken</translation>
+    </message>
+    <message>
+        <location filename="../pages/SharedRingDB.qml" line="378"/>
+        <source>Segregation height:</source>
+        <translation>Splitsingshoogte:</translation>
+    </message>
+</context>
+<context>
+    <name>Sign</name>
+    <message>
+        <location filename="../pages/Sign.qml" line="60"/>
+        <source>Good signature</source>
+        <translation>Geldige handtekening</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="61"/>
+        <source>This is a good signature</source>
+        <translation>Dit is een geldige handtekening</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="65"/>
+        <source>Bad signature</source>
+        <translation>Ongeldige handtekening</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="66"/>
+        <source>This signature did not verify</source>
+        <translation>Deze handtekening is ongeldig</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="124"/>
+        <source>Message to sign</source>
+        <translation>Te ondertekenen bericht</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="103"/>
+        <location filename="../pages/Sign.qml" line="137"/>
+        <location filename="../pages/Sign.qml" line="181"/>
+        <source>Sign</source>
+        <translation>Ondertekenen</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="107"/>
+        <source>This page lets you sign/verify a message (or file contents) with your address.</source>
+        <translation>Op deze pagina kunt u een bericht (of de inhoud van een bestand) ondertekenen/verifiëren met uw adres.</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="125"/>
+        <source>Message</source>
+        <translation>Bericht</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="155"/>
+        <source>Path to file</source>
+        <translation>Pad naar bestand</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="169"/>
+        <location filename="../pages/Sign.qml" line="262"/>
+        <source>Browse</source>
+        <translation>Bladeren</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="221"/>
+        <source>Verify message</source>
+        <translation>Bericht verifiëren</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="248"/>
+        <source>Verify file</source>
+        <translation>Bestand verifiëren</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="290"/>
+        <source>Address</source>
+        <translation>Adres</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="319"/>
+        <source>Please choose a file to sign</source>
+        <translation>Kies een bestand om te ondertekenen</translation>
+    </message>
+    <message>
+        <location filename="../pages/Sign.qml" line="211"/>
+        <location filename="../pages/Sign.qml" line="234"/>
+        <location filename="../pages/Sign.qml" line="274"/>
         <source>Verify</source>
         <translation>Verifiëren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="328"/>
+        <location filename="../pages/Sign.qml" line="330"/>
         <source>Please choose a file to verify</source>
         <translation>Kies een bestand om te verifiëren</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="387"/>
-        <source>Signing address</source>
-        <translatorcomment>Does this mean &apos;Address used to sign a message&apos;?</translatorcomment>
-        <translation>Adres voor ondertekening</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="389"/>
-        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
-        <translation>Plak het adres of selecteer het in het &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="160"/>
-        <location filename="../pages/Sign.qml" line="317"/>
-        <source>Or file:</source>
-        <translation>Of bestand:</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="197"/>
-        <source>Filename with message to sign</source>
-        <translation>Bestand met bericht om te ondertekenen</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="234"/>
-        <location filename="../pages/Sign.qml" line="239"/>
-        <location filename="../pages/Sign.qml" line="415"/>
-        <location filename="../pages/Sign.qml" line="420"/>
+        <location filename="../pages/Sign.qml" line="198"/>
+        <location filename="../pages/Sign.qml" line="199"/>
+        <location filename="../pages/Sign.qml" line="304"/>
+        <location filename="../pages/Sign.qml" line="309"/>
         <source>Signature</source>
         <translation>Handtekening</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="262"/>
-        <source>Verify a message or file signature from an address:</source>
-        <translation>Verifieer een bericht of bestandsinhoud met een adres:</translation>
-    </message>
-    <message>
-        <location filename="../pages/Sign.qml" line="285"/>
+        <location filename="../pages/Sign.qml" line="222"/>
         <source>Message to verify</source>
         <translation>Het te verifiëren bericht</translation>
     </message>
     <message>
-        <location filename="../pages/Sign.qml" line="354"/>
+        <location filename="../pages/Sign.qml" line="249"/>
         <source>Filename with message to verify</source>
         <translation>Bestandsnaam met bericht om te verifiëren</translation>
     </message>
@@ -1355,22 +1471,22 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
 <context>
     <name>StandardDialog</name>
     <message>
-        <location filename="../components/StandardDialog.qml" line="122"/>
+        <location filename="../components/StandardDialog.qml" line="133"/>
         <source>Double tap to copy</source>
         <translation>Dubbeltikken om te kopiëren</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="129"/>
+        <location filename="../components/StandardDialog.qml" line="140"/>
         <source>Content copied to clipboard</source>
         <translation>Gekopieerd naar klembord</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="147"/>
+        <location filename="../components/StandardDialog.qml" line="154"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../components/StandardDialog.qml" line="160"/>
+        <location filename="../components/StandardDialog.qml" line="163"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -1378,54 +1494,70 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
 <context>
     <name>StandardDropdown</name>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="203"/>
+        <location filename="../components/StandardDropdown.qml" line="162"/>
         <source>Low (x1 fee)</source>
         <translation>Laag (vergoeding × 1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="204"/>
+        <location filename="../components/StandardDropdown.qml" line="163"/>
         <source>Medium (x20 fee)</source>
         <translation>Gemiddeld (vergoeding × 20)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="205"/>
+        <location filename="../components/StandardDropdown.qml" line="164"/>
         <source>High (x166 fee)</source>
         <translation>Hoog (vergoeding × 166)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="206"/>
+        <location filename="../components/StandardDropdown.qml" line="165"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langzaam (vergoeding × 0,25)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="207"/>
+        <location filename="../components/StandardDropdown.qml" line="166"/>
         <source>Default (x1 fee)</source>
         <translation>Normaal (vergoeding × 1)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="208"/>
+        <location filename="../components/StandardDropdown.qml" line="167"/>
         <source>Fast (x5 fee)</source>
         <translation>Snel (vergoeding × 5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="209"/>
+        <location filename="../components/StandardDropdown.qml" line="168"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Razendsnel (vergoeding × 41,5)</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="210"/>
+        <location filename="../components/StandardDropdown.qml" line="169"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="211"/>
+        <location filename="../components/StandardDropdown.qml" line="170"/>
         <source>Sent</source>
         <translation>Verzonden</translation>
     </message>
     <message>
-        <location filename="../components/StandardDropdown.qml" line="212"/>
+        <location filename="../components/StandardDropdown.qml" line="171"/>
         <source>Received</source>
         <translation>Ontvangen</translation>
+    </message>
+</context>
+<context>
+    <name>SubaddressModel</name>
+    <message>
+        <location filename="../src/model/SubaddressModel.cpp" line="73"/>
+        <source>Primary address</source>
+        <translation>Primair adres</translation>
+    </message>
+</context>
+<context>
+    <name>SubaddressTable</name>
+    <message>
+        <location filename="../components/SubaddressTable.qml" line="78"/>
+        <source>Address copied to clipboard</source>
+        <translation>Adres gekopieerd naar klembord</translation>
     </message>
 </context>
 <context>
@@ -1454,22 +1586,22 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
 <context>
     <name>TableHeader</name>
     <message>
-        <location filename="../components/TableHeader.qml" line="65"/>
+        <location filename="../components/TableHeader.qml" line="79"/>
         <source>Payment ID</source>
         <translation>Betalings-ID</translation>
     </message>
     <message>
-        <location filename="../components/TableHeader.qml" line="66"/>
+        <location filename="../components/TableHeader.qml" line="80"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../components/TableHeader.qml" line="67"/>
+        <location filename="../components/TableHeader.qml" line="81"/>
         <source>Block height</source>
         <translation>Blokhoogte</translation>
     </message>
     <message>
-        <location filename="../components/TableHeader.qml" line="68"/>
+        <location filename="../components/TableHeader.qml" line="82"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
@@ -1477,25 +1609,33 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
 <context>
     <name>TickDelegate</name>
     <message>
-        <location filename="../components/TickDelegate.qml" line="55"/>
+        <location filename="../components/TickDelegate.qml" line="57"/>
         <source>Default</source>
         <translation>Normaal</translation>
     </message>
     <message>
-        <location filename="../components/TickDelegate.qml" line="56"/>
+        <location filename="../components/TickDelegate.qml" line="58"/>
         <source>High</source>
         <translation>Hoog</translation>
     </message>
 </context>
 <context>
+    <name>TransactionHistoryModel</name>
+    <message>
+        <location filename="../src/model/TransactionHistoryModel.cpp" line="103"/>
+        <source>Primary address</source>
+        <translation>Primair adres</translation>
+    </message>
+</context>
+<context>
     <name>Transfer</name>
     <message>
-        <location filename="../pages/Transfer.qml" line="129"/>
+        <location filename="../pages/Transfer.qml" line="189"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="181"/>
+        <location filename="../pages/Transfer.qml" line="212"/>
         <source>Transaction priority</source>
         <translation>Prioriteit transactie</translation>
     </message>
@@ -1505,248 +1645,252 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
         <translation></translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="419"/>
+        <location filename="../pages/Transfer.qml" line="445"/>
         <source>Transaction cost</source>
         <translation>Transactiekosten</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="69"/>
+        <location filename="../pages/Transfer.qml" line="70"/>
         <source>OpenAlias error</source>
         <translation>Fout in OpenAlias</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="81"/>
-        <source>Privacy level (ringsize %1)</source>
-        <translatorcomment>Is &apos;vertrouwenscirkel grootte&apos; een betere vertaling?</translatorcomment>
-        <translation>Privacyniveau (ring grootte %1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="194"/>
+        <location filename="../pages/Transfer.qml" line="228"/>
         <source>Slow (x0.25 fee)</source>
         <translation>Langzaam (vergoeding × 0,25)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="195"/>
-        <source>Default (x1 fee)</source>
-        <translation>Normaal (vergoeding × 1)</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="196"/>
+        <location filename="../pages/Transfer.qml" line="230"/>
         <source>Fast (x5 fee)</source>
         <translation>Snel (vergoeding × 5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="197"/>
+        <location filename="../pages/Transfer.qml" line="231"/>
         <source>Fastest (x41.5 fee)</source>
         <translation>Razendsnel (vergoeding × 41,5)</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="235"/>
+        <location filename="../pages/Transfer.qml" line="298"/>
         <source>QR Code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="259"/>
+        <location filename="../pages/Transfer.qml" line="260"/>
         <source>Resolve</source>
         <translation>Oplossen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="277"/>
+        <location filename="../pages/Transfer.qml" line="46"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Start daemon&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</source>
+        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #FF6C3C; font-size: 14px;}&lt;/style&gt;&lt;font size=&apos;2&apos;&gt; (&lt;/font&gt;&lt;a href=&apos;#&apos;&gt;Node starten&lt;/a&gt;&lt;font size=&apos;2&apos;&gt;)&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="82"/>
+        <source>Ring size: %1</source>
+        <translation>Ringgrootte: %1</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="156"/>
+        <source>This page lets you sign/verify a message (or file contents) with your address.</source>
+        <translation>Op deze pagina kunt u een bericht (of de inhoud van een bestand) ondertekenen/verifiëren met uw adres.</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="227"/>
+        <source>Default</source>
+        <translation>Normaal</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="229"/>
+        <source>Normal (x1 fee)</source>
+        <translation>Normaal (vergoeding × 1)</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="257"/>
+        <source>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #858585; font-size: 14px;}&lt;/style&gt;                Address &lt;font size=&apos;2&apos;&gt;  ( &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</source>
+        <translation>&lt;style type=&apos;text/css&apos;&gt;a {text-decoration: none; color: #858585; font-size: 14px;}&lt;/style&gt;                Adres &lt;font size=&apos;2&apos;&gt;  ( &lt;/font&gt; &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;&lt;font size=&apos;2&apos;&gt; )&lt;/font&gt;</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="275"/>
         <source>No valid address found at this OpenAlias address</source>
         <translation>Geen geldig adres gevonden voor dit OpenAlias-adres</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="282"/>
+        <location filename="../pages/Transfer.qml" line="280"/>
         <source>Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed</source>
         <translation>Adres gevonden, maar de DNSSEC-handtekeningen kunnen niet geverifiëerd worden, dus het adres kan gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="284"/>
+        <location filename="../pages/Transfer.qml" line="282"/>
         <source>No valid address found at this OpenAlias address, but the DNSSEC signatures could not be verified, so this may be spoofed</source>
         <translation>Geen geldig adres gevonden onder het opgegeven OpenAlias-adres, en de DNSSEC-handtekeningen kunnen niet geverifiëerd worden, dus het adres kan gespoofed en dus ongeldig zijn</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="287"/>
-        <location filename="../pages/Transfer.qml" line="290"/>
+        <location filename="../pages/Transfer.qml" line="285"/>
+        <location filename="../pages/Transfer.qml" line="288"/>
         <source>Internal error</source>
         <translation>Interne fout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="293"/>
+        <location filename="../pages/Transfer.qml" line="291"/>
         <source>No address found</source>
         <translation>Geen adres gevonden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="312"/>
+        <location filename="../pages/Transfer.qml" line="323"/>
         <source>Description &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Omschrijving &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="318"/>
+        <location filename="../pages/Transfer.qml" line="324"/>
         <source>Saved to local wallet history</source>
         <translation>Wordt opgeslagen in de lokale portemonnee-geschiedenis</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="326"/>
+        <location filename="../pages/Transfer.qml" line="335"/>
         <source>Send</source>
         <translation>Verzenden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="391"/>
-        <source>Show advanced options</source>
-        <translation>Laat geavanceerde opties zien</translation>
+        <location filename="../pages/Transfer.qml" line="607"/>
+        <source>Monero sent successfully</source>
+        <translation>Monero is verzonden</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="669"/>
+        <location filename="../pages/Transfer.qml" line="661"/>
         <source>Connected daemon is not compatible with GUI. 
 Please upgrade or connect to another daemon</source>
         <translation>Verbonden node is niet compatibel met de GUI.
 Upgrade of maak verbinding met een andere node</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="454"/>
+        <location filename="../pages/Transfer.qml" line="477"/>
         <source>Sweep Unmixable</source>
         <translation>Onmengbare bedragen samenvoegen</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="468"/>
+        <location filename="../pages/Transfer.qml" line="488"/>
         <source>Create tx file</source>
         <translation>Maak TX-bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="164"/>
+        <location filename="../pages/Transfer.qml" line="193"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="490"/>
+        <location filename="../pages/Transfer.qml" line="418"/>
+        <source>Advanced options</source>
+        <translation>Geavanceerde opties</translation>
+    </message>
+    <message>
+        <location filename="../pages/Transfer.qml" line="507"/>
         <source>Sign tx file</source>
         <translation>Onderteken TX-bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="504"/>
+        <location filename="../pages/Transfer.qml" line="518"/>
         <source>Submit tx file</source>
         <translation>Verzend TX-bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="537"/>
-        <location filename="../pages/Transfer.qml" line="593"/>
+        <location filename="../pages/Transfer.qml" line="544"/>
+        <location filename="../pages/Transfer.qml" line="600"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="599"/>
+        <location filename="../pages/Transfer.qml" line="606"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="526"/>
-        <location filename="../pages/Transfer.qml" line="587"/>
+        <location filename="../pages/Transfer.qml" line="533"/>
+        <location filename="../pages/Transfer.qml" line="594"/>
         <source>Please choose a file</source>
         <translation>Kies een bestand</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="45"/>
-        <source>Start daemon</source>
-        <translation>Start node</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="220"/>
-        <source>Address</source>
-        <translation>Adres</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="222"/>
-        <source>Paste in or select from &lt;a href=&apos;#&apos;&gt;Address book&lt;/a&gt;</source>
-        <translation>Plak het adres of selecteer het in het &lt;a href=&apos;#&apos;&gt;Adresboek&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="538"/>
+        <location filename="../pages/Transfer.qml" line="545"/>
         <source>Can&apos;t load unsigned transaction: </source>
         <translation>Het laden van de niet-ondertekende transactie is mislukt: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="545"/>
+        <location filename="../pages/Transfer.qml" line="552"/>
         <source>
 Number of transactions: </source>
         <translation>
 Aantal transacties: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="547"/>
+        <location filename="../pages/Transfer.qml" line="554"/>
         <source>
 Transaction #%1</source>
         <translation>
 Transactie #%1</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="548"/>
+        <location filename="../pages/Transfer.qml" line="555"/>
         <source>
 Recipient: </source>
         <translation>
 Ontvanger: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="549"/>
+        <location filename="../pages/Transfer.qml" line="556"/>
         <source>
 payment ID: </source>
         <translation>
 betalings-ID: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="550"/>
+        <location filename="../pages/Transfer.qml" line="557"/>
         <source>
 Amount: </source>
         <translation>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="551"/>
+        <location filename="../pages/Transfer.qml" line="558"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="552"/>
+        <location filename="../pages/Transfer.qml" line="559"/>
         <source>
 Ringsize: </source>
         <translation>
 Ringgrootte: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="566"/>
+        <location filename="../pages/Transfer.qml" line="573"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="594"/>
+        <location filename="../pages/Transfer.qml" line="601"/>
         <source>Can&apos;t submit transaction: </source>
         <translation>Kan transactie niet insturen: </translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="600"/>
-        <source>Money sent successfully</source>
-        <translation>Het geld is verstuurd</translation>
-    </message>
-    <message>
-        <location filename="../pages/Transfer.qml" line="654"/>
-        <location filename="../pages/Transfer.qml" line="666"/>
+        <location filename="../pages/Transfer.qml" line="646"/>
+        <location filename="../pages/Transfer.qml" line="658"/>
         <source>Wallet is not connected to daemon.</source>
         <translation>Portemonnee is niet verbonden met de node.</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="674"/>
+        <location filename="../pages/Transfer.qml" line="666"/>
         <source>Waiting on daemon synchronization to finish</source>
         <translation>Wachten totdat de synchronisatie met de node compleet is</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="301"/>
+        <location filename="../pages/Transfer.qml" line="314"/>
         <source>Payment ID &lt;font size=&apos;2&apos;&gt;( Optional )&lt;/font&gt;</source>
         <translation>Betalings-ID &lt;font size=&apos;2&apos;&gt;(Optioneel)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../pages/Transfer.qml" line="307"/>
+        <location filename="../pages/Transfer.qml" line="315"/>
         <source>16 or 64 hexadecimal characters</source>
         <translation>16 of 64 hexadecimale tekens</translation>
     </message>
@@ -1754,79 +1898,97 @@ Ringgrootte: </translation>
 <context>
     <name>TxKey</name>
     <message>
-        <location filename="../pages/TxKey.qml" line="349"/>
+        <location filename="../pages/TxKey.qml" line="228"/>
         <source>If a payment had several transactions then each must be checked and the results combined.</source>
         <translation>Als een betaling meerdere transacties had, dan moet elk afzonderlijk gecontroleerd worden en het resultaat opgeteld worden.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="133"/>
-        <location filename="../pages/TxKey.qml" line="245"/>
+        <location filename="../pages/TxKey.qml" line="94"/>
+        <location filename="../pages/TxKey.qml" line="169"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="97"/>
+        <location filename="../pages/TxKey.qml" line="66"/>
+        <source>Prove Transaction</source>
+        <translation>Transactie bewijzen</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="70"/>
         <source>Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. 
 For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that proves the authorship of a transaction. In this case, you don&apos;t need to specify the recipient address.</source>
         <translation>Genereer een bewijs van uw ontvangen/uitgaande betaling door de transactie-ID, het adres van de ontvanger en een optioneel bericht op te geven. 
 Voor uitgaande betalingen ontvangt u een betalingsbewijs waarmee wordt bewezen wie de transactie heeft gecreëerd. In dat geval hoeft u het adres van de ontvanger niet op te geven.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="140"/>
-        <location filename="../pages/TxKey.qml" line="252"/>
+        <location filename="../pages/TxKey.qml" line="96"/>
+        <location filename="../pages/TxKey.qml" line="171"/>
         <source>Recipient&apos;s wallet address</source>
         <translation>Portemonnee-adres van de ontvanger</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="159"/>
-        <location filename="../pages/TxKey.qml" line="271"/>
+        <location filename="../pages/TxKey.qml" line="107"/>
+        <location filename="../pages/TxKey.qml" line="183"/>
         <source>Message</source>
         <translation>Bericht</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="166"/>
-        <location filename="../pages/TxKey.qml" line="278"/>
+        <location filename="../pages/TxKey.qml" line="108"/>
+        <location filename="../pages/TxKey.qml" line="184"/>
         <source>Optional message against which the signature is signed</source>
         <translation>Optioneel bericht dat wordt ondertekend</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="186"/>
+        <location filename="../pages/TxKey.qml" line="120"/>
         <source>Generate</source>
         <translation>Genereer</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="209"/>
+        <location filename="../pages/TxKey.qml" line="140"/>
+        <source>Check Transaction</source>
+        <translation>Transactie controleren</translation>
+    </message>
+    <message>
+        <location filename="../pages/TxKey.qml" line="144"/>
         <source>Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.
 For the case with Spend Proof, you don&apos;t need to specify the recipient address.</source>
         <translation>Verifieer dat het geld is betaald aan een adres door de transactie-ID, het adres van de ontvanger, het te ondertekenen bericht en de handtekening op te geven.
 Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="297"/>
+        <location filename="../pages/TxKey.qml" line="196"/>
         <source>Signature</source>
         <translation>Handtekening</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="305"/>
+        <location filename="../pages/TxKey.qml" line="197"/>
         <source>Paste tx proof</source>
         <translation>Plak transactiebewijs</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="106"/>
-        <location filename="../pages/TxKey.qml" line="218"/>
+        <location filename="../pages/TxKey.qml" line="81"/>
+        <location filename="../pages/TxKey.qml" line="156"/>
         <source>Transaction ID</source>
         <translation>Transactie-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="113"/>
-        <location filename="../pages/TxKey.qml" line="225"/>
+        <location filename="../pages/TxKey.qml" line="84"/>
+        <location filename="../pages/TxKey.qml" line="158"/>
         <source>Paste tx ID</source>
         <translation>Plak een transactie-ID</translation>
     </message>
     <message>
-        <location filename="../pages/TxKey.qml" line="326"/>
+        <location filename="../pages/TxKey.qml" line="209"/>
         <source>Check</source>
         <translation>Controleren</translation>
+    </message>
+</context>
+<context>
+    <name>WalletManager</name>
+    <message>
+        <location filename="../src/libwalletqt/WalletManager.cpp" line="153"/>
+        <source>Unknown error</source>
+        <translation>Onbekende fout</translation>
     </message>
 </context>
 <context>
@@ -1842,27 +2004,27 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
         <translation>De Monero-blockchain starten?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="115"/>
+        <location filename="../wizard/WizardConfigure.qml" line="113"/>
         <source>It is very important to write it down as this is the only backup you will need for your wallet.</source>
         <translation>Het is erg belangrijk om dit op te schrijven, want dit is de enige back-up die u nodig heeft voor uw portemonnee.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="126"/>
+        <location filename="../wizard/WizardConfigure.qml" line="124"/>
         <source>Enable disk conservation mode?</source>
         <translation>Activeer modus voor schijfbehoud?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="144"/>
+        <location filename="../wizard/WizardConfigure.qml" line="140"/>
         <source>Disk conservation mode uses substantially less disk-space, but the same amount of bandwidth as a regular Monero instance. However, storing the full blockchain is beneficial to the security of the Monero network. If you are on a device with limited disk space, then this option is appropriate for you.</source>
         <translation>De modus voor schijfbehoud gebruikt substantieel minder schijfruimte, maar dezelfde hoeveelheid bandbreedte als een gewone Monero-installatie. Het volledig opslaan van de Monero-blockchain is echter beter voor de beveiliging van het Monero-netwerk. Deze optie is geschikt als u een apparaat gebruikt met beperkte schijfruimte.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="157"/>
+        <location filename="../wizard/WizardConfigure.qml" line="153"/>
         <source>Allow background mining?</source>
         <translation>Minen op de achtergrond toestaan?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardConfigure.qml" line="175"/>
+        <location filename="../wizard/WizardConfigure.qml" line="169"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
         <translation>Minen beveiligt het Monero-netwerk en u ontvangt ook een kleine beloning voor het verrichte werk. Deze optie laat Monero minen als uw computer op netstroom is aangesloten en niets aan het doen is. Het stopt met minen als u weer gebruikt maakt van uw computer.</translation>
     </message>
@@ -1897,22 +2059,22 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
         <translation>Automatisch een node starten op de achtergrond (aanbevolen)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDaemonSettings.qml" line="144"/>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="148"/>
         <source>Blockchain location</source>
         <translation>Locatie van blockchain</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDaemonSettings.qml" line="151"/>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="159"/>
         <source>(optional)</source>
         <translation>(optioneel)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDaemonSettings.qml" line="170"/>
-        <source>Connect to a remote node until my own node has finished syncing</source>
-        <translation>Verbinding maken met een externe node totdat mijn eigen node is gesynchroniseerd</translation>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="183"/>
+        <source>Bootstrap node (leave blank if not wanted)</source>
+        <translation>Externe node (leeg laten als u die niet gebruikt)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDaemonSettings.qml" line="171"/>
+        <location filename="../wizard/WizardDaemonSettings.qml" line="210"/>
         <source>Connect to a remote node</source>
         <translation>Verbinding maken met een externe node</translation>
     </message>
@@ -1930,22 +2092,22 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
         <translation>Automatisch doneren activeren?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDonation.qml" line="153"/>
+        <location filename="../wizard/WizardDonation.qml" line="151"/>
         <source>% of my fee added to each transaction</source>
         <translation>% van mijn vergoeding dat wordt toegevoegd aan iedere transactie</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDonation.qml" line="164"/>
+        <location filename="../wizard/WizardDonation.qml" line="162"/>
         <source>For every transaction, a small transaction fee is charged. This option lets you add an additional amount, as a percentage of that fee, to your transaction to support Monero development. For instance, a 50% autodonation take a transaction fee of 0.005 XMR and add a 0.0025 XMR to support Monero development.</source>
         <translation>Voor elke transactie betaalt u een kleine vergoeding. Met deze optie voegt u een extra bedrag (als percentage van die vergoeding) aan uw transactie toe om de ontwikkeling van Monero te ondersteunen. Bijvoorbeeld, een automatische donatie van 50% neemt een transactievergoeding van 0.005 XMR en voegt 0.0025 XMR toe om de ontwikkeling van Monero te ondersteunen.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDonation.qml" line="176"/>
+        <location filename="../wizard/WizardDonation.qml" line="174"/>
         <source>Allow background mining?</source>
         <translation>Minen in de achtergrond toestaan?</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardDonation.qml" line="194"/>
+        <location filename="../wizard/WizardDonation.qml" line="190"/>
         <source>Mining secures the Monero network, and also pays a small reward for the work done. This option will let Monero mine when your computer is on mains power and is idle. It will stop mining when you continue working.</source>
         <translation>Minen beveiligt het Monero-netwerk en u ontvangt ook een kleine beloning voor het verrichte werk. Deze optie laat Monero minen als uw computer op netstroom is aangesloten en niets aan het doen is. Het stopt met minen als u weer gebruikt maakt van uw computer.</translation>
     </message>
@@ -1953,66 +2115,79 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
 <context>
     <name>WizardFinish</name>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="49"/>
-        <location filename="../wizard/WizardFinish.qml" line="52"/>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="53"/>
         <source>Enabled</source>
         <translation>Ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="49"/>
-        <location filename="../wizard/WizardFinish.qml" line="52"/>
-        <location filename="../wizard/WizardFinish.qml" line="54"/>
+        <location filename="../wizard/WizardFinish.qml" line="50"/>
+        <location filename="../wizard/WizardFinish.qml" line="53"/>
         <source>Disabled</source>
         <translation>Uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="58"/>
+        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <source>Stagenet</source>
+        <translation>Stagenet</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="55"/>
+        <source>Mainnet</source>
+        <translation>Hoofdnet</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="59"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="59"/>
+        <location filename="../wizard/WizardFinish.qml" line="60"/>
         <source>Wallet name</source>
         <translation>Naam van portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="60"/>
+        <location filename="../wizard/WizardFinish.qml" line="63"/>
         <source>Backup seed</source>
         <translation>Hersteltekst</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="61"/>
+        <location filename="../wizard/WizardFinish.qml" line="64"/>
         <source>Wallet path</source>
         <translation>Locatie van portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="67"/>
+        <location filename="../wizard/WizardFinish.qml" line="70"/>
         <source>Daemon address</source>
         <translation>Node-adres</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="68"/>
+        <location filename="../wizard/WizardFinish.qml" line="55"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="70"/>
+        <location filename="../wizard/WizardFinish.qml" line="71"/>
+        <source>Network Type</source>
+        <translation>Soort netwerk</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardFinish.qml" line="73"/>
         <source>Restore height</source>
         <translation>Herstelpunt (blokhoogte)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="78"/>
+        <location filename="../wizard/WizardFinish.qml" line="81"/>
         <source>New wallet details:</source>
         <translation>Gegevens nieuwe portemonnee:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="82"/>
+        <location filename="../wizard/WizardFinish.qml" line="85"/>
         <source>Don&apos;t forget to write down your seed. You can view your seed and change your settings on settings page.</source>
         <translation>Vergeet uw hersteltekst niet op te schrijven. U kunt uw hersteltekst bekijken en instellingen aanpassen op de pagina Instellingen.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardFinish.qml" line="128"/>
+        <location filename="../wizard/WizardFinish.qml" line="131"/>
         <source>You’re all set up!</source>
         <translation>U bent klaar met configureren!</translation>
     </message>
@@ -2025,27 +2200,22 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
         <translation>Er bestaat al een portemonnee met dezelfde naam. Verander de naam van uw portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="191"/>
-        <source>Non-ASCII characters are not allowed in wallet path or account name</source>
-        <translation>Niet-ASCII karakters zijn niet toegestaan in het portemonnee-pad of de portemonnee-naam</translation>
-    </message>
-    <message>
-        <location filename="../wizard/WizardMain.qml" line="375"/>
+        <location filename="../wizard/WizardMain.qml" line="367"/>
         <source>USE MONERO</source>
         <translation>GEBRUIK MONERO</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="392"/>
+        <location filename="../wizard/WizardMain.qml" line="380"/>
         <source>Create wallet</source>
         <translation>Portemonnee maken</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="402"/>
+        <location filename="../wizard/WizardMain.qml" line="386"/>
         <source>Success</source>
         <translation>Geslaagd</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="403"/>
+        <location filename="../wizard/WizardMain.qml" line="387"/>
         <source>The view only wallet has been created. You can open it by closing this current wallet, clicking the &quot;Open wallet from file&quot; option, and selecting the view wallet in: 
 %1</source>
         <translatorcomment>The exact option text is: Open a wallet from file</translatorcomment>
@@ -2053,12 +2223,12 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
 %1</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="411"/>
+        <location filename="../wizard/WizardMain.qml" line="395"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMain.qml" line="424"/>
+        <location filename="../wizard/WizardMain.qml" line="408"/>
         <source>Abort</source>
         <translation>Afbreken</translation>
     </message>
@@ -2066,52 +2236,52 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
 <context>
     <name>WizardManageWalletUI</name>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="158"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="160"/>
         <source>Wallet name</source>
         <translation>Naam van portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="178"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="184"/>
         <source>Restore from seed</source>
         <translation>Herstel met hersteltekst</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="192"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="194"/>
         <source>Restore from keys</source>
         <translation>Herstel met sleutels</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="206"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="204"/>
         <source>From QR Code</source>
         <translation>Met QR-code</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="245"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="242"/>
         <source>Account address (public)</source>
         <translation>Adres van portemonnee (openbaar)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="253"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="258"/>
         <source>View key (private)</source>
         <translation>Aleen-lezen sleutel (privé)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="262"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="275"/>
         <source>Spend key (private)</source>
         <translation>Bestedingssleutel (privé)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="274"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="295"/>
         <source>Restore height (optional)</source>
         <translation>Herstelpunt (optioneel)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="287"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="315"/>
         <source>Your wallet is stored in</source>
         <translation>Uw portemonnee is opgeslagen in</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardManageWalletUI.qml" line="313"/>
+        <location filename="../wizard/WizardManageWalletUI.qml" line="345"/>
         <source>Please choose a directory</source>
         <translation>Kies een locatie</translation>
     </message>
@@ -2119,17 +2289,17 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
 <context>
     <name>WizardMemoTextInput</name>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="44"/>
-        <source>Enter your 25 word mnemonic seed</source>
-        <translation>Vul uw hersteltekst van 25 woorden in</translation>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="45"/>
+        <source>Enter your 25 (or 24) word mnemonic seed</source>
+        <translation>Voer uw hersteltekst van 25 (of 24) woorden in</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="64"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="65"/>
         <source>Seed copied to clipboard</source>
         <translation>Hersteltekst gekopieerd naar klembord</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardMemoTextInput.qml" line="92"/>
+        <location filename="../wizard/WizardMemoTextInput.qml" line="93"/>
         <source>This seed is &lt;b&gt;very&lt;/b&gt; important to write down and keep secret. It is all you need to backup and restore your wallet.</source>
         <translation>Deze hersteltekst is &lt;b&gt;zeer&lt;/b&gt; belangrijk om veilig op te slaan en privé te houden. Het is het enige dat u nodig heeft om een back-up van uw portemonnee te maken of uw portemonnee te herstellen.</translation>
     </message>
@@ -2137,34 +2307,39 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
 <context>
     <name>WizardOptions</name>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="74"/>
+        <location filename="../wizard/WizardOptions.qml" line="75"/>
         <source>Welcome to Monero!</source>
         <translation>Welkom bij Monero!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="85"/>
+        <location filename="../wizard/WizardOptions.qml" line="86"/>
         <source>Please select one of the following options:</source>
         <translation>Selecteer een van de volgende opties:</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="141"/>
+        <location filename="../wizard/WizardOptions.qml" line="142"/>
         <source>Create a new wallet</source>
         <translation>Maak een nieuwe portemonnee aan</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="182"/>
+        <location filename="../wizard/WizardOptions.qml" line="183"/>
         <source>Restore wallet from keys or mnemonic seed</source>
         <translation>Herstel een portemonnee met behulp van uw hersteltekst of sleutels</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="225"/>
+        <location filename="../wizard/WizardOptions.qml" line="226"/>
         <source>Open a wallet from file</source>
         <translation>Open een portemonnee vanaf een bestand</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardOptions.qml" line="245"/>
+        <location filename="../wizard/WizardOptions.qml" line="247"/>
         <source>Testnet</source>
         <translation>Testnet</translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardOptions.qml" line="266"/>
+        <source>Stagenet</source>
+        <translation>Stagenet</translation>
     </message>
 </context>
 <context>
@@ -2220,48 +2395,75 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="352"/>
-        <location filename="../main.qml" line="561"/>
-        <location filename="../main.qml" line="573"/>
-        <location filename="../main.qml" line="623"/>
-        <location filename="../main.qml" line="635"/>
-        <location filename="../main.qml" line="677"/>
-        <location filename="../main.qml" line="686"/>
-        <location filename="../main.qml" line="738"/>
-        <location filename="../main.qml" line="836"/>
-        <location filename="../main.qml" line="1032"/>
-        <location filename="../main.qml" line="1177"/>
-        <location filename="../main.qml" line="1280"/>
+        <location filename="../main.qml" line="283"/>
+        <location filename="../main.qml" line="386"/>
+        <location filename="../main.qml" line="590"/>
+        <location filename="../main.qml" line="602"/>
+        <location filename="../main.qml" line="658"/>
+        <location filename="../main.qml" line="670"/>
+        <location filename="../main.qml" line="712"/>
+        <location filename="../main.qml" line="721"/>
+        <location filename="../main.qml" line="773"/>
+        <location filename="../main.qml" line="871"/>
+        <location filename="../main.qml" line="1073"/>
+        <location filename="../main.qml" line="1218"/>
+        <location filename="../main.qml" line="1420"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="353"/>
+        <location filename="../main.qml" line="284"/>
+        <location filename="../main.qml" line="387"/>
         <source>Couldn&apos;t open wallet: </source>
         <translation>Portemonnee kan niet geopend worden: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="563"/>
+        <location filename="../main.qml" line="456"/>
+        <source>Waiting for daemon to sync</source>
+        <translation>Wachten tot node is gesynchroniseerd</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="458"/>
+        <source>Daemon is synchronized (%1)</source>
+        <translation>Node is gesynchroniseerd (%1)</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="460"/>
+        <source>Wallet is synchronized</source>
+        <translation>Portemonnee is gesynchroniseerd</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="546"/>
+        <source>Daemon is synchronized</source>
+        <translation>Node is gesynchroniseerd</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="592"/>
         <source>Can&apos;t create transaction: Wrong daemon version: </source>
         <translation>Transactie kan niet worden aangemaakt: Verkeerde node-versie: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="574"/>
-        <location filename="../main.qml" line="687"/>
+        <location filename="../main.qml" line="603"/>
+        <location filename="../main.qml" line="722"/>
         <source>No unmixable outputs to sweep</source>
         <translation>Geen onmengbare bedragen gevonden om samen te voegen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="587"/>
-        <location filename="../main.qml" line="700"/>
+        <location filename="../main.qml" line="614"/>
+        <location filename="../main.qml" line="735"/>
         <source>Please confirm transaction:
 </source>
         <translation>Bevestig de transactie:
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="590"/>
-        <location filename="../main.qml" line="701"/>
+        <location filename="../main.qml" line="616"/>
+        <source>Address: </source>
+        <translation>Adres: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="618"/>
+        <location filename="../main.qml" line="736"/>
         <source>
 
 Amount: </source>
@@ -2270,283 +2472,285 @@ Amount: </source>
 Bedrag: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="593"/>
-        <source>
-Number of transactions: </source>
-        <translation>
-Aantal transacties: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="594"/>
-        <source>
-
-Description: </source>
-        <translation>
-
-Omschrijving: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="624"/>
+        <location filename="../main.qml" line="659"/>
         <source>Amount is wrong: expected number from %1 to %2</source>
         <translation>Verkeerd bedrag: bedrag tussen %1 en %2 verwacht</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="748"/>
-        <source>Money sent successfully: %1 transaction(s) </source>
-        <translation>Het geld is verzonden: %1 transactie(s) </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="819"/>
+        <location filename="../main.qml" line="854"/>
         <source>This address received %1 monero, but the transaction is not yet mined</source>
         <translation>Dit adres heeft %1 monero ontvangen, maar de transactie is nog niet verwerkt</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="826"/>
+        <location filename="../main.qml" line="861"/>
         <source>This address received nothing</source>
         <translation>Dit adres heeft niets ontvangen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="565"/>
-        <location filename="../main.qml" line="678"/>
+        <location filename="../main.qml" line="594"/>
+        <location filename="../main.qml" line="713"/>
         <source>Can&apos;t create transaction: </source>
         <translation>Transactie kan niet worden aangemaakt: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="313"/>
-        <location filename="../main.qml" line="314"/>
+        <location filename="../main.qml" line="348"/>
+        <location filename="../main.qml" line="349"/>
         <source>HIDDEN</source>
         <translation>VERBORGEN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="416"/>
         <source>Unlocked balance (waiting for block)</source>
-        <translation>Beschikbaar saldo (wachten op blok)</translation>
+        <translatorcomment>&quot;Beschikbaar saldo (wachten op blok)&quot; is too long for the box. </translatorcomment>
+        <translation>Beschikbaar (wachten op blok)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="416"/>
         <source>Unlocked balance (~%1 min)</source>
         <translation>Beschikbaar saldo (~%1 min)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="382"/>
+        <location filename="../main.qml" line="416"/>
         <source>Unlocked balance</source>
         <translation>Beschikbaar saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="435"/>
-        <source>Remaining blocks (local node):</source>
-        <translation>Resterende blokken (lokale node):</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="498"/>
         <source>Waiting for daemon to start...</source>
         <translation>Wachten tot de node gestart is...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="481"/>
+        <location filename="../main.qml" line="504"/>
         <source>Waiting for daemon to stop...</source>
         <translation>Wachten tot de node gestopt is...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="506"/>
+        <location filename="../main.qml" line="529"/>
         <source>Daemon failed to start</source>
         <translation>Het starten van de node is mislukt</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="507"/>
+        <location filename="../main.qml" line="530"/>
         <source>Please check your wallet and daemon log for errors. You can also try to start %1 manually.</source>
         <translation>Controleer de logs van uw portemonnee en node op fouten. Of probeer %1 handmatig te starten.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="586"/>
-        <location filename="../main.qml" line="699"/>
+        <location filename="../main.qml" line="620"/>
+        <source>
+Ringsize: </source>
+        <translation>
+Ringgrootte: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="622"/>
+        <source>
+
+WARNING: non default ring size, which may harm your privacy. Default of 7 is recommended.</source>
+        <translation>
+
+WAARSCHUWING: ringgroote is niet standaard. Dit kan schadelijk zijn voor uw privacy. De standaardwaarde 7 wordt aangeraden.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="624"/>
+        <source>
+
+Number of transactions: </source>
+        <translation>
+
+Aantal transacties: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="625"/>
+        <source>
+Description: </source>
+        <translation>
+Omschrijving: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="627"/>
+        <source>
+Spending address index: </source>
+        <translation>
+Index van betalend adres: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="734"/>
         <source>Confirmation</source>
         <translation>Bevestiging</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="588"/>
-        <source>
-Address: </source>
-        <translation>
-Adres: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="589"/>
+        <location filename="../main.qml" line="617"/>
         <source>
 Payment ID: </source>
         <translation>
 Betalings-ID: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="591"/>
-        <location filename="../main.qml" line="702"/>
+        <location filename="../main.qml" line="619"/>
+        <location filename="../main.qml" line="737"/>
         <source>
 Fee: </source>
         <translation>
 Vergoeding: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="592"/>
-        <source>
-
-Ringsize: </source>
-        <translation>
-
-Ringgrootte: </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="636"/>
+        <location filename="../main.qml" line="671"/>
         <source>Insufficient funds. Unlocked balance: %1</source>
         <translation>Onvoldoende geld. Beschikbaar saldo: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="739"/>
+        <location filename="../main.qml" line="774"/>
         <source>Couldn&apos;t send the money: </source>
         <translation>Het geld kan niet worden verstuurd: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="742"/>
-        <location filename="../main.qml" line="1173"/>
+        <location filename="../main.qml" line="777"/>
+        <location filename="../main.qml" line="1214"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="748"/>
+        <location filename="../main.qml" line="783"/>
         <source>Transaction saved to file: %1</source>
         <translation>Transactie opgeslagen in bestand: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="778"/>
+        <location filename="../main.qml" line="783"/>
+        <source>Monero sent successfully: %1 transaction(s) </source>
+        <translation>Monero is verzonden: %1 transactie(s) </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="813"/>
         <source>Payment proof</source>
         <translation>Betalingsbewijs</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="781"/>
+        <location filename="../main.qml" line="816"/>
         <source>Couldn&apos;t generate a proof because of the following reason: 
 </source>
         <translation>Bewijs kan niet worden gegenereerd om de volgende reden: 
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="811"/>
-        <location filename="../main.qml" line="831"/>
+        <location filename="../main.qml" line="846"/>
+        <location filename="../main.qml" line="866"/>
         <source>Payment proof check</source>
         <translation>Controle betalingsbewijs</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="814"/>
-        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="849"/>
+        <location filename="../main.qml" line="868"/>
         <source>Bad signature</source>
         <translation>Ongeldige handtekening</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="822"/>
+        <location filename="../main.qml" line="857"/>
         <source>This address received %1 monero, with %2 confirmation(s).</source>
         <translation>Dit adres heeft %1 monero ontvangen, met %2 bevestiging(en).</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="868"/>
         <source>Good signature</source>
         <translation>Geldige handtekening</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="845"/>
+        <location filename="../main.qml" line="880"/>
         <source>Balance (syncing)</source>
         <translation>Saldo (synchroniseren)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="845"/>
+        <location filename="../main.qml" line="880"/>
         <source>Balance</source>
         <translation>Saldo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1033"/>
-        <location filename="../main.qml" line="1281"/>
+        <location filename="../main.qml" line="1074"/>
+        <location filename="../main.qml" line="1421"/>
         <source>Wrong password</source>
         <translation>Verkeerd wachtwoord</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1108"/>
+        <location filename="../main.qml" line="1149"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1111"/>
+        <location filename="../main.qml" line="1152"/>
         <source>Error: Filesystem is read only</source>
         <translation>Fout: bestandssysteem is alleen-lezen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1113"/>
+        <location filename="../main.qml" line="1154"/>
         <source>Warning: There&apos;s only %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Waarschuwing: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1115"/>
+        <location filename="../main.qml" line="1156"/>
         <source>Note: There&apos;s %1 GB available on the device. Blockchain requires ~%2 GB of data.</source>
         <translation>Let op: er is slechts %1 GB beschikbaar op dit apparaat. Voor de blockchain is ~%2 GB opslagruimte nodig.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1117"/>
+        <location filename="../main.qml" line="1158"/>
         <source>Note: lmdb folder not found. A new folder will be created.</source>
         <translation>LMDB-map niet gevonden. Er wordt een nieuwe map gemaakt.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1121"/>
+        <location filename="../main.qml" line="1162"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1174"/>
+        <location filename="../main.qml" line="1215"/>
         <source>Password changed successfully</source>
         <translation>Wachtwoord is gewijzigd</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1178"/>
+        <location filename="../main.qml" line="1219"/>
         <source>Error: </source>
         <translation>Fout: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1203"/>
+        <location filename="../main.qml" line="1261"/>
         <source>Please wait...</source>
         <translation>Even geduld alstublieft...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1227"/>
+        <location filename="../main.qml" line="1285"/>
         <source>Program setup wizard</source>
         <translation>Installatie-assistent</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1243"/>
+        <location filename="../main.qml" line="1301"/>
         <source>Monero</source>
         <translation>Monero</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1317"/>
+        <location filename="../main.qml" line="1457"/>
         <source>send to the same destination</source>
         <translation>naar hetzelfde adres verzenden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1599"/>
+        <location filename="../main.qml" line="1748"/>
         <source>Tap again to close...</source>
         <translation>Tik nogmaals om te sluiten...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1612"/>
+        <location filename="../main.qml" line="1761"/>
         <source>Daemon is running</source>
         <translation>Node is gestart</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1613"/>
+        <location filename="../main.qml" line="1762"/>
         <source>Daemon will still be running in background when GUI is closed.</source>
         <translation>Node wordt nog steeds op de achtergrond uitgevoerd nadat de GUI gesloten wordt.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1615"/>
+        <location filename="../main.qml" line="1764"/>
         <source>Stop daemon</source>
         <translation>Stop node</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1650"/>
+        <location filename="../main.qml" line="1799"/>
         <source>New version of monero-wallet-gui is available: %1&lt;br&gt;%2</source>
         <translation>Nieuwe versie van monero-wallet-gui is beschikbaar: %1&lt;br&gt;%2</translation>
     </message>


### PR DESCRIPTION
This is the Dutch translation of strings added shortly before and after the upgrade in April.

Line numbers are different because the source text used is from a version refreshed by @erciccione: https://github.com/erciccione/monero-core/tree/nl-updated/translations

There was a warning (not an error) in QT Linguist because of duplicate messages. I tracked this down to what's currently line 110 in pages/SharedRingDB.qml, where there are two qsTr strings on one line, while the line number is used to identify them:

```
            text: "<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 14px;}</style>" +
                  qsTr("Blackballed outputs") + " <a href='#'>" + qsTr("Help") + "</a>" + translationManager.emptyString
```
