### PR TITLE
MiddlePanel: use QtQuick.Control scrollbar

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -29,6 +29,7 @@
 
 import QtQml 2.0
 import QtQuick 2.2
+import QtQuick.Controls 2
 import QtQuick.Controls 1.4
 import QtQuick.Layouts 1.1
 import QtGraphicalEffects 1.0
@@ -181,21 +182,18 @@ Rectangle {
             Layout.fillHeight: true
             clip: true
 
-            onFlickingChanged: {
-                releaseFocus();
-                flickableScroll.flickableContentYChanged();
-            }
-
-            MoneroComponents.Scroll {
-                id: flickableScroll
+            ScrollBar.vertical: ScrollBar {
                 parent: mainFlickable.parent
                 anchors.left: parent.right
                 anchors.leftMargin: 3
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
-                flickable: mainFlickable
-                scrollWidth: 6
             }
+
+            onFlickingChanged: {
+                releaseFocus();
+            }
+
             // Views container
             StackView {
                 id: stackView


### PR DESCRIPTION
As there are problems with #1797 on macOS (see PR for more details), I decided to try out the QtQuick.Control scrollbar again. Seeing it is used in other places (e.g. [here](https://github.com/monero-project/monero-gui/blob/master/components/DaemonConsole.qml#L159)) I think this shouldn’t crash on Windows (#777) anymore.

Are additional changes to components/Scroll.qml required?