### PR TITLE
Correction of View-Only Wallet description (see Issue #1610)

### DIFF
--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -182,7 +182,7 @@ Rectangle {
                     textMargin: 0
                     leftPadding: 0
                     topPadding: 0
-                    text: qsTr("Creates a new wallet that can only view transactions, cannot initialize transactions.") + translationManager.emptyString
+                    text: qsTr("Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.") + translationManager.emptyString
                     width: parent.width
                     readOnly: true
 

--- a/translations/monero-core.ts
+++ b/translations/monero-core.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_ar.ts
+++ b/translations/monero-core_ar.ts
@@ -1259,8 +1259,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>انشاء محفظه يمكنها فقط رؤيه المعملات ولا يمكنها القيام بمعاملات.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">انشاء محفظه يمكنها فقط رؤيه المعملات ولا يمكنها القيام بمعاملات.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_bg.ts
+++ b/translations/monero-core_bg.ts
@@ -1257,8 +1257,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Създаване на нов портфейл, който може само да вижда, но не и да осъществява транзакции</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Създаване на нов портфейл, който може само да вижда, но не и да осъществява транзакции</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_cat.ts
+++ b/translations/monero-core_cat.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_cs.ts
+++ b/translations/monero-core_cs.ts
@@ -1258,8 +1258,8 @@ Starý soubor s cache pamětí bude přejmenován a může být následně obnov
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Vytvoří peněženku, která umožňuje pouze prohlížení transakcí, nikoli vytvoření nových.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Vytvoří peněženku, která umožňuje pouze prohlížení transakcí, nikoli vytvoření nových.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_da.ts
+++ b/translations/monero-core_da.ts
@@ -1257,8 +1257,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Opretter en ny tegnebog der kun kan se transaktioner, ikke oprette transaktioner.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Opretter en ny tegnebog der kun kan se transaktioner, ikke oprette transaktioner.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -1257,8 +1257,8 @@ Die alte Wallet-Cache-Datei wird umbenannt und kann später wiederhergestellt we
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Erstellt eine Wallet, die nur Transaktionen ansehen aber keine Transaktionen initialisieren kann.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation>Erstellt eine Wallet, die nur Transaktionen ansehen und initiieren kann, jedoch eine vollwertige Wallet benötigt, um Transaktionen vor dem Absenden zu signieren.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_eo.ts
+++ b/translations/monero-core_eo.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_es.ts
+++ b/translations/monero-core_es.ts
@@ -1265,8 +1265,8 @@ El archivo de caché anterior del monedero será renombrado y puede ser posterio
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Crea un nuevo monedero que sólo puede ver transacciones, no puede inicializar transacciones.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Crea un nuevo monedero que sólo puede ver transacciones, no puede inicializar transacciones.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -1258,8 +1258,8 @@ Vanha lompakkovälimuistitiedosto nimetään uudelleen ja voidaan palauttaa myö
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Luo uuden lompakon joka voi vain seurata siirtoja mutta ei tehdä niitä.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Luo uuden lompakon joka voi vain seurata siirtoja mutta ei tehdä niitä.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_fr.ts
+++ b/translations/monero-core_fr.ts
@@ -1258,8 +1258,8 @@ L&apos;ancien fichier du cache du portefeuille sera renommé et pourra être res
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Crée un nouveau portefeuille pouvant seulement voir les transactions, pas en initier</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Crée un nouveau portefeuille pouvant seulement voir les transactions, pas en initier</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_he.ts
+++ b/translations/monero-core_he.ts
@@ -1258,8 +1258,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>יוצר ארנק שיכול רק לראות העברות אך לא לבצע אותן.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">יוצר ארנק שיכול רק לראות העברות אך לא לבצע אותן.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_hi.ts
+++ b/translations/monero-core_hi.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_hr.ts
+++ b/translations/monero-core_hr.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_hu.ts
+++ b/translations/monero-core_hu.ts
@@ -1257,8 +1257,8 @@ A régi gyorsítótár fájlja át lesz nevezve és bármikor visszaállítható
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Új (figyelő) tárca létrehozása amivel csak tranzakciókat lehet keresni, de nem lehet tranzakciót indítani.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Új (figyelő) tárca létrehozása amivel csak tranzakciókat lehet keresni, de nem lehet tranzakciót indítani.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_id.ts
+++ b/translations/monero-core_id.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_it.ts
+++ b/translations/monero-core_it.ts
@@ -1259,8 +1259,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Crea un nuovo portafoglio che può vedere solo le transazioni, non eseguirle.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Crea un nuovo portafoglio che può vedere solo le transazioni, non eseguirle.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_ja.ts
+++ b/translations/monero-core_ja.ts
@@ -1258,8 +1258,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>トランザクションを作成できず閲覧のみ可能な新しいウォレットを作成します。</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">トランザクションを作成できず閲覧のみ可能な新しいウォレットを作成します。</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_ko.ts
+++ b/translations/monero-core_ko.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_lt.ts
+++ b/translations/monero-core_lt.ts
@@ -1258,8 +1258,8 @@ Sena piniginės talpyklos rinkmena bus pervadinta ir vėliau galės būti atstat
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Sukuria naują piniginę, kuri gali tik peržiūrėti sandorius, bet negali inicijuoti operacijų.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Sukuria naują piniginę, kuri gali tik peržiūrėti sandorius, bet negali inicijuoti operacijų.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -1269,8 +1269,8 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Er wordt een nieuwe portemonnee gemaakt die alleen transacties kan weergeven maar geen transacties kan uitvoeren.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Er wordt een nieuwe portemonnee gemaakt die alleen transacties kan weergeven maar geen transacties kan uitvoeren.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_pl.ts
+++ b/translations/monero-core_pl.ts
@@ -1259,8 +1259,8 @@ Poprzednia pamięć podręczna portfela zostanie zapisana pod inną nazwą i mo�
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Tworzy portfel, który może jedynie wyświetlać transakcje, a nie dodawać nowe.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Tworzy portfel, który może jedynie wyświetlać transakcje, a nie dodawać nowe.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_prt.ts
+++ b/translations/monero-core_prt.ts
@@ -1251,7 +1251,7 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_pt-br.ts
+++ b/translations/monero-core_pt-br.ts
@@ -1258,8 +1258,8 @@ O arquivo de cache da carteira antiga será renomeado e poderá ser restaurado p
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Cria uma nova carteira que só pode exibir mas não pode inicializar transações.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Cria uma nova carteira que só pode exibir mas não pode inicializar transações.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_pt-pt.ts
+++ b/translations/monero-core_pt-pt.ts
@@ -1258,8 +1258,8 @@ O ficheiro de cache antigo será renomeado e poderá ser restaurado mais tarde.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Cria uma nova carteira que só pode ser usada para visualizar transações, não será possível executar transações</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Cria uma nova carteira que só pode ser usada para visualizar transações, não será possível executar transações</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_ro.ts
+++ b/translations/monero-core_ro.ts
@@ -1258,8 +1258,8 @@ Vechiul fișier cache va fi redenumit și va putea fi restaurat mai tâziu.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Crează un portofel nou care poate doar să vadă tranzacțiile, dar nu poate să inițializeze tranzacții.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Crează un portofel nou care poate doar să vadă tranzacțiile, dar nu poate să inițializeze tranzacții.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_ru.ts
+++ b/translations/monero-core_ru.ts
@@ -1258,8 +1258,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Создает новый кошелек, в котором можно только просматривать транзакции, но не отправлять их.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Создает новый кошелек, в котором можно только просматривать транзакции, но не отправлять их.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_sk.ts
+++ b/translations/monero-core_sk.ts
@@ -1258,8 +1258,8 @@ Súbor starej cache bude premenovaný a môže byť obnovený neskôr.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Vytvorí novú peňaženku, cez ktorú môžte len nahliadať na transakcie a nie je možné uskutočniť transakciu.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Vytvorí novú peňaženku, cez ktorú môžte len nahliadať na transakcie a nie je možné uskutočniť transakciu.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_sl.ts
+++ b/translations/monero-core_sl.ts
@@ -1257,8 +1257,8 @@ Stara datoteka predpomnilnika denarnice bo preimenovana in se jo lahko obnovi po
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Ustvari novo denarnico, ki omogoča samo vpogled do transakcij, ne more pa jih ustvariti.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Ustvari novo denarnico, ki omogoča samo vpogled do transakcij, ne more pa jih ustvariti.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_sr.ts
+++ b/translations/monero-core_sr.ts
@@ -1257,8 +1257,8 @@ Stari fajl keša novčanika će biti preimenovan i može se povratiti kasnije.</
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Pravi novčanik koji može samo da posmatra transakcije, ne može ih inicijalizirati.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Pravi novčanik koji može samo da posmatra transakcije, ne može ih inicijalizirati.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_sv.ts
+++ b/translations/monero-core_sv.ts
@@ -1257,8 +1257,8 @@ Den gamla plånbokens cache-fil kommer att ändra namn och kan återställas sen
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Skapar en ny plånbok som endast kan visa transaktioner, kan inte initiera transaktioner.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Skapar en ny plånbok som endast kan visa transaktioner, kan inte initiera transaktioner.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_tr.ts
+++ b/translations/monero-core_tr.ts
@@ -1258,8 +1258,8 @@ Aşağıdaki bilgiler silinecek
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>İşlem yapamayan, yalnızca yapılan işlemleri görüntüleyen yeni bir cüzdan oluşturur.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">İşlem yapamayan, yalnızca yapılan işlemleri görüntüleyen yeni bir cüzdan oluşturur.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_uk.ts
+++ b/translations/monero-core_uk.ts
@@ -1257,8 +1257,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>Створює новий гаманець, в якому можна тільки переглядати транзакції, але не відправляти їх.</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">Створює новий гаманець, в якому можна тільки переглядати транзакції, але не відправляти їх.</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_zh-cn.ts
+++ b/translations/monero-core_zh-cn.ts
@@ -1258,8 +1258,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>创建一个新钱包，该钱包只能用来查看交易而不能发起交易。</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">创建一个新钱包，该钱包只能用来查看交易而不能发起交易。</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>

--- a/translations/monero-core_zh-tw.ts
+++ b/translations/monero-core_zh-tw.ts
@@ -1258,8 +1258,8 @@ The old wallet cache file will be renamed and can be restored later.
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="185"/>
-        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>
-        <translation>建立新的唯讀錢包，該錢包僅能查看交易，無法啟動交易。</translation>
+        <source>Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.</source>
+        <translation type="unfinished">建立新的唯讀錢包，該錢包僅能查看交易，無法啟動交易。</translation>
     </message>
     <message>
         <location filename="../pages/settings/SettingsWallet.qml" line="220"/>


### PR DESCRIPTION
* changed

<location filename="../pages/settings/SettingsWallet.qml" line="185"/>
        <source>Creates a new wallet that can only view transactions, cannot initialize transactions.</source>

to

Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.

* Updated all translations and added "unfinished" tag where necessary

* Updated german translation