### PR TITLE
receive: enable advanced option checkbox2 to persist

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1019,6 +1019,7 @@ ApplicationWindow {
         property string daemonUsername: ""
         property string daemonPassword: ""
         property bool transferShowAdvanced: false
+        property bool receiveShowAdvanced: false
         property string blockchainDataDir: ""
         property bool useRemoteNode: false
         property string remoteNodeAddress: ""

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -48,7 +48,6 @@ Rectangle {
     property var model
     property var current_address
     property int current_subaddress_table_index: 0
-    property bool advancedRowVisible: false
     property alias receiveHeight: mainLayout.height
     property alias addressText : pageReceive.current_address
 
@@ -398,9 +397,9 @@ Rectangle {
         RowLayout {
             CheckBox2 {
                 id: showAdvancedCheckbox
-                checked: false
+                checked: persistentSettings.receiveShowAdvanced
                 onClicked: {
-                    advancedRowVisible = !advancedRowVisible;
+                    persistentSettings.receiveShowAdvanced = !persistentSettings.receiveShowAdvanced
                 }
                 text: qsTr("Advanced options") + translationManager.emptyString
             }
@@ -411,7 +410,7 @@ Rectangle {
             columns: (isMobile)? 1 : 2
             Layout.fillWidth: true
             columnSpacing: 32 * scaleRatio
-            visible: advancedRowVisible
+            visible: persistentSettings.receiveShowAdvanced
 
             ColumnLayout {
                 Layout.alignment: Qt.AlignTop


### PR DESCRIPTION
Now behaves consistently to other "advance options" found in wallet by remembering visibility state.