### PR TITLE
wizard: fix restore from key and seed functionality

### DIFF
--- a/js/Wizard.js
+++ b/js/Wizard.js
@@ -3,18 +3,18 @@
 function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name, extra_parameters) {
     // Switch to recover from keys
     recoverFromSeedMode = false
-    spendkey.text = ""
+    spendKeyLine.text = ""
     viewKeyLine.text = ""
-    restoreHeightItem.text = ""
+    restoreHeight.text = ""
 
     if(typeof extra_parameters.secret_view_key != "undefined") {
         viewKeyLine.text = extra_parameters.secret_view_key
     }
     if(typeof extra_parameters.secret_spend_key != "undefined") {
-        spendkey.text = extra_parameters.secret_spend_key
+        spendKeyLine.text = extra_parameters.secret_spend_key
     }
     if(typeof extra_parameters.restore_height != "undefined") {
-        restoreHeightItem.text = extra_parameters.restore_height
+        restoreHeight.text = extra_parameters.restore_height
     }
     addressLine.text = address
 
@@ -170,12 +170,14 @@ function checkSeed(seed) {
 }
 
 function restoreWalletCheckViewSpendAddress(walletmanager, nettype, viewkey, spendkey, addressline){
-    var addressOK = (viewkey.length > 0 || spendkey.length > 0) ? walletmanager.addressValid(addressline, nettype) : false
-    var viewKeyOK = (viewkey.length > 0) ? walletmanager.keyValid(viewkey, addressline, true, nettype) : true
-    // Spendkey is optional
-    var spendKeyOK = (spendkey.length > 0) ? walletmanager.keyValid(spendkey, addressline, false, nettype) : true
-
-    return addressOK && viewKeyOK && spendKeyOK
+    var results = [];
+    // addressOK
+    results[0] = walletmanager.addressValid(addressline, nettype);
+    // viewKeyOK
+    results[1] = walletmanager.keyValid(viewkey, addressline, true, nettype);
+    // spendKeyOK, Spendkey is optional
+    results[2] = walletmanager.keyValid(spendkey, addressline, false, nettype);
+    return results;
 }
 
 //usage: getApproximateBlockchainHeight("March 18 2016") or getApproximateBlockchainHeight("2016-11-11")

--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -128,7 +128,6 @@ Rectangle {
 
                 onMenuClicked: {
                     wizardController.restart();
-                    wizardController.createWallet();
                     wizardStateView.state = "wizardRestoreWallet1"
                 }
             }

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -75,8 +75,7 @@ Rectangle {
         viewKeyLine.error = !result[1] && viewKeyLineLength != 0
         spendKeyLine.error = !result[2] && spendKeyLineLength != 0
 
-        return (!addressLine.error && !viewKeyLine.error && !spendKeyLine.error && 
-            addressLineLength != 0 && viewKeyLineLength != 0 && spendKeyLineLength != 0)
+        return (result[0] && result[1] && result[2])
     }
 
     function checkRestoreHeight() {
@@ -273,7 +272,17 @@ Rectangle {
                 onNextClicked: {
                     wizardController.walletOptionsName = wizardWalletInput.walletName.text;
                     wizardController.walletOptionsLocation = wizardWalletInput.walletLocation.text;
-                    wizardController.walletOptionsSeed = seedInput.text;
+
+                    switch (wizardController.walletRestoreMode) {
+                        case 'seed':
+                            wizardController.walletOptionsSeed = seedInput.text;
+                            break;
+                        default: // walletRestoreMode = keys or qr
+                            wizardController.walletOptionsRecoverAddress = addressLine.text;
+                            wizardController.walletOptionsRecoverViewkey = viewKeyLine.text
+                            wizardController.walletOptionsRecoverSpendkey = spendKeyLine.text;
+                            break;
+                    }
 
                     var _restoreHeight = 0;
                     if(restoreHeight.text){
@@ -299,6 +308,7 @@ Rectangle {
             seedInput.text = "";
             addressLine.text = "";
             spendKeyLine.text = "";
+            viewKeyLine.text = "";
             restoreHeight.text = "";
         }
     }

--- a/wizard/WizardRestoreWallet4.qml
+++ b/wizard/WizardRestoreWallet4.qml
@@ -75,6 +75,7 @@ Rectangle {
                     }
                 }
                 onNextClicked: {
+                    wizardController.recoveryWallet();
                     wizardController.writeWallet();
                     wizardController.useMoneroClicked();
                 }


### PR DESCRIPTION
While triaging https://github.com/monero-project/monero-gui/pull/1909#issuecomment-464224316
with the broken restore height functionality when restoring an existing wallet, it seems the whole restore from keys/seed functionality needed fixing. Also fixed some variable naming issues in updateFromQrCode.