### PR TITLE
[shortcuts]: ctrl+tab switches pages forward | ctrl+shift+tab switch pages backward (same order as leftpanel)

### DIFF
--- a/filter.cpp
+++ b/filter.cpp
@@ -34,13 +34,20 @@ filter::filter(QObject *parent) :
     QObject(parent)
 {
     m_tabPressed = false;
+    m_backtabPressed = false;
 }
 
 bool filter::eventFilter(QObject *obj, QEvent *ev) {
     switch(ev->type()) {
     case QEvent::KeyPress: {
         QKeyEvent *ke = static_cast<QKeyEvent*>(ev);
-        if(ke->key() == Qt::Key_Tab || ke->key() == Qt::Key_Backtab) {
+        if(ke->key() == Qt::Key_Backtab) {
+            if(m_backtabPressed)
+                break;
+            else m_backtabPressed = true;
+        }
+
+        if(ke->key() == Qt::Key_Tab) {
             if(m_tabPressed)
                 break;
             else m_tabPressed = true;
@@ -58,7 +65,7 @@ bool filter::eventFilter(QObject *obj, QEvent *ev) {
             sks = ks.toString();
         }
 #ifndef Q_OS_MAC
-        if(sks.contains("Alt+Tab") || sks.contains("Alt+Shift+Backtab"))
+        if(sks.contains("Alt+Tab") || sks.contains("Alt+Backtab"))
             break;
 #else
         sks.replace("Meta", "Ctrl");
@@ -67,7 +74,11 @@ bool filter::eventFilter(QObject *obj, QEvent *ev) {
     } break;
     case QEvent::KeyRelease: {
         QKeyEvent *ke = static_cast<QKeyEvent*>(ev);
-        if(ke->key() == Qt::Key_Tab || ke->key() == Qt::Key_Backtab)
+
+        if(ke->key() == Qt::Key_Backtab)
+            m_backtabPressed = false;
+
+        if(ke->key() == Qt::Key_Tab)
             m_tabPressed = false;
 
         QString sks;
@@ -88,7 +99,7 @@ bool filter::eventFilter(QObject *obj, QEvent *ev) {
             sks = ks.toString();
         }
 #ifndef Q_OS_MAC
-        if(sks.contains("Alt+Tab") || sks.contains("Alt+Shift+Backtab"))
+        if(sks.contains("Alt+Tab") || sks.contains("Alt+Backtab"))
             break;
 #else
         sks.replace("Meta", "Ctrl");

--- a/filter.h
+++ b/filter.h
@@ -36,7 +36,7 @@ class filter : public QObject
     Q_OBJECT
 private:
     bool m_tabPressed;
-
+    bool m_backtabPressed;
 public:
     explicit filter(QObject *parent = 0);
 

--- a/main.qml
+++ b/main.qml
@@ -146,12 +146,13 @@ ApplicationWindow {
             else if(middlePanel.state === "Transfer") middlePanel.state = "Dashboard"
             */
             if(middlePanel.state === "Settings") middlePanel.state = "Sign"
-            else if(middlePanel.state === "Sign") middlePanel.state = "AddressBook"
-            else if(middlePanel.state === "AddressBook") middlePanel.state = "History"
-            else if(middlePanel.state === "History") middlePanel.state = "SharedRingDB"
+            else if(middlePanel.state === "Sign") middlePanel.state = "SharedRingDB"
             else if(middlePanel.state === "SharedRingDB") middlePanel.state = "TxKey"
-            else if(middlePanel.state === "TxKey") middlePanel.state = "Receive"
-            else if(middlePanel.state === "Receive") middlePanel.state = "Transfer"
+            else if(middlePanel.state === "TxKey") middlePanel.state = "Mining"
+            else if(middlePanel.state === "Mining") middlePanel.state = "History"
+            else if(middlePanel.state === "History") middlePanel.state = "Receive"
+            else if(middlePanel.state === "Receive") middlePanel.state = "AddressBook"
+            else if(middlePanel.state === "AddressBook") middlePanel.state = "Transfer"
             else if(middlePanel.state === "Transfer") middlePanel.state = "Settings"
         }
 

--- a/main.qml
+++ b/main.qml
@@ -124,12 +124,13 @@ ApplicationWindow {
             else if(middlePanel.state === "Settings") middlePanel.state = "Dashboard"
             */
             if(middlePanel.state === "Settings") middlePanel.state = "Transfer"
-            else if(middlePanel.state === "Transfer") middlePanel.state = "Receive"
-            else if(middlePanel.state === "Receive") middlePanel.state = "TxKey"
+            else if(middlePanel.state === "Transfer") middlePanel.state = "AddressBook"
+            else if(middlePanel.state === "AddressBook") middlePanel.state = "Receive"
+            else if(middlePanel.state === "Receive") middlePanel.state = "History"
+            else if(middlePanel.state === "History") middlePanel.state = "Mining"
+            else if(middlePanel.state === "Mining") middlePanel.state = "TxKey"
             else if(middlePanel.state === "TxKey") middlePanel.state = "SharedRingDB"
-            else if(middlePanel.state === "SharedRingDB") middlePanel.state = "History"
-            else if(middlePanel.state === "History") middlePanel.state = "AddressBook"
-            else if(middlePanel.state === "AddressBook") middlePanel.state = "Sign"
+            else if(middlePanel.state === "SharedRingDB") middlePanel.state = "Sign"
             else if(middlePanel.state === "Sign") middlePanel.state = "Settings"
         } else if(seq === "Ctrl+Shift+Backtab" || seq === "Alt+Shift+Backtab") {
             /*


### PR DESCRIPTION
1. Fix ctrl+tab behaviour:

ctrl+tab behaviour is switching between pages in certain order:
`transfer->receive->txKey->sharedRingDB->history->addressBook->sign->settings`

This looks random on the gui because how those pages are placed in leftpanel menu.
I changed 'ctrl+tab behaviour to switch pages in this order: 
`transfer->addressbook->receive->history->mining->txkey->sharedRingDB->sign->settings`

I added mining page to the switchable pages but leave the keys page out because it asks for a password and somewhat breaks the workflow.

2. Fix ctrl+shift+tab behaviour (ctrl+tab reverse order)
