### PR TITLE
[DO NOT MERGE] pro: link against libsodium on Linux

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -116,6 +116,7 @@ LIBS += -L$$WALLET_ROOT/lib \
         -lepee \
         -lunbound \
         -leasylogging \
+        -lsodium \
 }
 
 android {


### PR DESCRIPTION
This is needed to link against libmonero_wallet from monero
with PR #4159 merged.

Please merge AFTER: https://github.com/monero-project/monero/pull/4159 is merged

Not touching other platforms because can't test.