### PR TITLE
Adding pricing/fiat conversion functionality

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -42,6 +42,8 @@ Rectangle {
     property alias unlockedBalanceLabelVisible: unlockedBalanceLabel.visible
     property alias balanceLabelText: balanceLabel.text
     property alias balanceText: balanceText.text
+    property alias balanceTextFiat: balanceTextFiat.text
+    property alias unlockedBalanceTextFiat: unlockedBalanceTextFiat.text
     property alias networkStatus : networkStatus
     property alias progressBar : progressBar
     property alias daemonProgressBar : daemonProgressBar
@@ -105,6 +107,12 @@ Rectangle {
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.topMargin: (persistentSettings.customDecorations)? 50 : 0
+
+        MouseArea {
+            id: balanceArea
+            anchors.fill: parent
+            hoverEnabled: true
+        }
 
         RowLayout {
             visible: true
@@ -191,7 +199,10 @@ Rectangle {
                 width: 50 * scaleRatio
 
                 Text {
-                    visible: !isMobile
+                    visible: !isMobile && !(balanceArea.containsMouse
+                                            && builtWithPrices
+                                            && persistentSettings.enableCurrencyConversion
+                                            && priceManager.priceReady)
                     id: balanceText
                     anchors.left: parent.left
                     anchors.leftMargin: 20
@@ -229,8 +240,24 @@ Rectangle {
                 }
 
                 Text {
+                    visible: !isMobile && !balanceText.visible
+                    id: balanceTextFiat
+                    anchors.left: parent.left
+                    anchors.leftMargin: 20
+                    anchors.top: parent.top
+                    anchors.topMargin: 76
+                    font.family: "Arial"
+                    color: "#FFFFFF"
+                    text: "N/A"
+                    font.pixelSize: balanceText.font.pixelSize
+                }
+
+                Text {
                     id: unlockedBalanceText
-                    visible: true
+                    visible: !(balanceArea.containsMouse
+                               && builtWithPrices
+                               && persistentSettings.enableCurrencyConversion
+                               && priceManager.priceReady)
                     anchors.left: parent.left
                     anchors.leftMargin: 20
                     anchors.top: parent.top
@@ -264,6 +291,21 @@ Rectangle {
                                 appWindow.showStatusMessage(qsTr("Copied to clipboard"),3)
                         }
                     }
+                }
+
+
+                Text {
+                    id: unlockedBalanceTextFiat
+                    visible: !unlockedBalanceText.visible
+                    anchors.left: parent.left
+                    anchors.leftMargin: 20
+                    anchors.top: parent.top
+                    anchors.topMargin: 126
+                    font.family: "Arial"
+                    color: "#FFFFFF"
+                    text: "N/A"
+                    // dynamically adjust text size
+                    font.pixelSize: unlockedBalanceText.font.pixelSize
                 }
 
                 MoneroComponents.Label {

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ find_command() {
 
 if [ "$BUILD_TYPE" == "release" ]; then
     echo "Building release"
-    CONFIG="CONFIG+=release";
+    CONFIG="CONFIG+=release WITH_PRICES";
     BIN_PATH=release/bin
 elif [ "$BUILD_TYPE" == "release-static" ]; then
     echo "Building release-static"
@@ -53,7 +53,7 @@ elif [ "$BUILD_TYPE" == "debug-android" ]; then
     DISABLE_PASS_STRENGTH_METER=true
 elif [ "$BUILD_TYPE" == "debug" ]; then
     echo "Building debug"
-	CONFIG="CONFIG+=debug"
+	CONFIG="CONFIG+=debug WITH_PRICES"
     BIN_PATH=debug/bin
 else
     echo "Valid build types are release, release-static, release-android, debug-android and debug"

--- a/components/StandardDropdown.qml
+++ b/components/StandardDropdown.qml
@@ -34,6 +34,7 @@ Item {
     id: dropdown
     property int itemTopMargin: 0
     property alias dataModel: repeater.model
+    property alias colText: firstColText.text
     property string shadowPressedColor
     property string shadowReleasedColor
     property string pressedColor

--- a/main.cpp
+++ b/main.cpp
@@ -70,6 +70,14 @@
 #include "QrCodeScanner.h"
 #endif
 
+#ifdef WITH_PRICES
+#include "prices/Currency.h"
+#include "prices/PriceManager.h"
+#include "prices/PriceSource.h"
+#include "prices/PriceSourceSelectorModel.h"
+#include "prices/CurrencySelectorModel.h"
+#endif
+
 bool isIOS = false;
 bool isAndroid = false;
 bool isWindows = false;
@@ -209,6 +217,22 @@ int main(int argc, char *argv[])
 
     qmlRegisterUncreatableType<Subaddress>("moneroComponents.Subaddress", 1, 0, "Subaddress",
                                                         "Subaddress can't be instantiated directly");
+#ifdef WITH_PRICES
+    qmlRegisterUncreatableType<PriceManager>("moneroComponents.PriceManager", 1, 0, "PriceManager",
+                                                        "PriceManager can't be instantiated directly");
+
+    qmlRegisterUncreatableType<PriceSource>("moneroComponents.PriceSource", 1, 0, "PriceSource",
+                                                        "PriceSource can't be instantiated directly");
+
+    qmlRegisterUncreatableType<PriceSourceSelectorModel>("moneroComponents.PriceSourceSelectorModel", 1, 0, "PriceSourceSelectorModel",
+                                                        "PriceSourceSelectorModel can't be instantiated directly");
+
+    qmlRegisterUncreatableType<Currency>("moneroComponents.Currency", 1, 0, "Currency",
+                                                        "Currency can't be instantiated directly");
+
+    qmlRegisterUncreatableType<CurrencySelectorModel>("moneroComponents.CurrencySelectorModel", 1, 0, "CurrencySelectorModel",
+                                                        "CurrencySelectorModel can't be instantiated directly");
+#endif
 
     qmlRegisterUncreatableType<SubaddressAccountModel>("moneroComponents.SubaddressAccountModel", 1, 0, "SubaddressAccountModel",
                                                         "SubaddressAccountModel can't be instantiated directly");
@@ -248,6 +272,9 @@ int main(int argc, char *argv[])
 
     engine.rootContext()->setContextProperty("walletLogPath", logPath);
 
+#ifdef WITH_PRICES
+    engine.rootContext()->setContextProperty("priceManager", PriceManager::instance(engine.networkAccessManager()));
+#endif
 // Exclude daemon manager from IOS
 #ifndef Q_OS_IOS
     const QStringList arguments = (QStringList) QCoreApplication::arguments().at(0);
@@ -307,6 +334,12 @@ int main(int argc, char *argv[])
     builtWithScanner = true;
 #endif
     engine.rootContext()->setContextProperty("builtWithScanner", builtWithScanner);
+
+    bool builtWithPrices = false;
+#ifdef WITH_PRICES
+    builtWithPrices = true;
+#endif
+    engine.rootContext()->setContextProperty("builtWithPrices", builtWithPrices);
 
     // Load main window (context properties needs to be defined obove this line)
     engine.load(QUrl(QStringLiteral("qrc:///main.qml")));

--- a/main.qml
+++ b/main.qml
@@ -245,6 +245,10 @@ ApplicationWindow {
         // enable timers
         userInActivityTimer.running = true;
         simpleModeConnectionTimer.running = true;
+        // Start the price manager if applicable
+        if (builtWithPrices && persistentSettings.enableCurrencyConversion) {
+            startPriceManager();
+        }
 
         // wallet already opened with wizard, we just need to initialize it
         if (typeof wizard.m_wallet !== 'undefined') {
@@ -385,6 +389,17 @@ ApplicationWindow {
         if(!hideBalanceForced && !persistentSettings.hideBalance){
             balance_unlocked = walletManager.displayAmount(currentWallet.unlockedBalance(currentWallet.currentSubaddressAccount));
             balance = walletManager.displayAmount(currentWallet.balance(currentWallet.currentSubaddressAccount));
+        }
+
+        if (builtWithPrices && persistentSettings.enableCurrencyConversion) {
+            var balance_unlocked_fiat = qsTr("HIDDEN");
+            var balance_fiat = qsTr("HIDDEN");
+            if(!hideBalanceForced && !persistentSettings.hideBalance){
+                balance_unlocked_fiat = priceManager.convert(currentWallet.unlockedBalance(currentWallet.currentSubaddressAccount));
+                balance_fiat = priceManager.convert(currentWallet.balance(currentWallet.currentSubaddressAccount));
+            }
+            leftPanel.unlockedBalanceTextFiat = balance_unlocked_fiat;
+            leftPanel.balanceTextFiat = balance_fiat;
         }
 
         middlePanel.unlockedBalanceText = balance_unlocked;
@@ -985,6 +1000,29 @@ ApplicationWindow {
         console.log(appWindow.width)
     }
 
+    function startPriceManager() {
+        console.log("Starting PriceManager");
+        var sourceIdx = priceManager.priceSourcesAvailableModel.index(persistentSettings.currencyConversionSourceIndex, 0);
+        priceManager.setPriceSource(sourceIdx);
+        var currencyIdx = priceManager.currenciesAvailableModel.index(persistentSettings.currencyConversionCurrencyIndex, 0);
+        priceManager.setCurrency(currencyIdx);
+        priceManager.priceRefreshed.connect(updateBalance);
+        priceManager.start();
+    }
+
+    function stopPriceManager() {
+        console.log("Stopping PriceManager");
+        priceManager.priceRefreshed.disconnect(updateBalance);
+        priceManager.stop();
+    }
+
+    function setPriceManager(bool) {
+        if (bool && !priceManager.running)
+            startPriceManager();
+        if (!bool && priceManager.running)
+            stopPriceManager();
+    }
+
 
     objectName: "appWindow"
     visible: true
@@ -1090,6 +1128,9 @@ ApplicationWindow {
         property string remoteNodeService: ""
         property int lockOnUserInActivityInterval: 10  // minutes
         property bool showPid: false
+        property bool enableCurrencyConversion: false
+        property int currencyConversionSourceIndex: 0
+        property int currencyConversionCurrencyIndex: 0
     }
 
     // Information dialog

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -198,6 +198,26 @@ CONFIG(WITH_SCANNER) {
     }
 }
 
+CONFIG(WITH_PRICES) {
+    message("building with prices")
+    DEFINES += "WITH_PRICES"
+    HEADERS += \
+        src/prices/Currency.h \
+        src/prices/Price.h \
+        src/prices/PriceSource.h \
+        src/prices/CurrencySelectorModel.h \
+        src/prices/PriceSourceSelectorModel.h \
+        src/prices/PriceManager.h \
+        src/prices/qtjsonpath.h
+    SOURCES += \
+        src/prices/Currency.cpp \
+        src/prices/Price.cpp \
+        src/prices/PriceSource.cpp \
+        src/prices/CurrencySelectorModel.cpp \
+        src/prices/PriceSourceSelectorModel.cpp \
+        src/prices/PriceManager.cpp
+}
+
 
 # currently we only support x86 build as qt.io only provides prebuilt qt for x86 mingw
 

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -182,6 +182,85 @@ Rectangle {
             Layout.fillWidth: true
             text: qsTr("No Layout options exist yet in mobile mode.") + translationManager.emptyString;
         }
+        //! Manage pricing
+
+        RowLayout {
+            MoneroComponents.CheckBox {
+                visible: builtWithPrices
+                id: enableConvertCurrency
+                text: qsTr("Enable displaying balance in other currencies") + translationManager.emptyString
+                checked: persistentSettings.enableCurrencyConversion
+                onCheckedChanged: {
+                    persistentSettings.enableCurrencyConversion = checked;
+                    appWindow.setPriceManager(checked);
+                }
+            }
+        }
+
+        GridLayout {
+            visible: builtWithPrices && enableConvertCurrency.checked
+            columns: (isMobile)? 1 : 2
+            Layout.fillWidth: true
+            columnSpacing: 32
+
+            ColumnLayout {
+                spacing: 0
+                Layout.fillWidth: true
+
+                MoneroComponents.StandardDropdown {
+                    id: priceSourceDropDown
+                    dataModel: priceManager.priceSourcesAvailableModel
+                    currentIndex: appWindow.persistentSettings.currencyConversionSourceIndex
+                    onChanged: {
+                        var idx = dataModel.index(currentIndex, 0);
+                        priceManager.setPriceSource(idx);
+                        appWindow.persistentSettings.currencyConversionSourceIndex = currentIndex;
+                    }
+                    Layout.fillWidth: true
+                    shadowReleasedColor: "#FF4304"
+                    shadowPressedColor: "#B32D00"
+                    releasedColor: "#363636"
+                    pressedColor: "#202020"
+
+                    function update() {
+                        colText = dataModel.getLabelAt(currentIndex);
+                    }
+                }
+            }
+
+            ColumnLayout {
+                spacing: 0
+                Layout.fillWidth: true
+
+                MoneroComponents.StandardDropdown {
+                    id: currencyDropDown
+                    dataModel: priceManager.currenciesAvailableModel
+                    currentIndex: appWindow.persistentSettings.currencyConversionCurrencyIndex
+                    onChanged: {
+                        var idx = dataModel.index(currentIndex, 0);
+                        priceManager.setCurrency(idx);
+                        appWindow.persistentSettings.currencyConversionCurrencyIndex = currentIndex;
+                    }
+                    Layout.fillWidth: true
+                    shadowReleasedColor: "#FF4304"
+                    shadowPressedColor: "#B32D00"
+                    releasedColor: "#363636"
+                    pressedColor: "#202020"
+
+                    function update() {
+                        colText = dataModel.getLabelAt(currentIndex);
+                    }
+                }
+
+                // Make sure dropdown is on top
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+            }
+
+            z: parent.z + 1
+        }
     }
 
     Component.onCompleted: {

--- a/src/prices/Currency.cpp
+++ b/src/prices/Currency.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "Currency.h"
+
+#include "QLocale"
+
+namespace Currencies {
+    Currency * const USD = new Currency(
+                QStringLiteral("USD"),
+                QChar('$'),
+                2);
+    Currency * const GBP = new Currency(
+                QStringLiteral("GBP"),
+                QChar(0x00A3),
+                2);
+    Currency * const EUR = new Currency(
+                QStringLiteral("EUR"),
+                QChar(0x20AC),
+                2);
+    Currency * const JPY = new Currency(
+                QStringLiteral("JPY"),
+                QChar(0x00A5),
+                2);
+    Currency * const CNY = new Currency(
+                QStringLiteral("CNY"),
+                QChar(0x00A5),
+                2);
+    Currency * const KRW = new Currency(
+                QStringLiteral("KRW"),
+                QChar(0x20A9),
+                0);
+    Currency * const BTC = new Currency(
+                QStringLiteral("BTC"),
+                // Using a Thai Bhat symbol right now since most OS fonts still don't support Unicode 10
+                QChar(0x0E3F),
+                9);
+    Currency * const ETH = new Currency(
+                QStringLiteral("ETH"),
+                QChar(0x039E),
+                6);
+}
+
+
+Currency::Currency(const QString label, const QChar symbol, const int precision, QObject *parent) :
+    QObject(parent),
+    m_label(label),
+    m_symbol(symbol),
+    m_precision(precision)
+{
+}
+
+QString Currency::label() const
+{
+    return m_label;
+}
+
+QChar Currency::symbol() const
+{
+    return m_symbol;
+}
+
+int Currency::precision() const
+{
+    return m_precision;
+}
+
+QString Currency::format(qreal amount) const
+{
+    return QLocale().toCurrencyString(amount, m_symbol, m_precision);
+}
+
+

--- a/src/prices/Currency.h
+++ b/src/prices/Currency.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifndef CURRENCY_H
+#define CURRENCY_H
+
+#include <QObject>
+#include <QList>
+
+class Currency : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString label READ label)
+    Q_PROPERTY(QChar symbol READ symbol)
+    Q_PROPERTY(int precision READ precision)
+public:
+    explicit Currency(const QString label = nullptr, const QChar symbol = 0, const int precision = 0, QObject *parent = nullptr);
+
+    QString label() const;
+    QChar symbol() const;
+    int precision() const;
+    Q_INVOKABLE QString format(qreal amount) const;
+
+private:
+    const QString m_label;
+    const QChar m_symbol;
+    const int m_precision;
+};
+
+namespace Currencies {
+    extern Currency * const USD;
+    extern Currency * const GBP;
+    extern Currency * const EUR;
+    extern Currency * const JPY;
+    extern Currency * const CNY;
+    extern Currency * const KRW;
+    extern Currency * const BTC;
+    extern Currency * const ETH;
+}
+
+#endif // CURRENCY_H

--- a/src/prices/CurrencySelectorModel.cpp
+++ b/src/prices/CurrencySelectorModel.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "CurrencySelectorModel.h"
+
+#include <QDebug>
+
+CurrencySelectorModel::CurrencySelectorModel(QObject *parent) :
+    QAbstractListModel(parent)
+{
+    m_availableCurrencies = QList<Currency*>();
+}
+
+QList<Currency*> CurrencySelectorModel::availableCurrencies() const
+{
+    return m_availableCurrencies;
+}
+
+QString CurrencySelectorModel::getLabelAt(int index) const
+{
+    QVariant var = this->data(this->index(index), CurrencyLabelRole);
+    if (var.isNull())
+        return QString();
+    return var.toString();
+}
+
+QVariant CurrencySelectorModel::data(const QModelIndex &index, int role) const
+{
+    if (m_availableCurrencies.empty()) {
+        qWarning() << __FUNCTION__ << ": Available currencies are empty.";
+        return QVariant();
+    }
+    if (index.row() < 0 || index.row() >= m_availableCurrencies.count()) {
+        qWarning() << __FUNCTION__ << ": Currency index " << index.row() << " is OOB.";
+        return QVariant();
+    }
+
+    Currency * currency = m_availableCurrencies.at(index.row());
+    if (!currency) {
+        qCritical() << __FUNCTION__ << ": internal error: no currency info for index " << index.row();
+        return QVariant();
+    }
+
+    QVariant result;
+    switch (role) {
+    case CurrencyRole:
+        result = QVariant::fromValue(currency);
+        break;
+    case CurrencyLabelRole:
+    case CurrencySimpleDropdownRole:
+        result = currency->label();
+        break;
+    case CurrencySymbolRole:
+        result = currency->symbol();
+        break;
+    default:
+        result = currency->label();
+        break;
+    }
+
+    return result;
+}
+
+int CurrencySelectorModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return m_availableCurrencies.count();
+}
+
+QHash<int, QByteArray> CurrencySelectorModel::roleNames() const
+{
+    static QHash<int, QByteArray> roleNames;
+    if (roleNames.empty())
+    {
+        roleNames.insert(CurrencyRole, "currency");
+        roleNames.insert(CurrencyLabelRole, "label");
+        roleNames.insert(CurrencySymbolRole, "symbol");
+        roleNames.insert(CurrencySimpleDropdownRole, "column1");
+    }
+    return roleNames;
+}
+
+void CurrencySelectorModel::setAvailableCurrencies(QList<Currency*> currencies)
+{
+    beginResetModel();
+    m_availableCurrencies = QList<Currency*>(currencies);
+    endResetModel();
+    emit availableCurrenciesChanged();
+}

--- a/src/prices/CurrencySelectorModel.h
+++ b/src/prices/CurrencySelectorModel.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifndef CURRENCYSELECTORMODEL_H
+#define CURRENCYSELECTORMODEL_H
+
+#include <QAbstractListModel>
+
+#include "Currency.h"
+
+class CurrencySelectorModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QList<Currency*> availableCurrencies READ availableCurrencies NOTIFY availableCurrenciesChanged)
+public:
+    enum CurrencyViewRole {
+        CurrencyRole =  Qt::UserRole + 1,
+        CurrencyLabelRole,
+        CurrencySimpleDropdownRole,
+        CurrencySymbolRole
+    };
+    Q_ENUM(CurrencyViewRole)
+
+    explicit CurrencySelectorModel(QObject *parent = nullptr);
+    QList<Currency*> availableCurrencies() const;
+
+    Q_INVOKABLE QString getLabelAt(int index) const;
+
+    virtual QVariant data(const QModelIndex & index, int role) const override;
+    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual QHash<int, QByteArray> roleNames() const  override;
+
+
+private:
+    void setAvailableCurrencies(QList<Currency*> currencies);
+signals:
+    void availableCurrenciesChanged();
+
+public slots:
+
+private:
+    friend class PriceManager;
+    QList<Currency*> m_availableCurrencies;
+};
+
+#endif // CURRENCYSELECTORMODEL_H

--- a/src/prices/Price.cpp
+++ b/src/prices/Price.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "Price.h"
+
+#include <QDateTime>
+#include <QLocale>
+#include <QDebug>
+
+#include "Currency.h"
+
+namespace {
+    static const qint64 DEFAULT_STALE_TIME_MILLISECONDS = 900 * 1000;
+    static const qint64 MONERO_STANDARD_UNIT = 1000000000000;
+}
+
+Price::Price(QObject *parent) : QObject(parent),
+    m_price(0),
+    m_currency(Currencies::BTC)
+{
+    m_lastUpdated = QDateTime();
+}
+
+void Price::update(qreal price, Currency * currency)
+{
+    m_price = price;
+    m_currency = currency;
+    m_lastUpdated = QDateTime::currentDateTimeUtc();
+    qDebug() << __FUNCTION__ << ": Updated price: " << m_price << ", currency: " << m_currency << ", last updated: " << m_lastUpdated.toString();
+    emit updated();
+}
+
+QString Price::currencyCode() const
+{
+    return m_currency->label();
+}
+
+qreal Price::price() const
+{
+    return m_price;
+}
+
+QDateTime Price::lastUpdated() const
+{
+    return m_lastUpdated;
+}
+
+bool Price::stale() const
+{
+    return m_lastUpdated.isNull() ||
+            (QDateTime::currentMSecsSinceEpoch() - m_lastUpdated.toMSecsSinceEpoch() > DEFAULT_STALE_TIME_MILLISECONDS);
+}
+
+QString Price::convert(quint64 amount) const
+{
+    if (stale()) {
+        qWarning() << __FUNCTION__ << ": convert() called while price is stale (last updated: " << m_lastUpdated.toString() << ")";
+        return QString();
+    }
+
+    if (!m_currency) {
+        qWarning() << __FUNCTION__ << ": convert() called when no currency was selected";
+        return QString();
+    }
+
+    qreal total = amount * m_price / MONERO_STANDARD_UNIT;
+    return m_currency->format(total);
+}
+
+Currency * Price::currency() const
+{
+    return m_currency;
+}

--- a/src/prices/Price.h
+++ b/src/prices/Price.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifndef PRICE_H
+#define PRICE_H
+
+#include <QObject>
+#include <QDateTime>
+#include <QString>
+
+#include "Currency.h"
+
+class PriceManager;
+
+class Price : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal price READ price NOTIFY updated)
+    Q_PROPERTY(QString currencyCode READ currencyCode NOTIFY updated)
+    Q_PROPERTY(QDateTime lastUpdated READ lastUpdated NOTIFY updated)
+    Q_PROPERTY(Currency * currency READ currency NOTIFY updated)
+    Q_PROPERTY(bool stale READ stale NOTIFY updated)
+public:
+    qreal price() const;
+    Currency * currency() const;
+    QString currencyCode() const;
+    QDateTime lastUpdated() const;
+    bool stale() const;
+    Q_INVOKABLE QString convert(quint64 amount) const;
+
+signals:
+    // Emitted when update is called
+    void updated();
+
+public:
+    explicit Price(QObject *parent = nullptr);
+    void update(qreal price, Currency *currency);
+
+private:
+    friend class PriceManager;
+    friend class PriceSource;
+    qreal m_price;
+    Currency * m_currency;
+    QDateTime m_lastUpdated;
+};
+
+#endif // PRICE_H

--- a/src/prices/PriceManager.cpp
+++ b/src/prices/PriceManager.cpp
@@ -1,0 +1,323 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "PriceManager.h"
+
+#include <QTimer>
+#include <QUrl>
+#include <QString>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QDebug>
+
+#include "Price.h"
+#include "Currency.h"
+#include "PriceSource.h"
+#include "CurrencySelectorModel.h"
+#include "PriceSourceSelectorModel.h"
+
+
+namespace {
+    static const int DEFAULT_REFRESH_PERIOD_MILLISECONDS = 15 * 1000;
+    static const QByteArray USER_AGENT = "Mozilla 5.0";
+}
+
+PriceManager * PriceManager::m_instance = nullptr;
+
+PriceManager *PriceManager::instance(QNetworkAccessManager *networkAccessManager)
+{
+    if (!m_instance) {
+        qDebug() << __FUNCTION__ << ": Creating new PriceManager";
+        m_instance = new PriceManager(networkAccessManager);
+    }
+
+    return m_instance;
+}
+
+PriceManager::PriceManager(QNetworkAccessManager *manager, QObject *parent) :
+    QObject(parent),
+    m_manager(manager),
+    m_reply(nullptr),
+    m_timer(nullptr),
+    m_currentPrice(nullptr),
+    m_currentCurrency(nullptr),
+    m_currentPriceSource(nullptr),
+    m_priceSourcesAvailableModel(nullptr),
+    m_currenciesAvailableModel(nullptr)
+{
+    m_running = false;
+    m_refreshing = false;
+    m_currentPrice = new Price(this);
+    m_timer = new QTimer(this);
+
+    PriceManager * pm = const_cast<PriceManager*>(this);
+    m_priceSourcesAvailableModel = new PriceSourceSelectorModel(pm, m_priceSourcesAvailable);
+    m_currenciesAvailableModel = new CurrencySelectorModel(pm);
+
+    connect(m_timer, SIGNAL(timeout()), this, SLOT(runPriceRefresh()));
+    connect(this, SIGNAL(priceSourceChanged()), this, SLOT(updateCurrenciesAvailable()));
+    connect(this, SIGNAL(priceSourceChanged()), this, SLOT(restart()));
+    connect(this, SIGNAL(currencyChanged()), this, SLOT(restart()));
+}
+
+PriceManager::PriceManager(QObject *parent) :
+    PriceManager(nullptr, parent)
+{
+}
+
+void PriceManager::start()
+{
+    qDebug() << __FUNCTION__ << ": Starting PriceManager";
+    emit starting();
+    m_running = true;
+    runPriceRefresh();
+    m_timer->start(DEFAULT_REFRESH_PERIOD_MILLISECONDS);
+}
+
+void PriceManager::stop()
+{
+    qDebug() << __FUNCTION__ << ": Stopping PriceManager";
+    emit stopping();
+    m_timer->stop();
+    abortReply();
+    m_running = false;
+    emit stopped();
+}
+
+void PriceManager::restart()
+{
+    stop();
+    start();
+}
+
+void PriceManager::abortReply()
+{
+    if (m_reply && m_reply->isRunning()) {
+        m_reply->abort();
+        m_reply->deleteLater();
+    }
+}
+
+void PriceManager::runPriceRefresh()
+{
+    if (!m_currentPriceSource || !m_currentCurrency) {
+        qDebug() << __FUNCTION__ << ": Cannot refresh price without a price source or currency set; NOOP";
+        return;
+    }
+
+    if (refreshing()) {
+        qWarning() << __FUNCTION__ << ": Refresh called while in process of refreshing; aborting current reply";
+        abortReply();
+    }
+
+    emit priceRefreshStarted();
+    m_refreshing = true;
+
+    QUrl reqUrl = m_currentPriceSource->renderUrl(m_currentCurrency);
+
+    QNetworkRequest request;
+    request.setUrl(reqUrl);
+    request.setRawHeader("User-Agent", USER_AGENT);
+
+    m_reply = m_manager->get(request);
+
+    connect(m_reply, SIGNAL(finished()), this, SLOT(handleHTTPFinished()));
+}
+
+void PriceManager::handleHTTPFinished()
+{
+    m_refreshing = false;
+
+    if (!m_reply)
+        return;
+
+    if (m_reply->error() == QNetworkReply::NoError)
+        updatePrice();
+    else
+        handleNetworkError();
+
+    m_reply->deleteLater();
+}
+
+void PriceManager::updatePrice()
+{
+    QByteArray data = m_reply->readAll();
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &error);
+
+    if (doc.isNull()) {
+        handleError(error.errorString());
+    }
+
+    if (!doc.isObject()) {
+        handleError("PriceManager: Could not parse response JSON as object: " + doc.toJson());
+        return;
+    }
+
+    bool success = m_currentPriceSource->updatePriceFromReply(m_currentPrice, m_currentCurrency, doc);
+
+    qDebug() << __FUNCTION__ << ": Got price " << m_currentPrice->price() << " for " << m_currentPrice->currency()->label();
+    if (success)
+        emit priceRefreshed();
+}
+
+void PriceManager::handleError(const QString &msg) const
+{
+    qCritical() << __FUNCTION__ << ": Error: " << msg;
+}
+
+void PriceManager::handleNetworkError()
+{
+    emit networkError();
+    handleError("Network error: " + m_reply->errorString());
+}
+
+Price * PriceManager::price() const
+{
+    return m_currentPrice;
+}
+
+QString PriceManager::convert(quint64 amount) const
+{
+    return m_currentPrice->convert(amount);
+}
+
+QList<PriceSource*> PriceManager::priceSourcesAvailable() const
+{
+    return m_priceSourcesAvailable;
+}
+
+
+PriceSourceSelectorModel *PriceManager::priceSourcesAvailableModel() const
+{
+    return m_priceSourcesAvailableModel;
+}
+
+
+QList<Currency*> PriceManager::currenciesAvailable() const
+{
+    if (!m_currentPriceSource)
+        return QList<Currency*>();
+    return m_currentPriceSource->currenciesAvailable();
+}
+
+void PriceManager::setPriceSource(int index)
+{
+    if (index < 0 || index >= m_priceSourcesAvailable.count()) {
+        qWarning() << __FUNCTION__ << ": Bad index " << index << " passed to setPriceSource; NOOP";
+        return;
+    }
+
+    m_currentPriceSource = m_priceSourcesAvailable.at(index);
+    emit priceSourceChanged();
+}
+
+void PriceManager::setCurrency(int index)
+{
+    if (index < 0 || index >= currenciesAvailable().count()) {
+        qWarning() << __FUNCTION__ << ": Bad index " << index << " passed to setCurrency; NOOP";
+        return;
+    }
+
+    m_currentCurrency = currenciesAvailable().at(index);
+    emit currencyChanged();
+}
+
+void PriceManager::updateCurrenciesAvailable()
+{
+    this->currenciesAvailableModel()->setAvailableCurrencies(this->currenciesAvailable());
+}
+
+CurrencySelectorModel *PriceManager::currenciesAvailableModel() const
+{
+    return m_currenciesAvailableModel;
+}
+
+void PriceManager::setPriceSource(QModelIndex index)
+{
+    QVariant p = m_priceSourcesAvailableModel->data(index, PriceSourceSelectorModel::PriceSourceRole);
+    if (!p.isValid() || p.isNull()) {
+        qWarning() << __FUNCTION__ << ": Invalid price source index passed, NOOP";
+        return;
+    }
+
+    if (!p.canConvert<PriceSource *>()) {
+        qCritical() << __FUNCTION__ << ": Did not get a price source in the model -- this should never happen";
+        return;
+    }
+
+    m_currentPriceSource = p.value<PriceSource *>();
+    emit priceSourceChanged();
+}
+
+void PriceManager::setCurrency(QModelIndex index)
+{
+    QVariant c = m_currenciesAvailableModel->data(index, CurrencySelectorModel::CurrencyRole);
+    if (!c.isValid() || c.isNull()) {
+        qWarning() << __FUNCTION__ << ": Invalid currency index passed, NOOP";
+        return;
+    }
+
+    if (!c.canConvert<Currency *>()) {
+        qCritical() << __FUNCTION__ <<  ": Did not get a currency in the model -- this should never happen";
+        return;
+    }
+
+    m_currentCurrency = c.value<Currency *>();
+    emit currencyChanged();
+}
+
+
+PriceSource *PriceManager::currentPriceSource() const
+{
+    return m_currentPriceSource;
+}
+
+Currency * PriceManager::currentCurrency() const
+{
+    return m_currentCurrency;
+}
+
+bool PriceManager::priceReady() const
+{
+    if (m_currentPrice->currency() && !m_currentPrice->stale())
+        return true;
+    return false;
+}
+
+
+bool PriceManager::running() const
+{
+    return m_running;
+}
+
+bool PriceManager::refreshing() const
+{
+    return m_refreshing;
+}

--- a/src/prices/PriceManager.h
+++ b/src/prices/PriceManager.h
@@ -1,0 +1,145 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifndef PRICEMANAGER_H
+#define PRICEMANAGER_H
+
+#include <QTimer>
+#include <QObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QPointer>
+#include <QString>
+#include <QSet>
+#include <QModelIndex>
+
+#include "PriceSource.h"
+#include "Currency.h"
+
+class Price;
+class CurrencySelectorModel;
+class PriceSourceSelectorModel;
+
+class PriceManager : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool running READ running)
+    Q_PROPERTY(bool refreshing READ refreshing)
+    Q_PROPERTY(bool priceReady READ priceReady NOTIFY priceRefreshed)
+    Q_PROPERTY(Currency * currentCurrency READ currentCurrency NOTIFY currencyChanged)
+    Q_PROPERTY(QList<Currency*> currenciesAvailable READ currenciesAvailable NOTIFY priceSourceChanged)
+    Q_PROPERTY(CurrencySelectorModel * currenciesAvailableModel READ currenciesAvailableModel NOTIFY priceSourceChanged)
+    Q_PROPERTY(Price * price READ price NOTIFY priceRefreshed)
+    Q_PROPERTY(const QList<PriceSource*> priceSourcesAvailable READ priceSourcesAvailable)
+    Q_PROPERTY(PriceSourceSelectorModel * priceSourcesAvailableModel READ priceSourcesAvailableModel)
+    Q_PROPERTY(PriceSource * currentPriceSource READ currentPriceSource NOTIFY priceSourceChanged)
+
+public:
+    static PriceManager * instance(QNetworkAccessManager *manager);
+
+    // Start the price polling thread
+    Q_INVOKABLE void start();
+    // Stop the price polling thread
+    Q_INVOKABLE void stop();
+    // Is there a price available yet?
+    bool priceReady() const;
+    // Are we running?
+    bool running() const;
+    // Are we refreshing the price?
+    bool refreshing() const;
+    // Get the current currency
+    Currency * currentCurrency() const;
+    // Get the current price
+    Price *price() const;
+    // Convert the amount given at the current price and currency
+    Q_INVOKABLE QString convert(quint64 amount) const;
+    // Get current price source
+    PriceSource * currentPriceSource() const;
+    // Set price source
+    void setPriceSource(int index);
+    Q_INVOKABLE void setPriceSource(QModelIndex index);
+    // Set currency
+    void setCurrency(int index);
+    Q_INVOKABLE void setCurrency(QModelIndex index);
+    // Get price sources which are available
+    QList<PriceSource*> priceSourcesAvailable() const;
+    // Get the available price sources in a StringListModel for display
+    PriceSourceSelectorModel *priceSourcesAvailableModel() const;
+    // Get list of available currencies
+    QList<Currency*> currenciesAvailable() const;
+    // Get the available currencies in a StringListModel for display
+    CurrencySelectorModel * currenciesAvailableModel() const;
+
+    Q_INVOKABLE void handleError(const QString &msg) const;
+
+private:
+    void updatePrice();
+    void abortReply();
+
+signals:
+    void starting() const;
+    void started() const;
+    void priceRefreshStarted() const;
+    void priceRefreshed() const;
+    void priceSourceChanged() const;
+    void currencyChanged() const;
+    void networkError() const;
+    void stopping() const;
+    void stopped() const;
+
+public slots:
+    Q_INVOKABLE void restart();
+    // Called when the timer hits (perform HTTP request)
+    void runPriceRefresh();
+    // Called when the HTTP request completes
+    void handleHTTPFinished();
+    // Called when the HTTP request fails
+    void handleNetworkError();
+    // Called when the PriceSource is changed
+    void updateCurrenciesAvailable();
+
+private:
+    explicit PriceManager(QNetworkAccessManager *manager, QObject *parent = nullptr);
+    explicit PriceManager(QObject *parent = nullptr);
+    static PriceManager * m_instance;
+    mutable bool m_running;
+    mutable bool m_refreshing;
+    QNetworkAccessManager * m_manager;
+    mutable QPointer<QNetworkReply> m_reply;
+    QTimer * m_timer;
+    Price * m_currentPrice;
+    Currency * m_currentCurrency;
+    PriceSource * m_currentPriceSource;
+    const QList<PriceSource*> m_priceSourcesAvailable = {PriceSources::CryptoCompare,
+                                                         PriceSources::CoinMarketCap,
+                                                         PriceSources::Binance};
+    PriceSourceSelectorModel * m_priceSourcesAvailableModel;
+    CurrencySelectorModel * m_currenciesAvailableModel;
+
+};
+
+#endif // PRICEMANAGER_H

--- a/src/prices/PriceSource.cpp
+++ b/src/prices/PriceSource.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "PriceSource.h"
+
+#include <QVariant>
+#include <QDebug>
+#include <QMetaType>
+#include <QUrl>
+#include <QUrlQuery>
+
+#include "Currency.h"
+#include "Price.h"
+#include "qtjsonpath.h"
+
+namespace PriceSources {
+    PriceSource * const CoinMarketCap = new CoinMarketCapSource();
+    PriceSource * const Binance = new BinanceSource();
+    PriceSource * const CryptoCompare = new CryptoCompareSource();
+}
+
+QUrl CoinMarketCapSource::renderUrl(Currency * currency)
+{
+    QUrl rendered(m_baseUrl);
+    QUrlQuery query = QUrlQuery();
+    query.addQueryItem(QStringLiteral("convert"), currency->label());
+    rendered.setQuery(query);
+    return rendered;
+}
+
+bool CoinMarketCapSource::updatePriceFromReply(Price *price, Currency * currency, QJsonDocument &reply)
+{
+    QtJsonPath walker(reply);
+    QString modpath = QString(QStringLiteral("data/quotes/"))
+            .append(currency->label())
+            .append(QStringLiteral("/price"));
+    QVariant res = walker.getValue(modpath);
+    if (!res.isValid() || res.isNull() || res.userType() != QMetaType::Double) {
+        qWarning() << __FUNCTION__ << ": Invalid parsing of response from JSON; ignoring price update";
+        return false;
+    }
+
+    price->update(res.toDouble(), currency);
+    return true;
+}
+
+QUrl BinanceSource::renderUrl(Currency * currency)
+{
+    QUrl rendered(m_baseUrl);
+    QUrlQuery query = QUrlQuery();
+    QString pair(QStringLiteral("XMR"));
+    pair.append(currency->label());
+    query.addQueryItem(QStringLiteral("symbol"), pair);
+    rendered.setQuery(query);
+    return rendered;
+}
+
+bool BinanceSource::updatePriceFromReply(Price *price, Currency * currency, QJsonDocument &reply)
+{
+    if (!reply.isObject() || reply.isEmpty()) {
+        qWarning() << __FUNCTION__ << ": Invalid JSON response [reply is not object or empty]; ignoring price update";
+        return false;
+    }
+
+    QString priceRaw = reply
+            .object()
+            .value(QStringLiteral("lastPrice"))
+            .toString();
+    if (priceRaw.isNull()) {
+        qWarning() << __FUNCTION__ << ": Invalid JSON response [does not contain valid key 'lastPrice']; ignoring price update";
+        return false;
+    }
+
+    bool success;
+    qreal priceDouble = priceRaw.toDouble(&success);
+    if (!success) {
+        qWarning() << __FUNCTION__ << ": Invalid JSON response [value " << priceRaw << " at key 'lastPrice' cannot be converted to double]; ignoring price update";
+        return false;
+    }
+
+    price->update(priceDouble, currency);
+    return true;
+}
+
+
+QUrl CryptoCompareSource::renderUrl(Currency * currency) {
+    QUrl rendered(m_baseUrl);
+    QUrlQuery query = QUrlQuery();
+    query.addQueryItem(QStringLiteral("fsym"), QStringLiteral("XMR"));
+    query.addQueryItem(QStringLiteral("tsyms"), currency->label());
+    rendered.setQuery(query);
+    return rendered;
+}
+
+bool CryptoCompareSource::updatePriceFromReply(Price *price, Currency * currency, QJsonDocument &reply)
+{
+    if (!reply.isObject() || reply.isEmpty()) {
+        qWarning() << __FUNCTION__ << ": Invalid JSON response [reply is not object or empty]; ignoring price update";
+        return false;
+    }
+
+    QJsonValue priceRaw = reply
+            .object()
+            .value(currency->label());
+    if (priceRaw.isNull()) {
+        qWarning() << __FUNCTION__ << ": Invalid JSON response [does not contain valid key '" << currency->label() << "']; ignoring price update";
+        return false;
+    }
+
+    qreal priceDouble = priceRaw.toDouble();
+    if (priceDouble == 0.0) {
+        qWarning() << __FUNCTION__ << ": Invalid JSON response [value " << priceRaw << " at key '"<< currency->label() << "' cannot be converted to double]; ignoring price update";
+        return false;
+    }
+
+    price->update(priceDouble, currency);
+    return true;
+}

--- a/src/prices/PriceSource.h
+++ b/src/prices/PriceSource.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifndef PRICESOURCE_H
+#define PRICESOURCE_H
+
+#include <QObject>
+#include <QUrl>
+#include <QString>
+#include <QList>
+#include <QGuiApplication>
+
+#include "Currency.h"
+
+class Price;
+
+class PriceSource : public QObject
+{
+    Q_OBJECT
+
+    // Label of the source, IE, "CoinMarketCap"
+    Q_PROPERTY(QString label READ label)
+    // URL used to contact the API for prices
+    Q_PROPERTY(QUrl baseUrl READ baseUrl)
+
+public:
+    explicit PriceSource(QObject *parent = nullptr) : QObject(parent) {}
+    virtual QString label() const = 0;
+    virtual QUrl baseUrl() const = 0;
+    virtual QList<Currency*> currenciesAvailable() const = 0;
+    virtual bool updatePriceFromReply(Price * price, Currency * currency, QJsonDocument & reply) = 0;
+    virtual QUrl renderUrl(Currency * currency) = 0;
+
+private:
+    friend class PriceManager;
+};
+
+class CoinMarketCapSource : public PriceSource
+{
+    Q_OBJECT
+
+public:
+    using PriceSource::PriceSource;
+    QString label() const {return m_label; }
+    QUrl baseUrl() const {return m_baseUrl; }
+    QList<Currency*> currenciesAvailable() const { return m_currenciesAvailable; }
+    bool updatePriceFromReply(Price *price, Currency *currency, QJsonDocument &reply);
+    QUrl renderUrl(Currency *currency);
+
+private:
+    const QString m_label = QLatin1Literal("CoinMarketCap");
+    const QList<Currency*> m_currenciesAvailable = {Currencies::USD, Currencies::BTC, Currencies::GBP};
+    const QUrl m_baseUrl = QUrl(QLatin1Literal("https://api.coinmarketcap.com/v2/ticker/328/"));
+    const QString m_jsonPath = QLatin1Literal("data/quotes/{CURRENCY}/price");
+};
+
+class BinanceSource : public PriceSource
+{
+    Q_OBJECT
+
+public:
+    using PriceSource::PriceSource;
+    QString label() const {return m_label; }
+    QUrl baseUrl() const {return m_baseUrl; }
+    QList<Currency*> currenciesAvailable() const { return m_currenciesAvailable; }
+    bool updatePriceFromReply(Price *price, Currency *currency, QJsonDocument &reply);
+    QUrl renderUrl(Currency *currency);
+
+private:
+    const QString m_label = QLatin1Literal("Binance");
+    const QList<Currency*> m_currenciesAvailable = {Currencies::BTC};
+    const QUrl m_baseUrl = QUrl(QLatin1Literal("https://api.binance.com/api/v1/ticker/24hr"));
+};
+
+class CryptoCompareSource: public PriceSource
+{
+    Q_OBJECT
+
+public:
+    using PriceSource::PriceSource;
+    QString label() const {return m_label; }
+    QUrl baseUrl() const { return m_baseUrl; }
+    QList<Currency *> currenciesAvailable() const { return m_currenciesAvailable; }
+    bool updatePriceFromReply(Price *price, Currency * currency, QJsonDocument &reply);
+    QUrl renderUrl(Currency *currency);
+
+private:
+    const QString m_label = QLatin1Literal("CryptoCompare");
+    const QList<Currency*> m_currenciesAvailable = {Currencies::USD, Currencies::BTC, Currencies::EUR,
+                                                    Currencies::JPY, Currencies::KRW, Currencies::ETH,
+                                                    Currencies::CNY, Currencies::GBP};
+    const QUrl m_baseUrl = QUrl(QLatin1Literal("https://min-api.cryptocompare.com/data/price"));
+};
+
+namespace PriceSources {
+    extern PriceSource * const CoinMarketCap;
+    extern PriceSource * const Binance;
+    extern PriceSource * const CryptoCompare;
+}
+
+#endif // PRICESOURCE_H

--- a/src/prices/PriceSourceSelectorModel.cpp
+++ b/src/prices/PriceSourceSelectorModel.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "PriceSourceSelectorModel.h"
+
+#include <QDebug>
+
+
+PriceSourceSelectorModel::PriceSourceSelectorModel(QObject *parent, QList<PriceSource*> available) :
+    QAbstractListModel(parent), m_availablePriceSources(available)
+{
+}
+
+QList<PriceSource*> PriceSourceSelectorModel::availablePriceSources() const
+{
+    return m_availablePriceSources;
+}
+
+QString PriceSourceSelectorModel::getLabelAt(int index) const
+{
+    QVariant var = this->data(this->index(index), PriceSourceLabelRole);
+    if (var.isNull())
+        return QString();
+    return var.toString();
+}
+
+QVariant PriceSourceSelectorModel::data(const QModelIndex &index, int role) const
+{
+    if (m_availablePriceSources.empty()) {
+        qWarning() << __FUNCTION__ << ": No available price sources configured!";
+        return QVariant();
+    }
+
+    if (index.row() < 0 || index.row() >= m_availablePriceSources.count()) {
+        qWarning() << __FUNCTION__ << ": Index " << index.row() <<" OOB for price source selection";
+        return QVariant();
+    }
+
+    PriceSource * priceSource = m_availablePriceSources.at(index.row());
+    Q_ASSERT(priceSource);
+    if (!priceSource) {
+        qWarning() << __FUNCTION__ << ": internal error: no priceSource for index " << index.row();
+        return QVariant();
+    }
+
+    QVariant result;
+    switch (role) {
+    case PriceSourceRole:
+        result = QVariant::fromValue(priceSource);
+        break;
+    case PriceSourceLabelRole:
+    case PriceSourceSimpleDropdownRole:
+        result = priceSource->label();
+        break;
+    case PriceSourceUrlRole:
+        result = priceSource->baseUrl();
+        break;
+    case PriceSourceAvailableCurrenciesRole:
+        result = QVariant::fromValue(priceSource->currenciesAvailable());
+        break;
+    default:
+        result = priceSource->label();
+        break;
+    }
+    return result;
+}
+
+int PriceSourceSelectorModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+    return m_availablePriceSources.count();
+}
+
+QHash<int, QByteArray> PriceSourceSelectorModel::roleNames() const
+{
+    static QHash<int, QByteArray> roleNames;
+    if (roleNames.empty())
+    {
+        roleNames.insert(PriceSourceRole, "priceSource");
+        roleNames.insert(PriceSourceLabelRole, "label");
+        roleNames.insert(PriceSourceSimpleDropdownRole, "column1");
+        roleNames.insert(PriceSourceUrlRole, "baseUrl");
+        roleNames.insert(PriceSourceAvailableCurrenciesRole, "availableCurrencies");
+    }
+    return roleNames;
+}

--- a/src/prices/PriceSourceSelectorModel.h
+++ b/src/prices/PriceSourceSelectorModel.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifndef PRICESOURCESELECTORMODEL_H
+#define PRICESOURCESELECTORMODEL_H
+
+#include <QAbstractListModel>
+#include <QObject>
+
+#include "PriceSource.h"
+
+class PriceSourceSelectorModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QList<PriceSource*> availablePriceSources READ availablePriceSources NOTIFY availablePriceSourcesChanged)
+public:
+    enum PriceSourceViewRole {
+        PriceSourceRole =  Qt::UserRole + 1,
+        PriceSourceLabelRole,
+        PriceSourceSimpleDropdownRole,
+        PriceSourceUrlRole,
+        PriceSourceAvailableCurrenciesRole
+    };
+    Q_ENUM(PriceSourceViewRole)
+    explicit PriceSourceSelectorModel(QObject * parent = nullptr, QList<PriceSource*> available = QList<PriceSource*>());
+    QList<PriceSource*> availablePriceSources() const;
+
+    Q_INVOKABLE QString getLabelAt(int index) const;
+
+    virtual QVariant data(const QModelIndex & index, int role) const override;
+    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual QHash<int, QByteArray> roleNames() const  override;
+
+signals:
+    void availablePriceSourcesChanged() const;
+
+private:
+    friend class PriceManager;
+    QList<PriceSource*> m_availablePriceSources;
+};
+
+#endif // PRICESOURCESELECTORMODEL_H

--- a/src/prices/qtjsonpath.h
+++ b/src/prices/qtjsonpath.h
@@ -1,0 +1,128 @@
+// Copyright (c) 2018, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifndef QTJSONPATH_H
+#define QTJSONPATH_H
+
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QStringList>
+#include <QString>
+#include <QVariant>
+
+/**
+ * Taken from lib-qt-qml-tricks (https://github.com/Cavewhere/lib-qt-qml-tricks)
+ */
+
+class QtJsonPath {
+public:
+    explicit QtJsonPath (QJsonValue & jsonVal) {
+        QJsonObject jsonObj = jsonVal.toObject ();
+        if (!jsonObj.isEmpty ()) {
+            initWithNode (jsonObj);
+        }
+        else {
+            QJsonArray jsonArray = jsonVal.toArray ();
+            if (!jsonArray.isEmpty ()) {
+                initWithNode (jsonArray);
+            }
+            else { }
+        }
+    }
+
+    explicit QtJsonPath (QJsonObject & jsonObj) {
+        initWithNode (jsonObj);
+    }
+
+    explicit QtJsonPath (QJsonArray & jsonArray) {
+        initWithNode (jsonArray);
+    }
+
+    explicit QtJsonPath (QJsonDocument & jsonDoc) {
+        QJsonObject jsonObj = jsonDoc.object ();
+        if (!jsonObj.isEmpty ()) {
+            initWithNode (jsonObj);
+        }
+        else {
+            QJsonArray jsonArray = jsonDoc.array ();
+            if (!jsonArray.isEmpty ()) {
+                initWithNode (jsonArray);
+            }
+            else { }
+        }
+    }
+
+    QVariant getValue (QString path, QVariant fallback = QVariant ()) const {
+        QVariant ret;
+        QStringList list = path.split ('/', QString::SkipEmptyParts);
+        if (!list.empty () && !m_rootNode.isUndefined () && !m_rootNode.isNull ()) {
+            QJsonValue currNode = m_rootNode;
+            bool error = false;
+            int len = list.size ();
+            for (int depth = 0; (depth < len) && (!error); depth++) {
+                QString part = list.at (depth);
+                bool isNum = false;
+                int index = part.toInt (&isNum, 10);
+                if (isNum) { // NOTE : array subpath
+                    if (currNode.isArray ()) {
+                        QJsonArray arrayNode = currNode.toArray ();
+                        if (index < arrayNode.size ()) {
+                            currNode = arrayNode.at (index);
+                        }
+                        else { error = true; }
+                    }
+                    else { error = true; }
+                }
+                else { // NOTE : object subpath
+                    if (currNode.isObject ()) {
+                        QJsonObject objNode = currNode.toObject ();
+                        if (objNode.contains (part)) {
+                            currNode = objNode.value (part);
+                        }
+                        else { error = true; }
+                    }
+                    else { error = true; }
+                }
+            }
+            ret = (!error ? currNode.toVariant () : fallback);
+        }
+        return ret;
+    }
+
+protected:
+    void initWithNode (QJsonValue jsonNode) {
+        m_rootNode = jsonNode;
+    }
+
+private:
+    QJsonValue m_rootNode;
+};
+
+#endif // QTJSONPATH_H


### PR DESCRIPTION
As described in https://github.com/monero-project/monero-gui/issues/1484.

A few things of note:

## Connections and security
This module uses the [QNetworkAccessManager](http://doc.qt.io/qt-5/qnetworkaccessmanager.html) to perform HTTP requests to the user's choice of a centralized server. As such, it introduces an insecure element for the benefit of convenience. This feature is off by default, and builds have to explicitly include the WITH_PRICES config option. As part of this pull request, I've added the WITH_PRICES flag to the release and debug builds in build.sh, but that can be easily reverted if desired (switching from an opt-out to an opt-in).

## Pricing providers
Out of the box I include support for CMC, Binance, and CryptoCompare. Other providers can be added by subclassing the PriceSource class.

## Currencies
Right now the choices are fairly arbitrary (I don't think I left out any major ones), but new currencies can be added very easily by creating new Currency objects.

I'm extremely open to feedback here; C++ isn't my first language so I'm sure there will be some issues or updates.