### PR TITLE
Debian 9 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Packaging for your favorite distribution would be a welcome contribution!
 
   - For Ubuntu 17.10+
 
-    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-xmllistmodel qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel qttools5-dev-tools`
+    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-xmllistmodel qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel qttools5-dev-tools qml-module-qtquick-templates2`
 
   - For Gentoo
 


### PR DESCRIPTION
Without the qml-module-qtquick-templates2 package after building the binaries and attempting to run them you'll see errors like this. After installing the package I was able to run the GUI just fine. This package appears to be in Ubuntu as well so I'm adding it under there.

```
user@host:~/Wallets/monero$ ./monero-wallet-gui
2018-10-28 16:11:18,023 INFO  [default] Page size: 4096
2018-10-28 16:11:19.064     7536ddfb77c0        WARN    frontend        src/wallet/api/wallet.cpp:367   app startd (log: /home/user/monero-wallet-gui.log)
2018-10-28 16:11:19.065     7536ddfb77c0        WARN    frontend        src/wallet/api/wallet.cpp:367   Qt:5.7.1 | screen: 1600x900 - dpi: 96.063 - ratio:0.750492
2018-10-28 16:11:19.382     7536ddfb77c0        WARN    frontend        src/wallet/api/wallet.cpp:367   QQmlApplicationEngine failed to load component
2018-10-28 16:11:19.382     7536ddfb77c0        WARN    frontend        src/wallet/api/wallet.cpp:367   qrc:///main.qml:1434 Type MiddlePanel unavailable
qrc:///MiddlePanel.qml:42 Type Transfer unavailable
qrc:///pages/Transfer.qml:88 Type StandardDialog unavailable
qrc:///components/StandardDialog.qml:117 Type TextArea unavailable
file:///usr/lib/x86_64-linux-gnu/qt5/qml/QtQuick/Controls.2/TextArea.qml:38 module "QtQuick.Templates" is not installed

2018-10-28 16:11:19.383     7536ddfb77c0        ERROR   frontend        src/wallet/api/wallet.cpp:371   Error: no root objects
```