### PR TITLE
[0.13] Windows Installer: Update for Beryllium Bullet 0.13.0.4, take two

### DIFF
--- a/installers/windows/Monero.iss
+++ b/installers/windows/Monero.iss
@@ -92,7 +92,7 @@ Source: "monero-daemon.bat"; DestDir: "{app}"; Flags: ignoreversion;
 ; Monero blockchain utilities
 Source: "bin\monero-blockchain-export.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "bin\monero-blockchain-import.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "bin\monero-blockchain-blackball.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\monero-blockchain-mark-spent-outputs.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "bin\monero-blockchain-usage.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "bin\monero-blockchain-import.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "bin\monero-blockchain-ancestry.exe"; DestDir: "{app}"; Flags: ignoreversion
@@ -373,6 +373,21 @@ begin
   Result := s;
 end;
 
+function WalletFlags(Param: String): String;
+// Flags to add to the shortcut to the GUI wallet
+// Use "--log-file" to force log file alongside the installed GUI exe which would not get
+// created there because of an unsolved issue in the 0.13.0.4 wallet code
+var s: String;
+begin
+  s := ExpandConstant('{app}\monero-wallet-gui.log');
+  if Pos(' ', s) > 0 then begin
+    // Quotes needed for filename with blanks
+    s := '"' + s + '"';
+  end;
+  s := '--log-file ' + s;
+  Result := s;
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 var s: TArrayOfString;
 begin
@@ -400,7 +415,7 @@ end;
 [Icons]
 ; Icons in the "Monero GUI Wallet" program group
 ; Windows will almost always display icons in alphabetical order, per level, so specify the text accordingly
-Name: "{group}\GUI Wallet"; Filename: "{app}\monero-wallet-gui.exe"
+Name: "{group}\GUI Wallet"; Filename: "{app}\monero-wallet-gui.exe"; Parameters: {code:WalletFlags}
 Name: "{group}\GUI Wallet Guide"; Filename: "{app}\monero-GUI-guide.pdf"; IconFilename: "{app}\monero-wallet-gui.exe"
 Name: "{group}\Uninstall GUI Wallet"; Filename: "{uninstallexe}"
 
@@ -426,7 +441,7 @@ Name: "{group}\Utilities\x (Try GUI Wallet Low Graphics Mode)"; Filename: "{app}
 Name: "{group}\Utilities\x (Try Kill Daemon)"; Filename: "Taskkill.exe"; Parameters: "/IM monerod.exe /T /F"
 
 ; Desktop icons, optional with the help of the "Task" section
-Name: "{commondesktop}\GUI Wallet"; Filename: "{app}\monero-wallet-gui.exe"; Tasks: desktopicon
+Name: "{commondesktop}\GUI Wallet"; Filename: "{app}\monero-wallet-gui.exe"; Parameters: {code:WalletFlags}; Tasks: desktopicon
 
 
 [Registry]

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -21,7 +21,7 @@ this version of the script only works with exactly the GUI wallet
 for Monero release *Beryllium Bullet* that you find on
 [the official download page](https://getmonero.org/downloads/).
 
-But of course it will be easy to modify the script for future
+It should however be easy to modify the script for future
 versions of the GUI wallet.
 
 ## License ##
@@ -37,8 +37,8 @@ Beryllium Bullet GUI wallet.
 The build steps in detail:
 
 1. Install *Inno Setup*. You can get it from [here](http://www.jrsoftware.org/isdl.php)
-2. Get the Inno Setup script plus related files by cloning the whole [monero-gui GitHub repository](https://github.com/monero-project/monero-gui); you will only need the files in the installer directory `installers\windows` however
-3. The setup script is written to take the GUI wallet files from a subdirectory named `bin`; so create `installers\windows\bin`, get the zip file of the GUI wallet from [here](https://getmonero.org/downloads/), unpack it somewhere, and copy all the files and subdirectories in the `monero-gui-0.13.0.4` directory to this `bin` subdirectory
+2. Get the Inno Setup script plus related files by cloning the whole [monero-gui GitHub repository](https://github.com/monero-project/monero-gui); you will only need the files in the installer directory `installers\windows` however. Depending on development state, additionally you may have to checkout a specific branch, like `release-v0.13`.
+3. The setup script is written to take the GUI wallet files from a subdirectory named `bin`; so create `installers\windows\bin`, get the zip file of the GUI wallet from [here](https://getmonero.org/downloads/), unpack it somewhere, and copy all the files and subdirectories in the single subdirectory there (currently named `monero-gui-0.13.0.4`) to this `bin` subdirectory
 4. Start Inno Setup, load `Monero.iss` and compile it
 5. The result i.e. the finished installer will be the file `mysetup.exe` in the `installers\windows\Output` subdirectory 
 

--- a/installers/windows/ReadMe.htm
+++ b/installers/windows/ReadMe.htm
@@ -7,7 +7,7 @@
 <h1>Monero Beryllium Bullet GUI Wallet</h1>
 
   <p>Copyright (c) 2014-2018, The Monero Project<br>
-  Date: October 18, 2018</p>
+  Date: November 2, 2018</p>
 
 <h2>Preface</h2>
 


### PR DESCRIPTION
Some finishing touches in addition to the changes for 0.13.0.4 already merged as commit #1680:

From `monero-blockchain-blackball.exe` to `monero-blockchain-mark-spent-outputs.exe`, and a `--log-file` parameter for the GUI wallet shortcut / icon to force the log file alongside the .exe (which currently is not written there by default because of an unsolved issue in the GUI wallet).