### PR TITLE
Allow arguments to be passed to `start-gui.sh`

### DIFF
--- a/linuxdeploy_helper.sh
+++ b/linuxdeploy_helper.sh
@@ -48,7 +48,7 @@ export QT_PLUGIN_PATH=\`pwd\`/plugins
 export QML2_IMPORT_PATH=\`pwd\`/qml
 # make it so that it can be called from anywhere and also through soft links
 SCRIPT_DIR="\$(dirname "\$(test -L "\${BASH_SOURCE[0]}" && readlink "\${BASH_SOURCE[0]}" || echo "\${BASH_SOURCE[0]}")")"
-"\$SCRIPT_DIR"/$GUI_EXEC
+"\$SCRIPT_DIR"/$GUI_EXEC "\$@"
 EOL
 
 chmod +x $TARGET/start-gui.sh


### PR DESCRIPTION
Allows arguments (`-h`, `-l`) to be passed to `start-gui.sh`, otherwise the log file location cannot be specified when using the script.