### PR TITLE
history: fix clipping of text in search box

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -154,7 +154,7 @@ Rectangle {
                 LineEdit {
                     id: searchLine
                     fontSize: 14 * scaleRatio
-                    inputHeight: 28 * scaleRatio
+                    inputHeight: 36 * scaleRatio
                     borderDisabled: true
                     Layout.fillWidth: true
                     backgroundColor: "#404040"


### PR DESCRIPTION
**Before**
![befsear](https://user-images.githubusercontent.com/40871101/49260399-3fa1be80-f3f2-11e8-9e45-53cc65090bcb.PNG)


**After**
![aftersearch](https://user-images.githubusercontent.com/40871101/49260397-3dd7fb00-f3f2-11e8-8acf-b6ad9b6cd297.PNG)