### PR TITLE
Fix for frozen settings page

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -358,6 +358,10 @@ ApplicationWindow {
         middlePanel.updateStatus();
         leftPanel.networkStatus.connected = status
 
+        // update local daemon status.
+        if(!isMobile && walletManager.isDaemonLocal(appWindow.persistentSettings.daemon_address))
+            daemonRunning = status;
+
         // Update fee multiplier dropdown on transfer page
         middlePanel.transferView.updatePriorityDropdown();
 

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -51,7 +51,7 @@ Rectangle {
         console.log("Settings page loaded");
 
         if(typeof daemonManager != "undefined"){
-            appWindow.daemonRunning = persistentSettings.useRemoteNode ? false : daemonManager.running(persistentSettings.nettype);
+            daemonRunning = persistentSettings.useRemoteNode ? false : appWindow.daemonRunning;
         }
 
         logLevelDropdown.update()
@@ -353,7 +353,7 @@ Rectangle {
             StandardButton {
                 id: startDaemonButton
                 small: true
-                visible: !appWindow.daemonRunning
+                visible: !daemonRunning
                 text: qsTr("Start Local Node") + translationManager.emptyString
                 onClicked: {
                     // Update bootstrap daemon address
@@ -368,7 +368,7 @@ Rectangle {
             StandardButton {
                 id: stopDaemonButton
                 small: true
-                visible: appWindow.daemonRunning
+                visible: daemonRunning
                 text: qsTr("Stop Local Node") + translationManager.emptyString
                 onClicked: {
                     appWindow.stopDaemon()


### PR DESCRIPTION
currently we are checking daemon status each time we go to settings page (when local daemon is selected). This causes a hang of a few seconds (it depends on monerod's workload). 

This is a proposal to remove this check and rely on  "onWalletConnectionStatusChanged", as we do for leftpanel's network status items.

I did check the behaviour of this patch against a local daemon (started both inside and outside the gui) and it seems to work fine for me. More testing would be required and reviews apreciated because this might be some stupid PR.