### PR TITLE
Replace string.startsWith() with string.indexOf()

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -339,7 +339,8 @@ Rectangle {
                   }
 
                   // The amount does not start with a period (example: `.4`)
-                  if(amountLine.text.startsWith('.')){
+                  // @TODO: replace with .startsWith() after Qt >=5.8
+                  if(amountLine.text.indexOf('.') === 0){
                       return false;
                   }
 


### PR DESCRIPTION
In preparation of 0.13; Qt 5.7 does not support `startsWith()`, replacing with `indexOf()`.