### PR TITLE
Keys: allow keys to be copied separately

### DIFF
--- a/pages/Keys.qml
+++ b/pages/Keys.qml
@@ -148,27 +148,40 @@ Rectangle {
                 opacity: Style.dividerOpacity
                 Layout.bottomMargin: 10 * scaleRatio
             }
-            TextEdit {
-                id: keysText
-                wrapMode: TextEdit.Wrap
-                Layout.fillWidth: true;
-                font.pixelSize: 14 * scaleRatio
-                textFormat: TextEdit.RichText
+            LineEdit {
+                Layout.fillWidth: true
+                id: secretViewKey
                 readOnly: true
-                color: Style.defaultFontColor
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                        appWindow.showStatusMessage(qsTr("Double tap to copy"),3)
-                    }
-                    onDoubleClicked: {
-                        parent.selectAll()
-                        parent.copy()
-                        parent.deselect()
-                        console.log("copied to clipboard");
-                        appWindow.showStatusMessage(qsTr("Keys copied to clipboard"),3)
-                    }
-                }
+                copyButton: true
+                labelText: qsTr("Secret view key") + translationManager.emptyString
+                fontSize: 16 * scaleRatio
+            }
+            LineEdit {
+                Layout.fillWidth: true
+                Layout.topMargin: 25 * scaleRatio
+                id: publicViewKey
+                readOnly: true
+                copyButton: true
+                labelText: qsTr("Public view key") + translationManager.emptyString
+                fontSize: 16 * scaleRatio
+            }
+            LineEdit {
+                Layout.fillWidth: true
+                Layout.topMargin: 25 * scaleRatio
+                id: secretSpendKey
+                readOnly: true
+                copyButton: true
+                labelText: qsTr("Secret spend key") + translationManager.emptyString
+                fontSize: 16 * scaleRatio
+            }
+            LineEdit {
+                Layout.fillWidth: true
+                Layout.topMargin: 25 * scaleRatio
+                id: publicSpendKey
+                readOnly: true
+                copyButton: true
+                labelText: qsTr("Public spend key") + translationManager.emptyString
+                fontSize: 16 * scaleRatio
             }
         }
 
@@ -244,10 +257,10 @@ Rectangle {
     function onPageCompleted() {
         console.log("keys page loaded");
 
-        keysText.text = "<b>" + qsTr("Secret view key") + ":</b> " + currentWallet.secretViewKey
-        keysText.text += "<br><br><b>" + qsTr("Public view key") + ":</b> " + currentWallet.publicViewKey
-        keysText.text += (!currentWallet.viewOnly) ? "<br><br><b>" + qsTr("Secret spend key") + ":</b> " + currentWallet.secretSpendKey : ""
-        keysText.text += "<br><br><b>" + qsTr("Public spend key") + ":</b> " + currentWallet.publicSpendKey
+        secretViewKey.text = currentWallet.secretViewKey
+        publicViewKey.text = currentWallet.publicViewKey
+        secretSpendKey.text = (!currentWallet.viewOnly) ? currentWallet.secretSpendKey : ""
+        publicSpendKey.text = currentWallet.publicSpendKey
 
         seedText.text = currentWallet.seed
 


### PR DESCRIPTION
I don't like the current way where the entire text including all the secret/public view/spend keys gets copied to clipboard. Quite often the user only needs to copy the view secret key, which means that the user would need to paste this text somewhere and then make the next selection therein. This pasting operation can be dangerous when e.g. the user pasted it onto an email client and forgot to delete the draft (or even send it to someone).

![screen shot 2018-06-19 at 12 57 28](https://user-images.githubusercontent.com/26077532/41576111-8936b68e-73c0-11e8-9491-f8f8fb00f44a.jpg)
