### PR TITLE
[WIP] implement system tray menu with contextual actions

### DIFF
--- a/filter.cpp
+++ b/filter.cpp
@@ -114,6 +114,12 @@ bool filter::eventFilter(QObject *obj, QEvent *ev) {
         QMouseEvent *me = static_cast<QMouseEvent*>(ev);
         emit mouseReleased(QVariant::fromValue<QObject*>(obj), me->x(), me->y());
     } break;
+    case QEvent::WindowBlocked: {
+        emit windowBlocked(true);
+    } break;
+    case QEvent::WindowUnblocked: {
+        emit windowBlocked(false);
+    } break;
     default: break;
     }
 

--- a/filter.h
+++ b/filter.h
@@ -48,6 +48,7 @@ signals:
     void sequenceReleased(const QVariant &o, const QVariant &seq);
     void mousePressed(const QVariant &o, const QVariant &x, const QVariant &y);
     void mouseReleased(const QVariant &o, const QVariant &x, const QVariant &y);
+    void windowBlocked(const bool blocked);
 };
 
 #endif // FILTER_H

--- a/main.cpp
+++ b/main.cpp
@@ -56,6 +56,7 @@
 #include "wallet/api/wallet2_api.h"
 #include "Logger.h"
 #include "MainApp.h"
+#include "systemtray.h"
 
 // IOS exclusions
 #ifndef Q_OS_IOS
@@ -145,6 +146,9 @@ int main(int argc, char *argv[])
                          << calculated_ratio;
 
 
+    // add a system tray
+    SystemTray *systray = new SystemTray();
+
     // registering types for QML
     qmlRegisterType<clipboardAdapter>("moneroComponents.Clipboard", 1, 0, "Clipboard");
 
@@ -221,6 +225,8 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("qtRuntimeVersion", qVersion());
 
     engine.rootContext()->setContextProperty("walletLogPath", logPath);
+
+    engine.rootContext()->setContextProperty("systray", systray);
 
 // Exclude daemon manager from IOS
 #ifndef Q_OS_IOS
@@ -307,6 +313,9 @@ int main(int argc, char *argv[])
     QObject::connect(eventFilter, SIGNAL(sequenceReleased(QVariant,QVariant)), rootObject, SLOT(sequenceReleased(QVariant,QVariant)));
     QObject::connect(eventFilter, SIGNAL(mousePressed(QVariant,QVariant,QVariant)), rootObject, SLOT(mousePressed(QVariant,QVariant,QVariant)));
     QObject::connect(eventFilter, SIGNAL(mouseReleased(QVariant,QVariant,QVariant)), rootObject, SLOT(mouseReleased(QVariant,QVariant,QVariant)));
+    QObject::connect(eventFilter, SIGNAL(windowBlocked(bool)), systray, SLOT(disableActionHide(bool)));
 
-    return app.exec();
+    bool status = app.exec();
+    delete systray;
+    return status;
 }

--- a/main.qml
+++ b/main.qml
@@ -82,6 +82,42 @@ ApplicationWindow {
     // true if wallet ever synchronized
     property bool walletInitialized : false
 
+
+    /* System Tray connections */
+
+    Connections {
+        target: systray
+
+        /* switch page from systray
+         * TODO: enable only if wallet is opened !!! */
+
+        onSignalPageRequested: {
+            console.log("System tray: requested page " + page)
+            showPageRequest(page)
+
+            if (appWindow.visibility === Window.Hidden)
+                appWindow.show()
+                systray.showActionHide(false)
+
+            // bring appWindow to front
+            appWindow.raise()
+        }
+
+        onSignalToggle:  {
+            if (appWindow.visibility === Window.Hidden)
+                appWindow.show()
+            else
+                appWindow.hide()
+        }
+
+        onSignalClose: {
+            appWindow.close()
+        }
+    }
+
+
+
+
     function altKeyReleased() { ctrlPressed = false; }
 
     function showPageRequest(page) {
@@ -210,7 +246,6 @@ ApplicationWindow {
             // set page to transfer if not changing daemon
             middlePanel.state = "Transfer";
             leftPanel.selectItem(middlePanel.state)
-
         }
 
 
@@ -244,6 +279,10 @@ ApplicationWindow {
 
         // Hide titlebar based on persistentSettings.customDecorations
         titleBar.visible = persistentSettings.customDecorations;
+
+        // Enable system tray based on persistentSettings.hasSystray
+        if (persistentSettings.hasSystray)
+            systray.toggleIcon(true)
     }
 
     function closeWallet() {

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -51,7 +51,8 @@ HEADERS += \
     src/zxcvbn-c/zxcvbn.h \
     src/libwalletqt/UnsignedTransaction.h \
     Logger.h \
-    MainApp.h
+    MainApp.h \
+    systemtray.h
 
 SOURCES += main.cpp \
     filter.cpp \
@@ -77,7 +78,8 @@ SOURCES += main.cpp \
     src/zxcvbn-c/zxcvbn.c \
     src/libwalletqt/UnsignedTransaction.cpp \
     Logger.cpp \
-    MainApp.cpp
+    MainApp.cpp \
+    systemtray.cpp
 
 CONFIG(DISABLE_PASS_STRENGTH_METER) {
     HEADERS -= src/zxcvbn-c/zxcvbn.h

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -506,6 +506,17 @@ Rectangle {
                 onClicked: Windows.setCustomWindowDecorations(checked)
                 text: qsTr("Custom decorations") + translationManager.emptyString
             }
+
+            CheckBox {
+                visible: !isMobile
+                id: systemTrayCheckBox
+                checked: persistentSettings.hasSystray
+                onClicked: {
+                    systray.toggleIcon(checked);
+                    persistentSettings.hasSystray = true;
+                }
+                text: qsTr("Enable System Tray") + translationManager.emptyString
+            }
         }
 
         // Log level

--- a/systemtray.cpp
+++ b/systemtray.cpp
@@ -1,0 +1,116 @@
+#include "systemtray.h"
+#include <QDebug>
+
+namespace {
+    static const QString title = "Monero GUI";
+}
+
+
+SystemTray::SystemTray(QObject *parent) : QObject(parent)
+{
+    m_trayIcon = new QSystemTrayIcon;
+    m_trayMenu = new QMenu;
+
+    // actions for switching pages
+    m_pageTransfer = new QAction(tr("Transfer"), m_trayIcon);
+    m_pageReceive = new QAction(tr("Receive"), m_trayIcon);
+    m_pageHistory = new QAction(tr("History"), m_trayIcon);
+    m_pageSettings = new QAction(tr("Settings"), m_trayIcon);
+
+    // misc actions
+    m_actionHide = new QAction(tr("Hide window"), m_trayIcon);
+    m_actionShow = new QAction(tr("Show window"), m_trayIcon);
+    m_actionClose = new QAction(tr("Close") + " " + title, m_trayIcon);
+
+    // add actions to menu
+    m_trayMenu->addAction(m_pageTransfer);
+    m_trayMenu->addAction(m_pageReceive);
+    m_trayMenu->addAction(m_pageHistory);
+    m_trayMenu->addAction(m_pageSettings);
+    m_trayMenu->addSeparator();
+    m_trayMenu->addAction(m_actionHide);
+    m_trayMenu->addAction(m_actionClose);
+
+    // set m_trayMenu as contextual menu of m_trayIcon
+    m_trayIcon->setContextMenu(m_trayMenu);
+
+    // set icon for m_trayIcon
+    m_trayIcon->setIcon(QIcon(":/images/moneroIcon-28x28.png"));
+
+    /* Connect systray with qml application */
+    connect(m_actionHide, &QAction::triggered, [&](){
+        showAppWindow(false);
+    });
+
+    connect(m_actionShow, &QAction::triggered, [&](){
+        showAppWindow(true);
+    });
+
+    connect(m_actionClose, &QAction::triggered, [&](){
+        emit signalClose();
+    });
+
+    connect(m_pageTransfer, &QAction::triggered, [&](){
+        emit signalPageRequested("Transfer");
+    });
+
+    connect(m_pageReceive, &QAction::triggered, [&](){
+        emit signalPageRequested("Receive");
+    });
+
+    connect(m_pageHistory, &QAction::triggered, [&](){
+        emit signalPageRequested("History");
+    });
+
+    connect(m_pageSettings, &QAction::triggered, [&](){
+        emit signalPageRequested("Settings");
+    });
+ }
+
+SystemTray::~SystemTray()
+ {
+     // QObject without parent.
+     delete m_trayIcon;
+     delete m_trayMenu;
+ }
+
+void SystemTray::toggleIcon(const bool visible)
+{
+    // slot to toggle systray icon features from qml.
+    m_trayIcon->setVisible(visible);
+}
+
+void SystemTray::disableActionHide(const bool hidden)
+{
+    // slot to toggle hide action
+    m_actionHide->setDisabled(hidden);
+}
+
+void SystemTray::showNotification(const QString message)
+{
+    // slot to show notifications
+    m_trayIcon->showMessage(title, message, QSystemTrayIcon::Information);
+}
+
+void SystemTray::showAppWindow(const bool visible)
+{
+    showActionHide(visible);
+    emit signalToggle();
+}
+
+void SystemTray::showActionHide(const bool hidden)
+{
+    if (hidden) {
+        m_trayMenu->removeAction(m_actionHide);
+        m_trayMenu->removeAction(m_actionClose);
+        m_trayMenu->addAction(m_actionShow);
+        m_trayMenu->addAction(m_actionClose);
+    } else {
+        m_trayMenu->removeAction(m_actionShow);
+        m_trayMenu->removeAction(m_actionClose);
+        m_trayMenu->addAction(m_actionHide);
+        m_trayMenu->addAction(m_actionClose);
+    }
+}
+
+

--- a/systemtray.h
+++ b/systemtray.h
@@ -1,0 +1,42 @@
+#ifndef SYSTEMTRAY_H
+#define SYSTEMTRAY_H
+
+#include <QObject>
+#include <QSystemTrayIcon>
+#include <QMenu>
+
+class SystemTray : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit SystemTray(QObject *parent = nullptr);
+    ~SystemTray();
+
+public slots:
+    void toggleIcon(const bool visible);
+    void disableActionHide(const bool hidden);
+    void showNotification(const QString message);
+    void showActionHide(const bool hidden);
+
+signals:
+    void signalPageRequested(QString page) const;
+    void signalToggle() const;
+    void signalClose() const;
+
+private slots:
+    void showAppWindow(const bool visible);
+
+private:
+    QSystemTrayIcon *m_trayIcon;
+    QAction *m_pageTransfer;
+    QAction *m_pageReceive;
+    QAction *m_pageHistory;
+    QAction *m_pageSettings;
+    QAction *m_actionHide;
+    QAction *m_actionShow;
+    QAction *m_actionClose;
+    QMenu *m_trayMenu;
+};
+
+#endif // SYSTEMTRAY_H


### PR DESCRIPTION
Don't merge.

This PR implements a system tray icon/menu with the following features: hide to systray/ show from systray and close app from systray. It also includes a slot to show system notifications, but is unused for now.

Having a system tray  can be useful to implement the following features:

1. Open/close wallets from systray
2. Lock current wallet ^^
3. Open qml pages ^^
4. Show system notifications at will.
5. View wallet/network status on icon hover
6 ...

The main reason to have a systray for me in the long run is to start monerod as a child of the gui (instead of detached) and being able to leave monerod running with all wallets closed, but a nice icon on notifications area. Sending commands to monerod via rpc is slower than using an interactive daemon session and blocks qt event loop. 

Feedback would be awesome. Both about the implemented stuff and about future implementation, ideas, etc.