### PR TITLE
wizard: optionally hide restore 'From QR Code' btn

### DIFF
--- a/wizard/WizardManageWalletUI.qml
+++ b/wizard/WizardManageWalletUI.qml
@@ -207,7 +207,7 @@ ColumnLayout {
         StandardButton {
             id: qrfinderButton
             text: qsTr("From QR Code") + translationManager.emptyString
-            visible : true //appWindow.qrScannerEnabled
+            visible : appWindow.qrScannerEnabled
             enabled : visible
             onClicked: {
                 cameraUi.state = "Capture"


### PR DESCRIPTION
Hide the button if we can't scan the code anyway (scanner/camera is disabled)

![restore-qr](https://user-images.githubusercontent.com/26060097/47610111-a0795800-da3c-11e8-8224-6b08b5ddbe10.png)
