### PR TITLE
Fix build instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
     ```
     cd monero-gui
-    ./build.sh
+    QT_SELECT=5 ./build.sh
     ```
 
 The executable can be found in the build/release/bin folder.


### PR DESCRIPTION
`QT_SELECT=5` is still required on Debian 9 and it also doesn't harm on any other Linux system.