### PR TITLE
wizardsummary: hide restore height when creating new wallet

### DIFF
--- a/wizard/WizardSummary.qml
+++ b/wizard/WizardSummary.qml
@@ -67,6 +67,7 @@ ColumnLayout {
         Layout.fillWidth: true
         header: qsTr("Restore height") + translationManager.emptyString
         value: wizardController.walletOptionsRestoreHeight
+        visible: wizardStateView.state != "wizardCreateWallet4"
     }
 
     WizardSummaryItem {


### PR DESCRIPTION
Extraneous information.