### PR TITLE
settings: fix Binding loop detected for property preferredHeight

### DIFF
--- a/pages/settings/Settings.qml
+++ b/pages/settings/Settings.qml
@@ -59,7 +59,7 @@ ColumnLayout {
         property SettingsLog settingsLogView: SettingsLog { }
         property SettingsInfo settingsInfoView: SettingsInfo { }
         Layout.fillWidth: true
-        Layout.preferredHeight: parent.height
+        Layout.preferredHeight: settingsHeight
         color: "transparent"
         state: "Wallet"
 


### PR DESCRIPTION
Resolves this warning:
WARNING frontend    src/wallet/api/wallet.cpp:367   <Unknown File>: QML QQuickLayoutAttached: Binding loop detected for property "preferredHeight"