### PR TITLE
AddressBook: hide 'Add' form when invoked from 'Send' tab

### DIFF
--- a/components/AddressBookTable.qml
+++ b/components/AddressBookTable.qml
@@ -34,6 +34,7 @@ ListView {
     id: listView
     clip: true
     boundsBehavior: ListView.StopAtBounds
+    property bool selectAndSend: false
 
     footer: Rectangle {
         height: 127
@@ -57,6 +58,11 @@ ListView {
         color: "transparent"
         z: listView.count - index
         function collapseDropdown() { dropdown.expanded = false }
+        function doSend() {
+            console.log("Sending to: ", address +" "+ paymentId);
+            middlePanel.sendTo(address, paymentId, description);
+            leftPanel.selectItem(middlePanel.state)
+        }
 
         Text {
             id: descriptionText
@@ -148,6 +154,7 @@ ListView {
             anchors.verticalCenter: parent.verticalCenter
             anchors.rightMargin: 5
             dataModel: dropModel
+            visible: !listView.selectAndSend
             z: 1
             onExpandedChanged: {
                 if(expanded) {
@@ -163,9 +170,7 @@ ListView {
                     appWindow.showStatusMessage(qsTr("Address copied to clipboard"),3)
                 }
                 else if(option === 1){
-                   console.log("Sending to: ", address +" "+ paymentId);
-                   middlePanel.sendTo(address, paymentId, description);
-                   leftPanel.selectItem(middlePanel.state)
+                    doSend()
                 } else if(option === 2){
                     console.log("Delete: ", rowId);
                     currentWallet.addressBookModel.deleteRow(rowId);
@@ -179,6 +184,15 @@ ListView {
             anchors.bottom: parent.bottom
             height: 1
             color: "#404040"
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            visible: listView.selectAndSend
+            onClicked: {
+                doSend();
+            }
         }
     }
 }

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -32,18 +32,17 @@ import "../components"
 import moneroComponents.AddressBook 1.0
 import moneroComponents.AddressBookModel 1.0
 
-Rectangle {
+ColumnLayout {
     id: root
-    color: "transparent"
     property var model
+    property bool selectAndSend: false
 
     ColumnLayout {
-        id: columnLayout
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.right: parent.right
+        Layout.margins: (isMobile ? 17 : 20) * scaleRatio
+        Layout.topMargin: 40 * scaleRatio
+        Layout.fillWidth: true
         spacing: 26 * scaleRatio
+        visible: !root.selectAndSend
 
         RowLayout {
             StandardButton {
@@ -118,13 +117,11 @@ Rectangle {
 
     Rectangle {
         id: tableRect
-        anchors.top: columnLayout.bottom
-        anchors.leftMargin: (isMobile)? 17 : 40
-        anchors.rightMargin: (isMobile)? 17 : 40
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        height: parent.height - addButton.y - addButton.height - 36 * scaleRatio
+        Layout.leftMargin: (isMobile ? 17 : 40) * scaleRatio
+        Layout.rightMargin: (isMobile ? 17 : 40) * scaleRatio
+        Layout.topMargin: (root.selectAndSend ? 40 : 0) * scaleRatio
+        Layout.fillHeight: true
+        Layout.fillWidth: true
         color: "transparent"
 
         Behavior on height {
@@ -148,6 +145,7 @@ Rectangle {
             anchors.bottom: parent.bottom
             onContentYChanged: flickableScroll.flickableContentYChanged()
             model: root.model
+            selectAndSend: root.selectAndSend
         }
     }
 
@@ -165,6 +163,10 @@ Rectangle {
       paymentIdLine.error = !payment_id_ok
 
       return address_ok && payment_id_ok
+    }
+
+    function onPageClosed() {
+        root.selectAndSend = false;
     }
 
     function onPageCompleted() {

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -213,7 +213,10 @@ Rectangle {
               placeholderText: "4.. / 8.."
               wrapMode: Text.WrapAnywhere
               addressValidation: true
-              onInputLabelLinkActivated: { appWindow.showPageRequest("AddressBook") }
+              onInputLabelLinkActivated: {
+                  middlePanel.addressBookView.selectAndSend = true;
+                  appWindow.showPageRequest("AddressBook");
+              }
               pasteButton: true
               onPaste: function(clipboardText) {
                   const parsed = walletManager.parse_uri_to_object(clipboardText);


### PR DESCRIPTION
https://github.com/monero-project/monero-gui/issues/1901 (1)

![addressbook-selectandsend](https://user-images.githubusercontent.com/26060097/51196534-378cd800-18e7-11e9-82e4-0085ff577bdd.gif)
