### PR TITLE
[Qt 5.9] qrscanner: enable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,24 +103,13 @@ The following instructions will fetch Qt from your distribution's repositories i
 
   - For Ubuntu 17.10+
 
-    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-xmllistmodel qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel qttools5-dev-tools qml-module-qtquick-templates2 libqt5svg5-dev`
+    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-xmllistmodel qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel qttools5-dev-tools qml-module-qtquick-templates2 libqt5svg5-dev qtmultimedia5-dev qml-module-qtmultimedia libzbar-dev`
 
   - For Gentoo
 
-    `sudo emerge dev-qt/qtcore:5 dev-qt/qtdeclarative:5 dev-qt/qtquickcontrols:5 dev-qt/qtquickcontrols2:5 dev-qt/qtgraphicaleffects:5`
+    The *qml* USE flag must be enabled.
 
-  - Optional : To build the flag `WITH_SCANNER`
-
-    - For Ubuntu
-
-      `sudo apt install qtmultimedia5-dev qml-module-qtmultimedia libzbar-dev`
-
-    - For Gentoo
-
-      The *qml* USE flag must be enabled.
-
-      `emerge dev-qt/qtmultimedia:5 media-gfx/zbar`
-
+    `sudo emerge dev-qt/qtcore:5 dev-qt/qtdeclarative:5 dev-qt/qtquickcontrols:5 dev-qt/qtquickcontrols2:5 dev-qt/qtgraphicaleffects:5 dev-qt/qtmultimedia:5 media-gfx/zbar`
 
 3. Clone repository
 
@@ -207,14 +196,8 @@ The Monero GUI on Windows is 64 bits only; 32-bit Windows GUI builds are not off
 3. Install MSYS2 packages for Monero dependencies; the needed 64-bit packages have `x86_64` in their names
 
     ```
-    pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb
+    pacman -S mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-zbar mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb
     ```
-
-    Optional : To build the flag `WITH_SCANNER`
-
-      ```
-      pacman -S mingw-w64-x86_64-zbar
-      ```
 
     You find more details about those dependencies in the [Monero documentation](https://github.com/monero-project/monero). Note that that there is no more need to compile Boost from source; like everything else, you can install it now with a MSYS2 package.
 

--- a/build.sh
+++ b/build.sh
@@ -27,16 +27,16 @@ find_command() {
 
 if [ "$BUILD_TYPE" == "release" ]; then
     echo "Building release"
-    CONFIG="CONFIG+=release";
+    CONFIG="CONFIG+=release WITH_SCANNER";
     BIN_PATH=release/bin
 elif [ "$BUILD_TYPE" == "release-static" ]; then
     echo "Building release-static"
     if [ "$platform" != "darwin" ]; then
-	    CONFIG="CONFIG+=release static";
+	    CONFIG="CONFIG+=release static WITH_SCANNER";
     else
         # OS X: build static libwallet but dynamic Qt. 
         echo "OS X: Building Qt project without static flag"
-        CONFIG="CONFIG+=release";
+        CONFIG="CONFIG+=release WITH_SCANNER";
     fi    
     BIN_PATH=release/bin
 elif [ "$BUILD_TYPE" == "release-android" ]; then
@@ -53,7 +53,7 @@ elif [ "$BUILD_TYPE" == "debug-android" ]; then
     DISABLE_PASS_STRENGTH_METER=true
 elif [ "$BUILD_TYPE" == "debug" ]; then
     echo "Building debug"
-	CONFIG="CONFIG+=debug"
+	CONFIG="CONFIG+=debug WITH_SCANNER"
     BIN_PATH=debug/bin
 else
     echo "Valid build types are release, release-static, release-android, debug-android and debug"

--- a/components/QRCodeScanner.qml
+++ b/components/QRCodeScanner.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2014-2019, The Monero Project
 //
 // All rights reserved.
 //
@@ -27,19 +27,20 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import QtQuick 2.9
-import QtMultimedia 5.4
+import QtMultimedia 5.8
+import QtQuick.Layouts 1.1
 import QtQuick.Dialogs 1.2
+import FontAwesome 1.0
 import moneroComponents.QRCodeScanner 1.0
+import "." as MoneroComponents
 
 Rectangle {
     id : root
-
     x: 0
     y: 0
     z: parent.z+1
     width: parent.width
     height: parent.height
-
     visible: false
     color: "black"
     state: "Stopped"
@@ -51,8 +52,9 @@ Rectangle {
             name: "Capture"
             StateChangeScript {
                 script: {
-		    root.visible = true
+                    root.visible = true
                     camera.captureMode = Camera.CaptureStillImage
+                    camera.cameraState = Camera.ActiveState
                     camera.start()
                     finder.enabled = true
                 }
@@ -63,8 +65,9 @@ Rectangle {
             StateChangeScript {
                 script: {
                     camera.stop()
-		    root.visible = false
+                    root.visible = false
                     finder.enabled = false
+                    camera.cameraState = Camera.UnloadedState
                 }
             }
         }
@@ -74,18 +77,19 @@ Rectangle {
         id: camera
         objectName: "qrCameraQML"
         captureMode: Camera.CaptureStillImage
-
+        cameraState: Camera.UnloadedState
         focus {
             focusMode: Camera.FocusContinuous
         }
     }
+
     QRCodeScanner {
         id : finder
         objectName: "QrFinder"
         onDecoded : {
             root.qrcode_decoded(address, payment_id, amount, tx_description, recipient_name, extra_parameters)
             root.state = "Stopped"
-	}
+        }
         onNotifyError : {
             if( warning )
                 messageDialog.icon = StandardIcon.Critical
@@ -119,6 +123,26 @@ Rectangle {
                 camera.searchAndLock()
             }
             onDoubleClicked: {
+                root.state = "Stopped"
+            }
+        }
+    }
+
+    Rectangle {
+        id: closeButton
+        anchors.top: root.top
+        anchors.right: root.right
+        anchors.topMargin: 64
+        anchors.rightMargin: 64
+        color: "transparent"
+        z: parent.z + 1
+
+        MoneroComponents.StandardButton {
+            id: btnDetails
+            text: FontAwesome.windowClose
+            label.font.family: FontAwesome.fontFamily
+            fontSize: 30
+            onClicked: {
                 root.state = "Stopped"
             }
         }

--- a/windeploy_helper.sh
+++ b/windeploy_helper.sh
@@ -23,7 +23,7 @@ else
 	ICU_FILES=(libicudtd62.dll libicuind62.dll libicuiod62.dll libicutud62.dll libicuucd62.dll)
 fi
 
-FILES=(libprotobuf.dll libusb-1.0.dll zlib1.dll libwinpthread-1.dll libtiff-5.dll libstdc++-6.dll libpng16-16.dll libpcre16-0.dll libpcre-1.dll libmng-2.dll liblzma-5.dll liblcms2-2.dll libjpeg-8.dll libintl-8.dll libiconv-2.dll libharfbuzz-0.dll libgraphite2.dll libglib-2.0-0.dll libfreetype-6.dll libbz2-1.dll libssp-0.dll libpcre2-16-0.dll libhidapi-0.dll)
+FILES=(libprotobuf.dll libusb-1.0.dll zlib1.dll libwinpthread-1.dll libtiff-5.dll libstdc++-6.dll libpng16-16.dll libpcre16-0.dll libpcre-1.dll libmng-2.dll liblzma-5.dll liblcms2-2.dll libjpeg-8.dll libintl-8.dll libiconv-2.dll libharfbuzz-0.dll libgraphite2.dll libglib-2.0-0.dll libfreetype-6.dll libbz2-1.dll libssp-0.dll libpcre2-16-0.dll libhidapi-0.dll libzbar-0.dll)
 
 platform=$(get_platform)
 


### PR DESCRIPTION
Lack of QR scanning capability is a major inconvenience when moving funds. i.e. sending from GUI to a mobile wallet or paper wallet/offline wallet.

Before this is merged,
- verify working on buildbots / build environment
- verify readme works on MacOS as is, or if further updates required.
- depends on #1807

Thoughts?