### PR TITLE
build: use 'exit' instead of 'return' in get_libwallet_api.sh

### DIFF
--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -75,8 +75,7 @@ else
 fi
 
 if [ "$BUILD_LIBWALLET" != true ]; then
-    # exit this script
-    return
+    exit 0
 fi
 
 echo "GUI_MONERO_VERSION=\"$VERSIONTAG\"" > $MONERO_DIR/version.sh


### PR DESCRIPTION
Fixed a bug that is causing constant libwallet rebuilding, even if it already exists.  
This happens because `return` instruction in get_libwallet_api.sh fails to execute and thus doesn't interrupt get_libwallet_api.sh execution.  
Have to use `exit` instead.
```bash
latest libwallet (06b0f9e8) is already built. Remove monero/lib/libwallet_merged.a to force rebuild
./get_libwallet_api.sh: line 78: return: can only `return' from a function or sourced script
Building libwallet release
```