### PR TITLE
LineEditMulti: fix showingHeader and padding (empty label case)

### DIFF
--- a/components/LineEditMulti.qml
+++ b/components/LineEditMulti.qml
@@ -78,7 +78,7 @@ ColumnLayout {
     property var onPaste: function(clipboardText) {
         item.text = clipboardText;
     }
-    property bool showingHeader: true
+    property bool showingHeader: labelText != "" || copyButton || pasteButton
     property var wrapMode: Text.NoWrap
     property alias addressValidation: input.addressValidation
     property string backgroundColor: "" // mock
@@ -150,7 +150,7 @@ ColumnLayout {
         readOnly: false
         addressValidation: false
         Layout.fillWidth: true
-        topPadding: item.showingHeader ? 10 * scaleRatio : 0
+        topPadding: 10 * scaleRatio
         bottomPadding: 10 * scaleRatio
         wrapMode: item.wrapMode
         fontSize: item.fontSize


### PR DESCRIPTION
The same way this is handled in `LineEdit` component implementation