### PR TITLE
IconButton: fix mousearea and remove animation

### DIFF
--- a/components/IconButton.qml
+++ b/components/IconButton.qml
@@ -35,7 +35,6 @@ Item {
 
     signal clicked(var mouse)
 
-
     id: button
     width: parent.height
     height: parent.height
@@ -47,13 +46,13 @@ Item {
         id: buttonImage
         source: ""
         x : (parent.width - width) / 2
-        y : (parent.height - height)  /2
+        y : (parent.height - height) / 2
         z: 100
     }
 
     MouseArea {
         id: buttonArea
-        anchors.fill: parent
+        anchors.fill: buttonImage
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
 
@@ -61,14 +60,21 @@ Item {
             buttonImage.x = buttonImage.x + 2
             buttonImage.y = buttonImage.y + 2
         }
+
         onReleased: {
-            buttonImage.x = buttonImage.x - 2
-            buttonImage.y = buttonImage.y - 2
+            buttonImage.x = (parent.width - width) / 2
+            buttonImage.y = (parent.height - height) / 2
+        }
+
+        onExited: {
+            if (pressed) {
+                buttonImage.x = (parent.width - width) / 2
+                buttonImage.y = (parent.height - height) / 2
+            }
         }
 
         onClicked: {
             parent.clicked(mouse)
         }
     }
-
 }


### PR DESCRIPTION
The animation was buggy if the mouse got released mouse outside of the mouse-area or outside of the whole program. Maybe someone has an idea how this can get fixed instead of removing it?