### PR TITLE
HistoryTable: missing TransactionID text fix

### DIFF
--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -293,7 +293,7 @@ ListView {
                 anchors.left: parent.left
                 anchors.leftMargin: 30 * scaleRatio
 
-                labelHeader: QsTr("Transaction ID") + translationManager.emptyString
+                labelHeader: qsTr("Transaction ID") + translationManager.emptyString
                 labelValue: hash.substring(0, 18) + "..."
                 copyValue: hash
             }


### PR DESCRIPTION
**Fixes**
WARNING frontend    src/wallet/api/wallet.cpp:367   qrc:///components/HistoryTable.qml:296: ReferenceError: QsTr is not defined

**Before**
![bt](https://user-images.githubusercontent.com/40871101/49331500-c40b5300-f552-11e8-957d-4902714d314c.PNG)

**After**
![at](https://user-images.githubusercontent.com/40871101/49331501-c5d51680-f552-11e8-8589-3d1abed5a8d4.PNG)