### PR TITLE
Prevent accidental off-by-one decimal point transfers

### DIFF
--- a/components/LineEdit.qml
+++ b/components/LineEdit.qml
@@ -196,7 +196,7 @@ Item {
         MoneroComponents.Input {
             id: input
             anchors.fill: parent
-            anchors.leftMargin: inlineIcon.visible ? 38 : 0
+            anchors.leftMargin: inlineIcon.visible ? 44 * scaleRatio : 0
             font.pixelSize: item.fontSize
             font.bold: item.fontBold
             onEditingFinished: item.editingFinished()

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -162,7 +162,7 @@ Rectangle {
                       inlineButton.onClicked: amountLine.text = "(all)"
 
                       validator: RegExpValidator {
-                          regExp: /(\d{1,8})([.]\d{1,12})?$/
+                          regExp: /(.|)(\d{1,8})([.]\d{1,12})?$/
                       }
                   }
               }
@@ -337,7 +337,12 @@ Rectangle {
                   if(parseFloat(amountLine.text) > parseFloat(unlockedBalanceText)){
                       return false;
                   }
-                  
+
+                  // The amount does not start with a period (example: `.4`)
+                  if(amountLine.text.startsWith('.')){
+                      return false;
+                  }
+
                   return true;
               }
               onClicked: {


### PR DESCRIPTION
[From Reddit](https://www.reddit.com/r/Monero/comments/9ap96g/gui_v01230_cli_v01230_both_with_direct_ledger/e5d40gb/):

> I have a complaint about the GUI xmr client, hope this is an appropriate place to comment this. I just tried to send a smaller amount of monero .2 xmr. When you type in .2 only 2 xmr fills in, the period does not fill in and I almost didn't realize. You have to type zero first to send less then 1, 0.2, the first char has to be a number not a period. Can this be changed to either accept the period first, or if a period is pressed to fill in 0. before it. If I didn't notice I could have sent 2 xmr instead of .2.

I changed the regex to support amounts that begin with a period, however, the actual validation that checks the amount will not let you create a transaction with amounts that start with a period. Should solve some confusion.

![](https://blog.cedsys.nl/paste/i/a2d2d7f1-51ed-4856-98c5-becac7b15a0e)

![](https://blog.cedsys.nl/paste/i/dbc4291c-1c95-47a1-8c78-b960fd37112c)

