### PR TITLE
Fix daemon host/port setting to allow tab switching

### DIFF
--- a/components/RemoteNodeEdit.qml
+++ b/components/RemoteNodeEdit.qml
@@ -63,7 +63,7 @@ GridLayout {
         return daemonAddr.text.trim() + ":" + daemonPort.text.trim()
     }
 
-    LineEditMulti {
+    LineEdit {
         id: daemonAddr
         Layout.fillWidth: true
         placeholderText: qsTr("Remote Node Hostname / IP") + translationManager.emptyString
@@ -81,7 +81,7 @@ GridLayout {
         onEditingFinished: root.editingFinished()
     }
 
-    LineEditMulti {
+    LineEdit {
         id: daemonPort
         Layout.fillWidth: true
         placeholderText: qsTr("Port") + translationManager.emptyString


### PR DESCRIPTION
Previously, these were multiline editing (for some reason I'm not sure,
perhaps you can have multiple remote nodes?)

I tried various workarounds, but the simplest was to change them to
simply LineEdit (like username/password) and now my bug is fixed.

Fixes #1688