### PR TITLE
RadioButton: remove a gap between rectangle and text, fix layout

### DIFF
--- a/components/RadioButton.qml
+++ b/components/RadioButton.qml
@@ -31,7 +31,7 @@ import QtQuick.Layouts 1.1
 
 import "../components" as MoneroComponents
 
-RowLayout {
+Item {
     id: radioButton
     property alias text: label.text
     property bool checked: false
@@ -39,6 +39,7 @@ RowLayout {
     property alias fontColor: label.color
     signal clicked()
     height: 26 * scaleRatio
+    width: layout.width
     // legacy properties
     property var checkedColor: "white"
     property var borderColor: checked ? Qt.rgba(1, 1, 1, 0.35) : Qt.rgba(1, 1, 1, 0.25)
@@ -49,15 +50,14 @@ RowLayout {
     }
 
     RowLayout {
-        Layout.fillWidth: true
+        id: layout
+
         Rectangle {
             id: button
-            anchors.left: parent.left
-            y: 0
             color: "transparent"
             border.color: borderColor
-            width: radioButton.height
             height: radioButton.height
+            width: radioButton.height
             radius: radioButton.height
 
             Rectangle {
@@ -70,32 +70,23 @@ RowLayout {
                 radius: 10
                 opacity: 0.8
             }
-
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onClicked: {
-                    toggle()
-                }
-            }
         }
 
         Text {
             id: label
-            anchors.left: button.right
-            anchors.leftMargin: !isMobile ? 10 : 8
+            Layout.leftMargin: (!isMobile ? 10 : 8) * scaleRatio
             color: MoneroComponents.Style.defaultFontColor
             font.family: MoneroComponents.Style.fontRegular.name
             font.pixelSize: radioButton.fontSize
             wrapMode: Text.Wrap
+        }
+    }
 
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                onClicked: {
-                    toggle()
-                }
-            }
+    MouseArea {
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+        onClicked: {
+            toggle()
         }
     }
 }


### PR DESCRIPTION
Same as https://github.com/monero-project/monero-gui/pull/1782