### PR TITLE
[osx]: fix typo in Info.plist & replace toolbar app name

### DIFF
--- a/share/Info.plist
+++ b/share/Info.plist
@@ -19,6 +19,9 @@
 
   <key>CFBundleExecutable</key>
   <string>monero-wallet-gui</string>
+  
+  <key>CFBundleName</key>
+  <string>Monero GUI</string>
 
   <key>CFBundleIdentifier</key>
   <string>org.monero-project.monero-wallet-gui</string>

--- a/share/Info.plist
+++ b/share/Info.plist
@@ -26,4 +26,4 @@
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
 </dict>
-</plist
+</plist>


### PR DESCRIPTION
fixes a typo that makes the file invalid and replaces the toolbar app name (monero-wallet-gui => Monero GUI)