### PR TITLE
Fix build with smartcard

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -10,8 +10,8 @@ QT += qml quick widgets
 WALLET_ROOT=$$PWD/monero
 
 CONFIG += c++11 link_pkgconfig
-packagesExist(libpcsclite) {
-    PKGCONFIG += libpcsclite
+packagesExist(hidapi-libusb) {
+    PKGCONFIG += hidapi-libusb
 }
 !win32 {
     QMAKE_CXXFLAGS += -fPIC -fstack-protector -fstack-protector-strong


### PR DESCRIPTION
If monero-0.13.0.2 is build with smartcard support, monero-gui should be build with hidapi rather than pcsclite.