### PR TITLE
warningbox: make text readonly

### DIFF
--- a/components/WarningBox.qml
+++ b/components/WarningBox.qml
@@ -51,7 +51,7 @@ Rectangle {
             textMargin: 0
             leftPadding: 0
             topPadding: 6
-            readOnly: false
+            readOnly: true
             onLinkActivated: root.linkActivated();
 
             // @TODO: Legacy. Remove after Qt 5.8.


### PR DESCRIPTION
Fixes this from happening.

![sda](https://user-images.githubusercontent.com/40871101/52158082-80fc5780-2649-11e9-9541-2281bea270e9.PNG)
