### PR TITLE
keys: add secret spend key text for viewonly wallet

### DIFF
--- a/pages/Keys.qml
+++ b/pages/Keys.qml
@@ -276,7 +276,8 @@ Rectangle {
                 viewOnlyQRCode.visible = true
                 showFullQr.visible = false
                 showViewOnlyQr.visible = false
-                seedText.text = qsTr("(View Only Wallet -  No mnemonic seed available)") + translationManager.emptyString
+                seedText.text = qsTr("(View Only Wallet - No mnemonic seed available)") + translationManager.emptyString
+                secretSpendKey.text = qsTr("(View Only Wallet - No secret spend key available)") + translationManager.emptyString
             }
         }
     }


### PR DESCRIPTION
For UI completeness + consistency purposes.

Before 
![beforeviewonlywallet](https://user-images.githubusercontent.com/40871101/50318161-52009c80-0474-11e9-8548-ed98ce581eee.PNG)

After
![consistency](https://user-images.githubusercontent.com/40871101/50318146-3e553600-0474-11e9-8efe-1237fef8f98d.PNG)

