### PR TITLE
Bring back paymentID to tranfer page and force hide paymentId on a settings toggle

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1047,7 +1047,7 @@ ApplicationWindow {
         property bool hideBalance: false
         property bool lockOnUserInActivity: true
         property int lockOnUserInActivityInterval: 10  // minutes
-        property bool showPid: false
+        property bool showPid: true
     }
 
     // Information dialog

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -300,7 +300,7 @@ Rectangle {
               fontSize: paymentIdLine.labelFontSize
               iconOnTheLeft: false
               Layout.fillWidth: true
-              text: qsTr("Payment ID <font size='2'>( Optional )</font>") + translationManager.emptyString
+              text: qsTr("Payment ID <font size='2'>( Optional, deprecated )</font>") + translationManager.emptyString
               onClicked: {
                   if (!paymentIdCheckbox.checked) {
                     paymentIdLine.text = "";

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -84,6 +84,7 @@ Rectangle {
             checked: persistentSettings.showPid
             onClicked: {
                 persistentSettings.showPid = !persistentSettings.showPid
+                middlePanel.transferView.clearFields();
             }
             text: qsTr("Enable transfer with payment ID (OBSOLETE)") + translationManager.emptyString
         }


### PR DESCRIPTION
This was reported by charuto on https://git.pwned.systems/monero-project/monero-gui/issues/1

> If payment ID option is expanded, upon removing the payment ID setting, it will remain on the send page.
> Tested on master branch.

**Edit**: Brought back payment id to the transfer page, albeit collapsed by default, as was decided in the [dev meeting](https://www.reddit.com/r/Monero/comments/akmf5q/logs_of_yesterdays_dev_meeting/).