### PR TITLE
get_libwallet_api: configure cmake toolchain for msys

### DIFF
--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -188,14 +188,14 @@ elif [ "$platform" == "mingw64" ]; then
     # Do something under Windows NT platform
     echo "Configuring build for MINGW64.."
     BOOST_ROOT=/mingw64/boost
-    cmake -D CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -D STATIC=ON -D BOOST_ROOT="$BOOST_ROOT" -D ARCH="x86-64" -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
+    cmake -D CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -D STATIC=ON -D BOOST_ROOT="$BOOST_ROOT" -D ARCH="x86-64" -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" -D CMAKE_TOOLCHAIN_FILE=../../cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=c:/msys64 ../..
 
 ## Windows 32
 elif [ "$platform" == "mingw32" ]; then
     # Do something under Windows NT platform
     echo "Configuring build for MINGW32.."
     BOOST_ROOT=/mingw32/boost
-    cmake -D CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -D STATIC=ON -D Boost_DEBUG=ON -D BOOST_ROOT="$BOOST_ROOT" -D ARCH="i686" -D BUILD_64=OFF -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" ../..
+    cmake -D CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -D STATIC=ON -D Boost_DEBUG=ON -D BOOST_ROOT="$BOOST_ROOT" -D ARCH="i686" -D BUILD_64=OFF -D BUILD_GUI_DEPS=ON -D INSTALL_VENDORED_LIBUNBOUND=ON -D CMAKE_INSTALL_PREFIX="$MONERO_DIR" -G "MSYS Makefiles" -D CMAKE_TOOLCHAIN_FILE=../../cmake/32-bit-toolchain.cmake -D MSYS2_FOLDER=c:/msys32 ../..
     make_exec="mingw32-make"
 else
     echo "Unknown platform, configuring general build"


### PR DESCRIPTION
I fail to compile the current master on MSYS2 with this error:
```
C:/msys64/home/stoffu/github/monero-project/monero-gui/monero/external/unbound/validator/val_secalgo.c: In function 'verify_canonrrset':
C:/msys64/home/stoffu/github/monero-project/monero-gui/monero/external/unbound/validator/val_secalgo.c:665:35: error: dereferencing pointer to incomplete type 'EVP_MD_CTX' {aka 'struct evp_md_ctx_st'}
  ctx = (EVP_MD_CTX*)malloc(sizeof(*ctx));
                                   ^~~~
```
This seems related to the backward incompatibility in OpenSSL transitioning from 1.0.x to 1.1.x (and FWIW, the MSYS latest package uses 1.1.1), but strangely, adding these flags to cmake (borrowed from the CLI Makefile) seems to resolve it. I'm not sure why, and I'm surprised that this hasn't been spotted already AFAIK. Also strange is the fact that the buildbot is just fine with the current code. Am I missing something obvious?
