### PR TITLE
Fix word in finnish translation

### DIFF
--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -2356,7 +2356,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="280"/>
         <source>Spend key (private)</source>
-        <translation>Kulutusavain (julkinen)</translation>
+        <translation>Kulutusavain (yksityinen)</translation>
     </message>
     <message>
         <location filename="../wizard/WizardManageWalletUI.qml" line="300"/>


### PR DESCRIPTION
The original word was translated as "public" instead of "private" (at least according automatic translators).
As reported on reddit: https://www.reddit.com/r/Monero/comments/9ti2on/gui_v01304_beryllium_bullet_released/e8xp6c7/?context=3

@rpinola Could you review this?