### PR TITLE
Add hidapi for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The executable can be found in the build/release/bin folder.
   `brew install cmake`
 
   `brew install zeromq`
+  
+  `brew install hidapi`
 
   *Note*: If cmake can not find zmq.hpp file on OS X, installing `zmq.hpp` from https://github.com/zeromq/cppzmq to `/usr/local/include` should fix that error.
 


### PR DESCRIPTION
Add brew install hidapi for osx installs of latest Monero GUI. (need this for ledger / trezor support of "usb to app")