### PR TITLE
PasswordDialog: cancel button text is more descriptive and dynamic

### DIFF
--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -191,7 +191,7 @@ Item {
                 MoneroComponents.StandardButton {
                     id: cancelButton
                     small: true
-                    text: qsTr("Cancel") + translationManager.emptyString
+                    text: root.walletName.length > 0 ? qsTr("Change wallet") + translationManager.emptyString : qsTr("Cancel") + translationManager.emptyString
                     KeyNavigation.tab: passwordInput
                     onClicked: {
                         root.close()


### PR DESCRIPTION
![cancel](https://user-images.githubusercontent.com/40871101/50549942-4c951600-0c1b-11e9-9361-93b757ef035b.gif)
