### PR TITLE
Avoid pushd error when system libunbound is used

### DIFF
--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -238,12 +238,13 @@ eval make -C $MONERO_DIR/build/$BUILD_TYPE/external/easylogging++ all install
 eval make -C $MONERO_DIR/build/$BUILD_TYPE/external/db_drivers/liblmdb all install
 
 # Install libunbound
-echo "Installing libunbound..."
-pushd $MONERO_DIR/build/$BUILD_TYPE/external/unbound
-# no need to make, it was already built as dependency for libwallet
-# make -j$CPU_CORE_COUNT
-$make_exec install -j$CPU_CORE_COUNT
-popd
-
+if [ -d $MONERO_DIR/build/$BUILD_TYPE/external/unbound ]; then
+    echo "Installing libunbound..."
+    pushd $MONERO_DIR/build/$BUILD_TYPE/external/unbound
+    # no need to make, it was already built as dependency for libwallet
+    # make -j$CPU_CORE_COUNT
+    $make_exec install -j$CPU_CORE_COUNT
+    popd
+fi
 
 popd


### PR DESCRIPTION
I was getting 'no such file or directory' error from pushd. It turned out that my build was using system libunbound (on Ubuntu 18.04.1 LTS). 

It seems reasonable to check for directory existence before pushd to avoid the error which may be misleading if there are other errors.