### PR TITLE
Add submodule 'monero-GUI-guide'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = monero
 	url = https://github.com/monero-project/monero
 	ignore = all
+[submodule "monero-GUI-guide"]
+	path = monero-GUI-guide
+	url = https://github.com/monero-ecosystem/monero-GUI-guide.git

--- a/README.md
+++ b/README.md
@@ -106,14 +106,13 @@ Packaging for your favorite distribution would be a welcome contribution!
       `emerge dev-qt/qtmultimedia:5 media-gfx/zbar`
 
 
-3. Clone repository
+3. Clone repository (including the guide)
 
-    `git clone https://github.com/monero-project/monero-gui.git`
+    `git clone https://github.com/monero-project/monero-gui.git && cd monero-gui && git submodule init monero-GUI-guide && git submodule update`
 
 4. Build
 
     ```
-    cd monero-gui
     QT_SELECT=5 ./build.sh
     ```
 
@@ -153,15 +152,11 @@ The executable can be found in the build/release/bin folder.
 
     This is the directory where Qt 5.x is installed on **your** system
 
-6. Grab an up-to-date copy of the monero-gui repository
+6. Grab an up-to-date copy of the monero-gui repository (including the guide)
 
-  `git clone https://github.com/monero-project/monero-gui.git`
+  `git clone https://github.com/monero-project/monero-gui.git && cd monero-gui && git submodule init monero-GUI-guide && git submodule update`
 
-7. Go into the repository
-
-  `cd monero-gui`
-
-8. Start the build
+7. Start the build
 
   `./build.sh`
 
@@ -210,16 +205,15 @@ The Monero GUI on Windows is 64 bits only; 32-bit Windows GUI builds are not off
     pacman -S git
     ```
 
-6. Clone repository
+6. Clone repository (including the guide)
 
     ```
-    git clone https://github.com/monero-project/monero-gui.git
+    git clone https://github.com/monero-project/monero-gui.git && cd monero-gui && git submodule init monero-GUI-guide && git submodule update
     ```
 
 7. Build
 
     ```
-    cd monero-gui
     ./build.sh
     cd build
     make deploy


### PR DESCRIPTION
This PR add the GUI guide (https://github.com/monero-ecosystem/monero-GUI-guide) as a submodule, so that it can be included directly in the monero-gui repository.
Some issues need to be addressed:

- This PR updates the instructions in the README. Instead of the simple `git clone`, it instructs to use `git clone https://github.com/monero-project/monero-gui.git && cd monero-gui && git submodule init monero-GUI-guide && git submodule update`, so that the guide's submodule will be also cloned.
This to avoid to use `--recurse-submodules`, since it's not intended to clone the 'monero' submodule along with the GUI. Is this ok? Would you prefer to simply clone 'monero-gui' and give the option in the README to clone also the guide? Is there a better way to handle this? Should we just clone the GUI repo and include the guide only when the wallets is built? (as it happens for the 'monero' submodule).

- As @fluffypony suggested, the guide should be copied into the 'build' folder. I guess we need to edit the makefile to do that, but that goes beyond my knowledge. Could somebody take care of it?

@moneromooo-monero @rbrunner7 