### PR TITLE
Re-revert hasty paymentID revert

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1054,7 +1054,7 @@ ApplicationWindow {
         property bool hideBalance: false
         property bool lockOnUserInActivity: true
         property int lockOnUserInActivityInterval: 10  // minutes
-        property bool showPid: true
+        property bool showPid: false
     }
 
     // Information dialog

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -299,7 +299,7 @@ Rectangle {
               fontSize: paymentIdLine.labelFontSize
               iconOnTheLeft: false
               Layout.fillWidth: true
-              text: qsTr("Payment ID <font size='2'>( Optional, deprecated )</font>") + translationManager.emptyString
+              text: qsTr("Payment ID <font size='2'>( Optional )</font>") + translationManager.emptyString
               onClicked: {
                   if (!paymentIdCheckbox.checked) {
                     paymentIdLine.text = "";

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -84,7 +84,6 @@ Rectangle {
             checked: persistentSettings.showPid
             onClicked: {
                 persistentSettings.showPid = !persistentSettings.showPid
-                middlePanel.transferView.clearFields();
             }
             text: qsTr("Enable transfer with payment ID (OBSOLETE)") + translationManager.emptyString
         }


### PR DESCRIPTION
This reverts PR https://github.com/monero-project/monero-gui/pull/1916 commit 02493be6eb7426b2814d356283c5877e779f1aea.

Standalone/long Payment ID must be hidden by default with the next fork.