### PR TITLE
transfer: amount validation regexp improvement

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -151,7 +151,7 @@ Rectangle {
                       }
 
                       validator: RegExpValidator {
-                          regExp: /^(\d{1,8})?([\.]\d{1,12})?$/
+                          regExp: /^(0*\d{1,8})?([\.]\d{1,12})?$/
                       }
                   }
               }


### PR DESCRIPTION
Any opinions on this? This would disallow amounts like:

`0003.313`

The CLI allows numbers like above.