### PR TITLE
pro: link protobuf

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -119,7 +119,8 @@ LIBS += -L$$WALLET_ROOT/lib \
         -lepee \
         -lunbound \
         -lsodium \
-        -leasylogging
+        -leasylogging \
+        -lprotobuf
 }
 
 android {


### PR DESCRIPTION
Required on Arch Linux (Tested on x86_64), otherwise linking fails with undefined symbols referencing protobuf.