### PR TITLE
filter qr code amount

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -57,7 +57,7 @@ Rectangle {
         var nfields = 0
         s += current_address;
         var amount = amountToReceiveLine.text.trim()
-        if (amount !== "") {
+        if (amount !== "" && amount.slice(-1) !== ".") {
           s += (nfields++ ? "&" : "?")
           s += "tx_amount=" + amount
         }
@@ -456,12 +456,8 @@ Rectangle {
                         placeholderText: qsTr("Amount to receive") + translationManager.emptyString
                         fontBold: true
                         inlineIcon: true
-                        validator: DoubleValidator {
-                            bottom: 0.0
-                            top: 18446744.073709551615
-                            decimals: 12
-                            notation: DoubleValidator.StandardNotation
-                            locale: "C"
+                        validator: RegExpValidator {
+                            regExp: /(\d{1,8})([.]\d{1,12})?$/
                         }
                     }
                 }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -193,12 +193,8 @@ Rectangle {
                       inlineButtonText: qsTr("All") + translationManager.emptyString
                       inlineButton.onClicked: amountLine.text = "(all)"
 
-                      validator: DoubleValidator {
-                          bottom: 0.0
-                          top: 18446744.073709551615
-                          decimals: 12
-                          notation: DoubleValidator.StandardNotation
-                          locale: "C"
+                      validator: RegExpValidator {
+                          regExp: /(\d{1,8})([.]\d{1,12})?$/
                       }
                   }
               }


### PR DESCRIPTION
Commas in the amount supplied by the user (eg 1,000.02) will produce an invalid uri which results in a QR code that can not be properly parsed. To fix that this PR introduces a regex filter before the amount is added to the uri used by the QR code. (eg the user gives 1,000.02 but it will go in the uri as 1000.02 to avoid an invalid uri)