### PR TITLE
main: disable resize bar if custom decorations are off

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1564,6 +1564,7 @@ ApplicationWindow {
         property int minHeight: 400
         MouseArea {
             id: resizeArea
+            enabled: persistentSettings.customDecorations
             hoverEnabled: true
             anchors.right: parent.right
             anchors.bottom: parent.bottom
@@ -1577,6 +1578,7 @@ ApplicationWindow {
 
             Image {
                 anchors.centerIn: parent
+                visible: persistentSettings.customDecorations
                 source: parent.containsMouse || parent.pressed ? "images/resizeHovered.png" :
                                                                  "images/resize.png"
             }


### PR DESCRIPTION
This should be the job of the window manager. It makes sense to disable it if custom decorations aren’t used.