### PR TITLE
warning label in mining page when daemon is not fully syncd

### DIFF
--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -68,6 +68,14 @@ Rectangle {
                 text: qsTr("(only available for local daemons)")
                 visible: !walletManager.isDaemonLocal(appWindow.currentDaemonAddress)
             }
+            
+            Label {
+                id: soloSyncedLabel
+                fontSize: 18
+                color: "#D02020"
+                text: qsTr("Your daemon must be synchronized before you can start mining")
+                visible: walletManager.isDaemonLocal(appWindow.currentDaemonAddress) && !appWindow.daemonSynced
+            }
 
             Text {
                 id: soloMainLabel


### PR DESCRIPTION
I think most people know that your node needs to be fully sync'd before you can start mining but if somebody new doesn't know that then they would probably be confused when they open the wallet and try to start mining but just get a non-descript "Error starting mining" message. This PR adds a red label similiar to the "only avaliable for local daemons" label that will be displayed if the wallet is connected to a local daemon but it is not completely sync'd with the network