### PR TITLE
transfer: fix non-existent property cursorPosition

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -265,7 +265,6 @@ Rectangle {
                       if (parts[0] === "true") {
                           if (address_ok) {
                               addressLine.text = parts[1]
-                              addressLine.cursorPosition = 0
                           }
                           else
                               oa_message(qsTr("No valid address found at this OpenAlias address"))
@@ -273,7 +272,6 @@ Rectangle {
                       else if (parts[0] === "false") {
                             if (address_ok) {
                                 addressLine.text = parts[1]
-                                addressLine.cursorPosition = 0
                                 oa_message(qsTr("Address found, but the DNSSEC signatures could not be verified, so this address may be spoofed"))
                             }
                             else


### PR DESCRIPTION
WARNING	frontend	src/wallet/api/wallet.cpp:367	qrc:/pages/Transfer.qml:271: Error: Cannot assign to non-existent property "cursorPosition"