### PR TITLE
Linking libsodium

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -118,7 +118,8 @@ LIBS += -L$$WALLET_ROOT/lib \
         -llmdb \
         -lepee \
         -lunbound \
-        -leasylogging \
+        -lsodium \
+        -leasylogging
 }
 
 android {
@@ -128,6 +129,7 @@ android {
         -llmdb \
         -lepee \
         -lunbound \
+        -lsodium \
         -leasylogging
 }
 
@@ -147,6 +149,7 @@ ios {
         -llmdb \
         -lepee \
         -lunbound \
+        -lsodium \
         -leasylogging
 
     LIBS+= \
@@ -246,6 +249,7 @@ win32 {
         -licutu \
         -liconv \
         -lssl \
+        -lsodium \
         -lcrypto \
         -Wl,-Bdynamic \
         -lwinscard \
@@ -291,6 +295,7 @@ linux {
         -lboost_program_options \
         -lssl \
         -llmdb \
+        -lsodium \
         -lcrypto
 
     if(!android) {
@@ -329,6 +334,7 @@ macx {
         -lboost_chrono \
         -lboost_program_options \
         -lssl \
+        -lsodium \
         -lcrypto \
         -ldl
     LIBS+= -framework PCSC


### PR DESCRIPTION
In preparation of 0.13; linking libsodium, which is required since https://github.com/monero-project/monero/pull/3999

This PR is similiar to #1540 but includes more platforms.

Closes #1540