### PR TITLE
Print GUI version to stdout on application startup

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -35,6 +35,7 @@
 #include <QObject>
 #include <QDesktopWidget>
 #include <QScreen>
+#include <QRegExp>
 #include "clipboardAdapter.h"
 #include "filter.h"
 #include "oscursor.h"
@@ -140,10 +141,24 @@ int main(int argc, char *argv[])
     qreal physicalDpi = QGuiApplication::primaryScreen()->physicalDotsPerInch();
     qreal calculated_ratio = physicalDpi/ref_dpi;
 
-    qWarning().nospace() << "Qt:" << QT_VERSION_STR << " | screen: " << rect.width()
-                         << "x" << rect.height() << " - dpi: " << dpi << " - ratio:"
-                         << calculated_ratio;
+    QString GUI_VERSION = "-";
+    QFile f(":/version.js");
+    if(!f.open(QFile::ReadOnly)) {
+        qWarning() << "Could not read qrc:///version.js";
+    } else {
+        QByteArray contents = f.readAll();
+        f.close();
 
+        QRegularExpression re("var GUI_VERSION = \"(.*)\"");
+        QRegularExpressionMatch version_match = re.match(contents);
+        if (version_match.hasMatch()) {
+            GUI_VERSION = version_match.captured(1);  // "v0.13.0.3"
+        }
+    }
+
+    qWarning().nospace().noquote() << "Qt:" << QT_VERSION_STR << " GUI:" << GUI_VERSION
+                                   << " | screen: " << rect.width() << "x" << rect.height()
+                                   << " - dpi: " << dpi << " - ratio:" << calculated_ratio;
 
     // registering types for QML
     qmlRegisterType<clipboardAdapter>("moneroComponents.Clipboard", 1, 0, "Clipboard");


### PR DESCRIPTION
People often post application logs to debug problems and to be able to see their GUI version (without explicitly asking) would be beneficial. 

At runtime, QML is able to read the current GUI version by reading out `version.js` (registered as a resource in `qml.qrc`). We can access `version.js` by retrieving it from the Qt resource system in C++ in `main.cpp` and print it to stdout.

Prints: `Qt:5.7.1 GUI:v0.13.0.3 | screen: 2560x1440 - dpi: 96 - ratio:0.850684`

Fixes #1654

