### PR TITLE
Corrected language code for Ukrainian and renamed localized file

### DIFF
--- a/translations/monero-core_uk.ts
+++ b/translations/monero-core_uk.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="ua_UA">
+<TS version="2.0" language="uk_UA">
 <context>
     <name>AddressBook</name>
     <message>


### PR DESCRIPTION
Pinging @TheFuzzStone @LvMsterfild for verification

The file was called monero-core_ua.ts and it contained the attribute language="ua_UA", but the language code for Ukrainian is "uk" (UA being the country code). This must have been a typo, am I right?

NB. the file lang/languages.xml was already correct which supports the typo thesis: 

![image](https://user-images.githubusercontent.com/15184875/44466188-f2a69300-a61f-11e8-980e-f08fffa2bbfd.png)



