### PR TITLE
Support for the legacy config file/registry key 'monero-core'

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,7 @@
 #include <QIcon>
 #include <QDebug>
 #include <QObject>
+#include <QSettings>
 #include <QDesktopWidget>
 #include <QScreen>
 #include "clipboardAdapter.h"
@@ -103,6 +104,20 @@ int main(int argc, char *argv[])
     app.setApplicationName("monero-gui");
     app.setOrganizationDomain("getmonero.org");
     app.setOrganizationName("monero-project");
+
+    // support for older configuration files/registry keys (monero-core.conf)
+    // @TODO: Legacy. Remove in 2019.
+    QString configPath;
+    QSettings *settingsLegacy = new QSettings(QSettings::NativeFormat, QSettings::UserScope, "monero-project", "monero-core");
+    if(!settingsLegacy->value("customDecorations").isNull()) {
+        configPath = settingsLegacy->fileName();
+        app.setApplicationName("monero-core");
+    } else {
+        QSettings *settings = new QSettings(QSettings::NativeFormat, QSettings::UserScope, "monero-project", "monero-gui");
+        configPath = settings->fileName();
+        delete settings;
+    }
+    delete settingsLegacy;
 
 #if defined(Q_OS_LINUX)
     if (isDesktop) app.setWindowIcon(QIcon(":/images/appicon.ico"));
@@ -269,6 +284,7 @@ int main(int argc, char *argv[])
 
     engine.rootContext()->setContextProperty("defaultAccountName", accountName);
     engine.rootContext()->setContextProperty("applicationDirectory", QApplication::applicationDirPath());
+    engine.rootContext()->setContextProperty("configPath", configPath);
 
     bool builtWithScanner = false;
 #ifdef WITH_SCANNER

--- a/pages/Settings.qml
+++ b/pages/Settings.qml
@@ -738,6 +738,21 @@ Rectangle {
                 font.pixelSize: 14
                 text: walletLogPath
             }
+
+            TextBlock {
+                Layout.fillWidth: true
+                font.pixelSize: 14
+                text: qsTr("Config path: ") + translationManager.emptyString
+            }
+
+            TextBlock {
+                Layout.fillWidth: true
+                font.pixelSize: 14
+                text: {
+                    configPath
+                }
+                
+            }
         }
     }
 


### PR DESCRIPTION
The application name was switched to `monero-gui` for 0.12.2. This led to the GUI trying to locate `~/.config/monero-gui.conf` for the settings, ignoring the old `~/.config/monero-core.conf` resulting in lost configuration. 

On Windows, the same happened in the registry `HKEY_LOCAL_USER\Software\monero-core\...`

This PR sets the application name depending on if it can find the old config file/key, allowing new users to adopt the new scheme and old users keep their config.

It also adds a line to Debug info on the settings page:

![](https://i.imgur.com/CFIvSo5.png)

#1502 #1503

