### PR TITLE
README: update MSYS2 dependencies for Ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The Monero GUI on Windows is 64 bits only; 32-bit Windows GUI builds are not off
 3. Install MSYS2 packages for Monero dependencies; the needed 64-bit packages have `x86_64` in their names
 
     ```
-    pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium
+    pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi
     ```
 
     You find more details about those dependencies in the [Monero documentation](https://github.com/monero-project/monero). Note that that there is no more need to compile Boost from source; like everything else, you can install it now with a MSYS2 package.


### PR DESCRIPTION
Monero repo have added `mingw-w64-x86_64-hidapi` in [MSYS2 Mingw64 build instruction](https://github.com/monero-project/monero/commit/0656050f76c8aa9cd8845b0ddcc1df3f3fa378c0). So update here as well.