### PR TITLE
build: always checkout latest remote master

### DIFF
--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -17,7 +17,7 @@ if [ ! -d $MONERO_DIR/src ]; then
 fi
 git submodule update --remote
 git -C $MONERO_DIR fetch
-git -C $MONERO_DIR checkout master
+git -C $MONERO_DIR checkout origin/master
 
 # get monero core tag
 pushd $MONERO_DIR


### PR DESCRIPTION
Not sure if this is more correct, but I ran into weird caching issues where `git -C $MONERO_DIR checkout master` would checkout deleted local commits.