### PR TITLE
osx -lsodium LIBS addition to compile

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -118,6 +118,7 @@ LIBS += -L$$WALLET_ROOT/lib \
         -lepee \
         -lunbound \
         -leasylogging \
+        -lsodium \
 }
 
 android {
@@ -162,6 +163,7 @@ ios {
         -lssl \
         -lcrypto \
         -ldl
+        -lsodium
 }
 
 CONFIG(WITH_SCANNER) {
@@ -290,7 +292,8 @@ linux {
         -lboost_program_options \
         -lssl \
         -llmdb \
-        -lcrypto
+        -lcrypto \
+        -lsodium
 
     if(!android) {
         LIBS+= \
@@ -329,7 +332,8 @@ macx {
         -lboost_program_options \
         -lssl \
         -lcrypto \
-        -ldl
+        -ldl \
+        -lsodium
     LIBS+= -framework PCSC
 
     QMAKE_LFLAGS += -pie


### PR DESCRIPTION
Additional  changes for compile on osx 10.13.6 along with changes made from https://github.com/monero-project/monero-gui/pull/1540. I was able to successfully compile with these changes today.