### PR TITLE
transfer: make simple mode more simple

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -127,7 +127,7 @@ Rectangle {
       }
 
       GridLayout {
-          columns: (isMobile)? 1 : 2
+          columns: (isMobile || !(appWindow.walletMode >= 2)) ? 1 : 2
           Layout.fillWidth: true
           columnSpacing: 32
 
@@ -165,6 +165,7 @@ Rectangle {
           }
 
           ColumnLayout {
+              visible: appWindow.walletMode >= 2
               Layout.fillWidth: true
               Label {
                   id: transactionPriority


### PR DESCRIPTION
Less is more in simple mode. 

Only the absolute required fields should be visible. Compared to other beginner-friendly wallets, only the essentials remain. Those are amount and address. Currently, transfer page in simple has two extra optional touch points causing undue user thoughts and doubt. Removed transaction priority and description based on some user's feedback. Thoughts?

After
![feed](https://user-images.githubusercontent.com/40871101/53309581-89693c00-385d-11e9-8a5a-6c6ba2810e93.PNG)

Before

![afttt](https://user-images.githubusercontent.com/40871101/53309582-8b32ff80-385d-11e9-8a6d-c81357498a59.PNG)
