### PR TITLE
Revert StandardButton

### DIFF
--- a/components/StandardButton.qml
+++ b/components/StandardButton.qml
@@ -35,6 +35,7 @@ Item {
     id: button
     property string rightIcon: ""
     property string rightIconInactive: ""
+    property string icon: ""
     property string textColor: button.enabled? MoneroComponents.Style.buttonTextColor: MoneroComponents.Style.buttonTextColorDisabled
     property string textAlign: rightIcon !== "" ? "left" : "center"
     property bool small: false
@@ -45,10 +46,23 @@ Item {
     }
     signal clicked()
 
-    height: small ?  30 * scaleRatio : 36 * scaleRatio
-    width: buttonLayout.width + 22 * scaleRatio
-    implicitHeight: height
-    implicitWidth: width
+    // Dynamic height/width
+    Layout.minimumWidth: {
+        var _padding = 22;
+        if(button.rightIcon !== ""){
+            _padding += 60;
+        }
+
+        var _width = label.contentWidth + _padding;
+        if(_width <= 50) {
+            return 60;
+        }
+
+        return _width;
+    }
+
+    width: Layout.minimumWidth
+    height: small ?  28 * scaleRatio : 34 * scaleRatio
 
     function doClick() {
         // Android workaround
@@ -57,91 +71,70 @@ Item {
     }
 
     Rectangle {
-        id: buttonRect
-        anchors.fill: parent
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: parent.height - 1
         radius: 3
+        color: parent.enabled ? MoneroComponents.Style.buttonBackgroundColor : MoneroComponents.Style.buttonBackgroundColorDisabled
         border.width: parent.focus ? 1 : 0
 
-        state: button.enabled ? "active" : "disabled"
-        Component.onCompleted: state = state
-        states: [
-            State {
-                name: "hover"
-                when: buttonArea.containsMouse || button.focus
-                PropertyChanges {
-                    target: buttonRect
-                    color: MoneroComponents.Style.buttonBackgroundColorHover
-                }
-            },
-            State {
-                name: "active"
-                when: button.enabled
-                PropertyChanges {
-                    target: buttonRect
-                    color: MoneroComponents.Style.buttonBackgroundColor
-                }
-            },
-            State {
-                name: "disabled"
-                when: !button.enabled
-                PropertyChanges {
-                    target: buttonRect
-                    color: MoneroComponents.Style.buttonBackgroundColorDisabled
-                }
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            hoverEnabled: true
+
+            propagateComposedEvents: true
+
+            // possibly do some hover effects here
+            onEntered: {
+//                if(button.enabled) parent.color = Style.buttonBackgroundColorHover;
+//                else parent.color = Style.buttonBackgroundColorDisabledHover;
             }
-        ]
-        transitions: Transition {
-            ColorAnimation { duration: 100 }
+            onExited: {
+//                if(button.enabled) parent.color = Style.buttonBackgroundColor;
+//                else parent.color = Style.buttonBackgroundColorDisabled;
+            }
         }
     }
 
-    RowLayout {
-        id: buttonLayout
-        height: button.height
-        spacing: 11 * scaleRatio
+    Text {
+        id: label
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
+        anchors.right: parent.right
+        horizontalAlignment: textAlign === "center" ? Text.AlignHCenter : Text.AlignLeft
+        anchors.leftMargin: textAlign === "center" ? 0 : 11
+        font.family: MoneroComponents.Style.fontBold.name
+        font.bold: true
+        font.pixelSize: buttonArea.pressed ? button.fontSize - 1 : button.fontSize
+        color: parent.textColor
+        visible: parent.icon === ""
+    }
+
+    Image {
         anchors.centerIn: parent
+        visible: parent.icon !== ""
+        source: parent.icon
+    }
 
-        Text {
-            id: label
-            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
-            horizontalAlignment: textAlign === "center" ? Text.AlignHCenter : Text.AlignLeft
-            font.family: MoneroComponents.Style.fontBold.name
-            font.bold: true
-            font.pixelSize: button.fontSize
-            color: !buttonArea.pressed ? button.textColor : "transparent"
-            visible: text !== ""
-
-            Text {
-                anchors.fill: parent
-                color: button.textColor
-                font.bold: label.font.bold
-                font.family: label.font.family
-                font.pixelSize: label.font.pixelSize - 1
-                horizontalAlignment: label.horizontalAlignment
-                Layout.alignment: label.Layout.alignment
-                text: label.text
-                visible: buttonArea.pressed
+    Image {
+        visible: parent.rightIcon !== ""
+        anchors.right: parent.right
+        anchors.rightMargin: 11 * scaleRatio
+        anchors.verticalCenter: parent.verticalCenter
+        width: parent.small ? 16 * scaleRatio : 20 * scaleRatio
+        height: parent.small ? 16 * scaleRatio : 20 * scaleRatio
+        source: {
+            if(parent.rightIconInactive !== "" && !parent.enabled){
+                return parent.rightIconInactive;
             }
-        }
-
-        Image {
-            visible: button.rightIcon !== ""
-            Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-            width: button.small ? 16 * scaleRatio : 20 * scaleRatio
-            height: button.small ? 16 * scaleRatio : 20 * scaleRatio
-            source: {
-                if(button.rightIconInactive !== "" && !button.enabled) {
-                    return button.rightIconInactive;
-                }
-                return button.rightIcon;
-            }
+            return parent.rightIcon;
         }
     }
 
     MouseArea {
         id: buttonArea
         anchors.fill: parent
-        hoverEnabled: true
         onClicked: doClick()
         cursorShape: Qt.PointingHandCursor
     }


### PR DESCRIPTION
Buildbot issue; StandardButton not rendering correctly.

![](https://i.imgur.com/ASzgEPM.png)

I am forced to revert the following commits:

- [standard-button: handle changing text/icon at runtime](https://github.com/monero-project/monero-gui/commit/fbac6f2afa8cfae88d76f5870afaa373eedf86de#diff-dac8547eb93796c69b4db4f20dc95ef9) - Dec 13 2018 - @xiphon
- [standard-button: remove redundant 'icon' property](https://github.com/monero-project/monero-gui/commit/831dc59013a2af28eaae9ee83e1e1811a7ccc090#diff-dac8547eb93796c69b4db4f20dc95ef9) Dec 8, 2018 - @xiphon 
- [standard-button: add hover color animation](https://github.com/monero-project/monero-gui/commit/f8a920dc38d1af80148cbc88fb820871e4ba41cf#diff-dac8547eb93796c69b4db4f20dc95ef9) Dec 8 2018 - @xiphon
- [standard-button: fix layout](https://github.com/monero-project/monero-gui/commit/e0796b24c98ac1c20a140ee1d194e62efe3b00a7#diff-dac8547eb93796c69b4db4f20dc95ef9) Dec 8 2018 - @xiphon

These were rather nice features from @xiphon, so I propose to get them back for the next point release (14.1). This buys us time to figure out what is wrong with the buildbot, potentially upgrading to Qt 5.9 in the process.

The bug can be observed on the [buildbot](https://build.getmonero.org/builders/monero-gui-ubuntu-amd64/builds/1570)