### PR TITLE
Fix Receive.qml:388: Error: Insufficient arguments

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -385,7 +385,7 @@ Rectangle {
                             inputDialog.inputText = qsTr("(Untitled)")
                             inputDialog.onAcceptedCallback = function() {
                                 appWindow.currentWallet.subaddress.addRow(appWindow.currentWallet.currentSubaddressAccount, inputDialog.inputText)
-                                current_subaddress_table_index = appWindow.currentWallet.numSubaddresses() - 1
+                                current_subaddress_table_index = appWindow.currentWallet.numSubaddresses(appWindow.currentWallet.currentSubaddressAccount) - 1
                             }
                             inputDialog.onRejectedCallback = null;
                             inputDialog.open()


### PR DESCRIPTION
Fixes:
WARNING frontend    src/wallet/api/wallet.cpp:367   qrc:///pages/Receive.qml:388: Error: Insufficient arguments