### PR TITLE
Change application name back to monero-core (revert 28fb9fa)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 
     MainApp app(argc, argv);
 
-    app.setApplicationName("monero-gui");
+    app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");
     app.setOrganizationName("monero-project");
 


### PR DESCRIPTION
Changing the application name caused wallets created prior to v0.12 to "forget" their config file