### PR TITLE
Qt 5.7 compatibility

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -453,7 +453,7 @@ Rectangle {
                         fontBold: true
                         inlineIcon: true
                         onTextChanged: {
-                            if (amountToReceiveLine.text.startsWith('.')) {
+                            if(amountToReceiveLine.text.indexOf('.') === 0){
                                 amountToReceiveLine.text = '0' + amountToReceiveLine.text;
                             }
                         }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -145,7 +145,7 @@ Rectangle {
                       inlineButtonText: qsTr("All") + translationManager.emptyString
                       inlineButton.onClicked: amountLine.text = "(all)"
                       onTextChanged: {
-                          if (amountLine.text.startsWith('.')) {
+                          if(amountLine.text.indexOf('.') === 0){
                               amountLine.text = '0' + amountLine.text;
                           }
                       }

--- a/wizard/WizardOptions.qml
+++ b/wizard/WizardOptions.qml
@@ -381,7 +381,7 @@ ColumnLayout {
             color: "#4A4949"
             text: persistentSettings.kdfRounds
             validator: IntValidator { bottom: 1 }
-            onTextEdited: {
+            onEditingFinished: {
                 kdfRoundsText.text = persistentSettings.kdfRounds = parseInt(kdfRoundsText.text) >= 1 ? parseInt(kdfRoundsText.text) : 1;
             }
         }


### PR DESCRIPTION
`TextField.onEditingFinished()` and `string.startsWith()` are not available in Qt 5.7 - it breaks the compile.

Best to use Qt 5.7 as the version whilst developing to ensure compatibility.