### PR TITLE
Fixed wrong argument for retrieving mixins

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -571,7 +571,7 @@ Rectangle {
                     + (transaction.paymentId[i] == "" ? "" : qsTr("\n\payment ID: ") + transaction.paymentId[i])
                     + qsTr("\nAmount: ") + walletManager.displayAmount(transaction.amount(i))
                     + qsTr("\nFee: ") + walletManager.displayAmount(transaction.fee(i))
-                    + qsTr("\nRingsize: ") + transaction.mixin(i+1)
+                    + qsTr("\nRingsize: ") + (transaction.mixin(i)+1)
 
                     // TODO: add descriptions to unsigned_tx_set?
     //              + (transactionDescription === "" ? "" : (qsTr("\n\nDescription: ") + transactionDescription))


### PR DESCRIPTION
In [Transfer.qml](https://github.com/monero-project/monero-gui/blob/b56074bef1b789ca258cb3bacaad2693be2c3e2d/pages/Transfer.qml#L574) there's `transaction.mixin(i+1)`. Unfortunately the mixin function treats the argument as index (as you can see in [UnsignedTransaction.cpp](https://github.com/monero-project/monero-gui/blob/98ca4f1a70051447c39d5f9161db2e1741fdceb9/src/libwalletqt/UnsignedTransaction.cpp#L31)).
So `i+1` is getting the `i+1`-th mixin (which doesn't exist) instead of getting `i`-th and adding 1 to it (because ringsize=mixins+1).

## How to reproduce this
1. Create a view only wallet.
2. Create a tx file (in `Send` tab).
3. Open a spendable wallet.
4. Sign the tx file (in `Send` tab).
5. The confirmation popup will have `Ringsize: 0`.

