### PR TITLE
Correctly maximize window

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1631,7 +1631,7 @@ ApplicationWindow {
             showMoneroLogo: true
             onCloseClicked: appWindow.close();
             onMaximizeClicked: {
-                appWindow.visibility = appWindow.visibility !== Window.FullScreen ? Window.FullScreen :
+                appWindow.visibility = appWindow.visibility !== Window.Maximized ? Window.Maximized :
                                                                                     Window.Windowed
             }
             onMinimizeClicked: appWindow.visibility = Window.Minimized


### PR DESCRIPTION
Handle maximizing of the window just like any other application. Currently maximizing shows the wallet in fullscreen which also hides the taskbar.