### PR TITLE
Allow adjusting number of rounds for the key derivation function (requires #4103)

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -243,7 +243,7 @@ ApplicationWindow {
             // console.log("opening wallet at: ", wallet_path, "with password: ", appWindow.walletPassword);
             console.log("opening wallet at: ", wallet_path, ", network type: ", persistentSettings.nettype == NetworkType.MAINNET ? "mainnet" : persistentSettings.nettype == NetworkType.TESTNET ? "testnet" : "stagenet");
             walletManager.openWalletAsync(wallet_path, walletPassword,
-                                              persistentSettings.nettype);
+                                              persistentSettings.nettype, persistentSettings.kdfRounds);
         }
 
         // Hide titlebar based on persistentSettings.customDecorations
@@ -1026,6 +1026,7 @@ ApplicationWindow {
         property bool segregatePreForkOutputs: true
         property bool keyReuseMitigation2: true
         property int segregationHeight: 0
+        property int kdfRounds: 1
     }
 
     // Information dialog

--- a/pages/settings/SettingsInfo.qml
+++ b/pages/settings/SettingsInfo.qml
@@ -188,7 +188,7 @@ Rectangle {
                                     walletManager.closeWallet();
                                     walletManager.clearWalletCache(persistentSettings.wallet_path);
                                     walletManager.openWalletAsync(persistentSettings.wallet_path, appWindow.walletPassword,
-                                                                      persistentSettings.nettype);
+                                                                      persistentSettings.nettype, persistentSettings.kdfRounds);
                                 }
 
                                 confirmationDialog.onRejectedCallback = null;

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -25,7 +25,7 @@ WalletManager *WalletManager::instance()
 }
 
 Wallet *WalletManager::createWallet(const QString &path, const QString &password,
-                                    const QString &language, NetworkType::Type nettype)
+                                    const QString &language, NetworkType::Type nettype, quint64 kdfRounds)
 {
     QMutexLocker locker(&m_mutex);
     if (m_currentWallet) {
@@ -33,12 +33,12 @@ Wallet *WalletManager::createWallet(const QString &path, const QString &password
         delete m_currentWallet;
     }
     Monero::Wallet * w = m_pimpl->createWallet(path.toStdString(), password.toStdString(),
-                                                  language.toStdString(), static_cast<Monero::NetworkType>(nettype));
+                                                  language.toStdString(), static_cast<Monero::NetworkType>(nettype), kdfRounds);
     m_currentWallet  = new Wallet(w);
     return m_currentWallet;
 }
 
-Wallet *WalletManager::openWallet(const QString &path, const QString &password, NetworkType::Type nettype)
+Wallet *WalletManager::openWallet(const QString &path, const QString &password, NetworkType::Type nettype, quint64 kdfRounds)
 {
     QMutexLocker locker(&m_mutex);
     if (m_currentWallet) {
@@ -48,7 +48,7 @@ Wallet *WalletManager::openWallet(const QString &path, const QString &password, 
     qDebug("%s: opening wallet at %s, nettype = %d ",
            __PRETTY_FUNCTION__, qPrintable(path), nettype);
 
-    Monero::Wallet * w =  m_pimpl->openWallet(path.toStdString(), password.toStdString(), static_cast<Monero::NetworkType>(nettype));
+    Monero::Wallet * w =  m_pimpl->openWallet(path.toStdString(), password.toStdString(), static_cast<Monero::NetworkType>(nettype), kdfRounds);
     qDebug("%s: opened wallet: %s, status: %d", __PRETTY_FUNCTION__, w->address(0, 0).c_str(), w->status());
     m_currentWallet  = new Wallet(w);
 
@@ -60,10 +60,10 @@ Wallet *WalletManager::openWallet(const QString &path, const QString &password, 
     return m_currentWallet;
 }
 
-void WalletManager::openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype)
+void WalletManager::openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype, quint64 kdfRounds)
 {
     QFuture<Wallet*> future = QtConcurrent::run(this, &WalletManager::openWallet,
-                                        path, password, nettype);
+                                        path, password, nettype, kdfRounds);
     QFutureWatcher<Wallet*> * watcher = new QFutureWatcher<Wallet*>();
 
     connect(watcher, &QFutureWatcher<Wallet*>::finished,
@@ -76,21 +76,21 @@ void WalletManager::openWalletAsync(const QString &path, const QString &password
 }
 
 
-Wallet *WalletManager::recoveryWallet(const QString &path, const QString &memo, NetworkType::Type nettype, quint64 restoreHeight)
+Wallet *WalletManager::recoveryWallet(const QString &path, const QString &memo, NetworkType::Type nettype, quint64 restoreHeight, quint64 kdfRounds)
 {
     QMutexLocker locker(&m_mutex);
     if (m_currentWallet) {
         qDebug() << "Closing open m_currentWallet" << m_currentWallet;
         delete m_currentWallet;
     }
-    Monero::Wallet * w = m_pimpl->recoveryWallet(path.toStdString(), memo.toStdString(), static_cast<Monero::NetworkType>(nettype), restoreHeight);
+    Monero::Wallet * w = m_pimpl->recoveryWallet(path.toStdString(), "", memo.toStdString(), static_cast<Monero::NetworkType>(nettype), restoreHeight, kdfRounds);
     m_currentWallet = new Wallet(w);
     return m_currentWallet;
 }
 
 Wallet *WalletManager::createWalletFromKeys(const QString &path, const QString &language, NetworkType::Type nettype,
                                             const QString &address, const QString &viewkey, const QString &spendkey,
-                                            quint64 restoreHeight)
+                                            quint64 restoreHeight, quint64 kdfRounds)
 {
     QMutexLocker locker(&m_mutex);
     if (m_currentWallet) {
@@ -98,8 +98,8 @@ Wallet *WalletManager::createWalletFromKeys(const QString &path, const QString &
         delete m_currentWallet;
         m_currentWallet = NULL;
     }
-    Monero::Wallet * w = m_pimpl->createWalletFromKeys(path.toStdString(), language.toStdString(), static_cast<Monero::NetworkType>(nettype), restoreHeight,
-                                                       address.toStdString(), viewkey.toStdString(), spendkey.toStdString());
+    Monero::Wallet * w = m_pimpl->createWalletFromKeys(path.toStdString(), "", language.toStdString(), static_cast<Monero::NetworkType>(nettype), restoreHeight,
+                                                       address.toStdString(), viewkey.toStdString(), spendkey.toStdString(), kdfRounds);
     m_currentWallet = new Wallet(w);
     return m_currentWallet;
 }

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -33,7 +33,7 @@ public:
     static WalletManager * instance();
     // wizard: createWallet path;
     Q_INVOKABLE Wallet * createWallet(const QString &path, const QString &password,
-                                      const QString &language, NetworkType::Type nettype = NetworkType::MAINNET);
+                                      const QString &language, NetworkType::Type nettype = NetworkType::MAINNET, quint64 kdfRounds = 1);
 
     /*!
      * \brief openWallet - opens wallet by given path
@@ -42,17 +42,17 @@ public:
      * \param nettype    - type of network the wallet is running on
      * \return wallet object pointer
      */
-    Q_INVOKABLE Wallet * openWallet(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET);
+    Q_INVOKABLE Wallet * openWallet(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET, quint64 kdfRounds = 1);
 
     /*!
      * \brief openWalletAsync - asynchronous version of "openWallet". Returns immediately. "walletOpened" signal
      *                          emitted when wallet opened;
      */
-    Q_INVOKABLE void openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET);
+    Q_INVOKABLE void openWalletAsync(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET, quint64 kdfRounds = 1);
 
     // wizard: recoveryWallet path; hint: internally it recorvers wallet and set password = ""
     Q_INVOKABLE Wallet * recoveryWallet(const QString &path, const QString &memo,
-                                       NetworkType::Type nettype = NetworkType::MAINNET, quint64 restoreHeight = 0);
+                                       NetworkType::Type nettype = NetworkType::MAINNET, quint64 restoreHeight = 0, quint64 kdfRounds = 1);
 
     Q_INVOKABLE Wallet * createWalletFromKeys(const QString &path,
                                               const QString &language,
@@ -60,7 +60,8 @@ public:
                                               const QString &address,
                                               const QString &viewkey,
                                               const QString &spendkey = "",
-                                              quint64 restoreHeight = 0);
+                                              quint64 restoreHeight = 0,
+                                              quint64 kdfRounds = 1);
 
     Q_INVOKABLE Wallet * createWalletFromDevice(const QString &path,
                                                 const QString &password,

--- a/wizard/WizardCreateWallet.qml
+++ b/wizard/WizardCreateWallet.qml
@@ -86,8 +86,9 @@ ColumnLayout {
         var tmp_wallet_filename = oshelper.temporaryFilename();
         console.log("Creating temporary wallet", tmp_wallet_filename)
         var nettype = appWindow.persistentSettings.nettype;
+        var kdfRounds = appWindow.persistentSettings.kdfRounds;
         var wallet = walletManager.createWallet(tmp_wallet_filename, "", settingsObject.wallet_language,
-                                                nettype)
+                                                nettype, kdfRounds)
         uiItem.wordsTextItem.memoText = wallet.seed
         // saving wallet in "global" settings object
         // TODO: wallet should have a property pointing to the file where it stored or loaded from

--- a/wizard/WizardOptions.qml
+++ b/wizard/WizardOptions.qml
@@ -28,6 +28,7 @@
 
 import QtQuick 2.2
 import QtQml 2.2
+import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.1
 import moneroComponents.NetworkType 1.0
 import "../components"
@@ -352,6 +353,36 @@ ColumnLayout {
                     testNet.checked = false;
                     console.log("Network type set to ", persistentSettings.nettype == NetworkType.STAGENET ? "Stagenet" : "Mainnet")
                 }
+            }
+        }
+    }
+
+    RowLayout {
+        Layout.leftMargin: wizardLeftMargin
+        Layout.rightMargin: wizardRightMargin
+        Layout.topMargin: 50 * scaleRatio
+        Layout.alignment: Qt.AlignHCenter
+        Layout.fillWidth: true
+        visible: showAdvancedCheckbox.checked
+
+        Text {
+            font.family: "Arial"
+            font.pixelSize: 16 * scaleRatio
+            color: "#4A4949"
+            text: qsTr("Number of KDF rounds:") + translationManager.emptyString
+        }
+        TextField {
+            id: kdfRoundsText
+            font.family: "Arial"
+            font.pixelSize: 16 * scaleRatio
+            Layout.preferredWidth: 60
+            horizontalAlignment: TextInput.AlignRight
+            selectByMouse: true
+            color: "#4A4949"
+            text: persistentSettings.kdfRounds
+            validator: IntValidator { bottom: 1 }
+            onTextEdited: {
+                kdfRoundsText.text = persistentSettings.kdfRounds = parseInt(kdfRoundsText.text) >= 1 ? parseInt(kdfRoundsText.text) : 1;
             }
         }
     }

--- a/wizard/WizardRecoveryWallet.qml
+++ b/wizard/WizardRecoveryWallet.qml
@@ -77,6 +77,7 @@ ColumnLayout {
 
     function recoveryWallet(settingsObject, fromSeed) {
         var nettype = appWindow.persistentSettings.nettype;
+        var kdfRounds = appWindow.persistentSettings.kdfRounds;
         var restoreHeight = settingsObject.restore_height;
         var tmp_wallet_filename = oshelper.temporaryFilename()
         console.log("Creating temporary wallet", tmp_wallet_filename)
@@ -89,11 +90,11 @@ ColumnLayout {
 
         // From seed or keys
         if(fromSeed)
-            var wallet = walletManager.recoveryWallet(tmp_wallet_filename, settingsObject.words, nettype, restoreHeight)
+            var wallet = walletManager.recoveryWallet(tmp_wallet_filename, settingsObject.words, nettype, restoreHeight, kdfRounds)
         else
             var wallet = walletManager.createWalletFromKeys(tmp_wallet_filename, settingsObject.wallet_language, nettype,
                                                             settingsObject.recover_address, settingsObject.recover_viewkey,
-                                                            settingsObject.recover_spendkey, restoreHeight)
+                                                            settingsObject.recover_spendkey, restoreHeight, kdfRounds)
 
 
         var success = wallet.status === Wallet.Status_Ok;


### PR DESCRIPTION

![screen shot 2018-08-09 at 8 45 04](https://user-images.githubusercontent.com/26077532/43870172-2cb3c71c-9bb1-11e8-81e2-71c7cb4b8b62.jpg)


This setting clearly belongs to the advanced ones, so it should be best combined with something like #1452.
**EDIT: #1452 was merged, so the widget is now put under the "Advanced options" section.** 

Since the dependent patch https://github.com/monero-project/monero/pull/4103 is made against the master branch, `get_libwallet_api.sh` is temporarily modified to use the master branch in 887c0eb.