### PR TITLE
Transfer: disable long payment ids by default

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1049,6 +1049,7 @@ ApplicationWindow {
         property bool hideBalance: false
         property bool lockOnUserInActivity: true
         property int lockOnUserInActivityInterval: 10  // minutes
+        property bool showPid: false
     }
 
     // Information dialog

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -71,6 +71,7 @@ Rectangle {
 
         LineEditMulti {
             id: paymentIdLine
+            visible: appWindow.persistentSettings.showPid
             Layout.fillWidth: true;
             labelText: qsTr("Payment ID <font size='2'>(Optional)</font>") + translationManager.emptyString
             placeholderText: qsTr("Paste 64 hexadecimal characters") + translationManager.emptyString

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -293,6 +293,8 @@ Rectangle {
       }
 
       ColumnLayout {
+          visible: appWindow.persistentSettings.showPid || paymentIdCheckbox.checked 
+
           CheckBox {
               id: paymentIdCheckbox
               border: false

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -80,6 +80,16 @@ Rectangle {
 
         MoneroComponents.CheckBox {
             visible: !isMobile
+            id: showPidCheckBox
+            checked: persistentSettings.showPid
+            onClicked: {
+                persistentSettings.showPid = !persistentSettings.showPid
+            }
+            text: qsTr("Enable transfer with payment ID (OBSOLETE)") + translationManager.emptyString
+        }
+
+        MoneroComponents.CheckBox {
+            visible: !isMobile
             id: userInActivityCheckbox
             checked: persistentSettings.lockOnUserInActivity
             onClicked: persistentSettings.lockOnUserInActivity = !persistentSettings.lockOnUserInActivity


### PR DESCRIPTION
monero-project/monero#5020

Not sure how this should be implemented, this is just an idea.

Default looks like this: 

<img width="1081" alt="screenshot 2018-12-27 at 19 55 52" src="https://user-images.githubusercontent.com/7697454/50491211-7aa70a00-0a11-11e9-99d2-ca6226de30b0.png">

Can be re-enabled in settings.

<img width="1081" alt="screenshot 2018-12-27 at 19 55 48" src="https://user-images.githubusercontent.com/7697454/50491205-767aec80-0a11-11e9-9753-c782bac42376.png">

