### PR TITLE
middlepanel: fix length of scrollable area on Transfer page

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -118,7 +118,7 @@ Rectangle {
             }, State {
                 name: "Transfer"
                 PropertyChanges { target: root; currentView: transferView }
-                PropertyChanges { target: mainFlickable; contentHeight: 1000 * scaleRatio }
+                PropertyChanges { target: mainFlickable; contentHeight: 700 * scaleRatio }
             }, State {
                name: "Receive"
                PropertyChanges { target: root; currentView: receiveView }


### PR DESCRIPTION
#1806 (5)

Corrects: why can scroll this far on the Transfer page?