### PR TITLE
Added boolean method 'checkPassword(wallet_path, passwd)' to WalletManager

### DIFF
--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -75,6 +75,17 @@ void WalletManager::openWalletAsync(const QString &path, const QString &password
     watcher->setFuture(future);
 }
 
+bool WalletManager::checkPassword(const QString &path, const QString &password, NetworkType::Type nettype){
+    Monero::Wallet * w = m_pimpl->openWallet(path.toStdString(), password.toStdString(), static_cast<Monero::NetworkType>(nettype));
+    int status = w->status();
+    qDebug("%s: check password: %s, status: %d", __PRETTY_FUNCTION__, w->address(0, 0).c_str(), status);
+    delete w;
+
+    if (status == Monero::Wallet::Status_Ok) {
+        return true;
+    }
+    return false;
+}
 
 Wallet *WalletManager::recoveryWallet(const QString &path, const QString &memo, NetworkType::Type nettype, quint64 restoreHeight)
 {

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -78,6 +78,9 @@ public:
 
     //! returns list with wallet's filenames, if found by given path
     Q_INVOKABLE QStringList findWallets(const QString &path);
+    
+    //! checks a combination of wallet_path, password and nettype
+    Q_INVOKABLE bool checkPassword(const QString &path, const QString &password, NetworkType::Type nettype = NetworkType::MAINNET);
 
     //! returns error description in human language
     Q_INVOKABLE QString errorString() const;


### PR DESCRIPTION
Context: #1537

QML/Javascript:

```qml
import moneroComponents.NetworkType 1.0
```

```javascript
{
    var password = "findme"
    var wallet_path = walletPath();
    console.log("checking wallet at: ", wallet_path, ", network type: ", persistentSettings.nettype == NetworkType.MAINNET ? "mainnet" : persistentSettings.nettype == NetworkType.TESTNET ? "testnet" : "stagenet");

    var result = walletManager.checkPassword(wallet_path, password, persistentSettings.nettype);
    console.log(result)
}
```