### PR TITLE
add explicit mainnet button and move nettypes to advanced options

### DIFF
--- a/components/CheckBox2.qml
+++ b/components/CheckBox2.qml
@@ -28,6 +28,7 @@
 
 import QtQuick 2.0
 import QtQuick.Layouts 1.1
+import QtGraphicalEffects 1.0
 import "." 1.0
 
 RowLayout {
@@ -40,6 +41,7 @@ RowLayout {
     property int fontSize: 14 * scaleRatio
     property alias fontColor: label.color
     property int textMargin: 8 * scaleRatio
+    property bool darkDropIndicator: false
     signal clicked()
     height: 25 * scaleRatio
 
@@ -74,12 +76,19 @@ RowLayout {
                 anchors.left: label.right
                 anchors.leftMargin: textMargin
                 color: "transparent"
+                rotation: checkBox.checked ? 180  * scaleRatio : 0
 
                 Image {
                     id: indicatorImage
                     anchors.centerIn: parent
                     source: "../images/whiteDropIndicator.png"
-                    rotation: checkBox.checked ? 180  * scaleRatio : 0
+                    visible: !darkDropIndicator
+                }
+                ColorOverlay {
+                    anchors.fill: indicatorImage
+                    source: indicatorImage
+                    color: "#FF000000"
+                    visible: darkDropIndicator
                 }
             }
 

--- a/wizard/WizardOptions.qml
+++ b/wizard/WizardOptions.qml
@@ -237,9 +237,41 @@ ColumnLayout {
         Layout.fillWidth: true
         spacing: 38 * scaleRatio
 
+        RowLayout {
+            CheckBox2 {
+                id: showAdvancedCheckbox
+                darkDropIndicator: true
+                text: qsTr("Advanced options") + translationManager.emptyString
+                fontColor: "#4A4646"
+            }
+        }
+
         Rectangle {
             width: 100 * scaleRatio
             RadioButton {
+                visible: showAdvancedCheckbox.checked
+                enabled: !this.checked
+                id: mainNet
+                text: qsTr("Mainnet") + translationManager.emptyString
+                checkedColor: Qt.rgba(0, 0, 0, 0.75)
+                borderColor: Qt.rgba(0, 0, 0, 0.45)
+                fontColor: "#4A4646"
+                fontSize: 16 * scaleRatio
+                checked: appWindow.persistentSettings.nettype == NetworkType.MAINNET;
+                onClicked: {
+                    persistentSettings.nettype = NetworkType.MAINNET
+                    testNet.checked = false;
+                    stageNet.checked = false;
+                    console.log("Network type set to MainNet")
+                }
+            }
+        }
+
+        Rectangle {
+            width: 100 * scaleRatio
+            RadioButton {
+                visible: showAdvancedCheckbox.checked
+                enabled: !this.checked
                 id: testNet
                 text: qsTr("Testnet") + translationManager.emptyString
                 checkedColor: Qt.rgba(0, 0, 0, 0.75)
@@ -249,6 +281,7 @@ ColumnLayout {
                 checked: appWindow.persistentSettings.nettype == NetworkType.TESTNET;
                 onClicked: {
                     persistentSettings.nettype = testNet.checked ? NetworkType.TESTNET : NetworkType.MAINNET
+                    mainNet.checked = false;
                     stageNet.checked = false;
                     console.log("Network type set to ", persistentSettings.nettype == NetworkType.TESTNET ? "Testnet" : "Mainnet")
                 }
@@ -258,6 +291,8 @@ ColumnLayout {
         Rectangle {
             width: 100 * scaleRatio
             RadioButton {
+                visible: showAdvancedCheckbox.checked
+                enabled: !this.checked
                 id: stageNet
                 text: qsTr("Stagenet") + translationManager.emptyString
                 checkedColor: Qt.rgba(0, 0, 0, 0.75)
@@ -267,6 +302,7 @@ ColumnLayout {
                 checked: appWindow.persistentSettings.nettype == NetworkType.STAGENET;
                 onClicked: {
                     persistentSettings.nettype = stageNet.checked ? NetworkType.STAGENET : NetworkType.MAINNET
+                    mainNet.checked = false;
                     testNet.checked = false;
                     console.log("Network type set to ", persistentSettings.nettype == NetworkType.STAGENET ? "Stagenet" : "Mainnet")
                 }


### PR DESCRIPTION
Most users don't need to worry about  testnet/stagenet so they are moved to an "Advanced Options" tab. Under this tab a "Mainnet" button is also added along side the other nettypes to address #1436