### PR TITLE
transfer: prepend '0' to amount starting with '.' 

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -144,6 +144,11 @@ Rectangle {
                       fontBold: true
                       inlineButtonText: qsTr("All") + translationManager.emptyString
                       inlineButton.onClicked: amountLine.text = "(all)"
+                      onTextChanged: {
+                          if (amountLine.text.startsWith('.')) {
+                              amountLine.text = '0' + amountLine.text;
+                          }
+                      }
 
                       validator: RegExpValidator {
                           regExp: /(.|)(\d{1,8})([.]\d{1,12})?$/


### PR DESCRIPTION
@dvsdan's approach https://github.com/monero-project/monero-gui/pull/1553#issuecomment-418468076:
> If a value that starts with a period is invalid why not check if a period is pressed as the first character in the field and just insert the chars "0." before the regex check, instead to make the user's transaction amount valid.

Resolves #1718 