### PR TITLE
transfer: fix amount validation regexp

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -146,7 +146,7 @@ Rectangle {
                       inlineButton.onClicked: amountLine.text = "(all)"
 
                       validator: RegExpValidator {
-                          regExp: /(.|)(\d{1,8})([.]\d{1,12})?$/
+                          regExp: /^(\d{1,8})?([\.]\d{1,12})?$/
                       }
                   }
               }


### PR DESCRIPTION
**Bugs fixed**
1. A user can enter any character (`!`, `x`, etc.) as the first character in the amount field  
Ex: amount `!123` passes the validation regexp
2. Multiple dots in the amount field
Ex.: amount `.123.123` passes the validation regexp