### PR TITLE
macOS: fix UI issues with dark mode

### DIFF
--- a/share/Info.plist
+++ b/share/Info.plist
@@ -28,5 +28,8 @@
 
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
+
+  <key>NSRequiresAquaSystemAppearance</key>
+  <string>True</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fix from https://github.com/bitcoin/bitcoin/pull/14593

Temporary until the GUI handles macOS dark mode properly.

Before:
<img width="1042" alt="screenshot 2018-12-05 at 19 30 07" src="https://user-images.githubusercontent.com/7697454/49535333-3918b880-f8c4-11e8-9bfd-d8143e91b010.png">
After:
<img width="1042" alt="screenshot 2018-12-05 at 19 29 38" src="https://user-images.githubusercontent.com/7697454/49535340-3ddd6c80-f8c4-11e8-8c8a-25838dcb2404.png">
