### PR TITLE
German translation: fixed missing line break

### DIFF
--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -2741,7 +2741,8 @@ Beschreibung: </translation>
         <location filename="../main.qml" line="644"/>
         <source>
 Spending address index: </source>
-        <translation>Indizes der beteiligten Adressen: </translation>
+        <translation>
+Indizes der beteiligten Adressen: </translation>
     </message>
     <message>
         <location filename="../main.qml" line="688"/>


### PR DESCRIPTION
In the german translation there is a missing line break in the window where you confirm your transaction.