### PR TITLE
Dont show message on simple mode disconnect/reconnect

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1791,7 +1791,7 @@ ApplicationWindow {
                 appWindow.disconnectedEpoch = 0;
                 return;
             }, function(){
-                appWindow.showStatusMessage(qsTr("Failed to fetch remote nodes from third-party server."), simpleModeConnectionTimer.interval / 1000);
+                console.log("Failed to fetch remote nodes from third-party server.");
             });
         }
     }

--- a/wizard/WizardCreateWallet2.qml
+++ b/wizard/WizardCreateWallet2.qml
@@ -73,7 +73,7 @@ Rectangle {
                         wizardController.fetchRemoteNodes(function(){
                             wizardStateView.state = "wizardCreateWallet4";
                         }, function(){
-                            appWindow.showStatusMessage(qsTr("Failed to fetch remote nodes from third-party server."), 5);
+                            console.log("Failed to fetch remote nodes from third-party server.");
                             wizardStateView.state = "wizardCreateWallet4";
                         });
                     } else {

--- a/wizard/WizardOpenWallet1.qml
+++ b/wizard/WizardOpenWallet1.qml
@@ -198,7 +198,7 @@ Rectangle {
                                     wizardController.fetchRemoteNodes(function(){
                                         wizardController.openWalletFile(moneroAccountsDir + "/" + fileName + "/" + fileName + ".keys");
                                     }, function(){
-                                        appWindow.showStatusMessage(qsTr("Failed to fetch remote nodes from third-party server."), 5);
+                                        console.log("Failed to fetch remote nodes from third-party server.");
                                         wizardController.openWalletFile(moneroAccountsDir + "/" + fileName + "/" + fileName + ".keys");
                                     });
                                 } else {

--- a/wizard/WizardRestoreWallet2.qml
+++ b/wizard/WizardRestoreWallet2.qml
@@ -72,7 +72,7 @@ Rectangle {
                         wizardController.fetchRemoteNodes(function(){
                             wizardStateView.state = "wizardRestoreWallet4";
                         }, function(){
-                            appWindow.showStatusMessage(qsTr("Failed to fetch remote nodes from third-party server."), 5);
+                            console.log("Failed to fetch remote nodes from third-party server.");
                             wizardStateView.state = "wizardRestoreWallet4";
                         });
                     } else {


### PR DESCRIPTION
I've noticed on Windows 10, it will show this warning message while connecting to a remote node, regardless if it is (eventually) successful or not. This is bad because users will think something is up, while it's working.

I loosely assume this is due to the Javascript code that does the XHR request to the node aggregator, but I don't know for sure. This behaviour has not happened to me on Linux. sgp observed the same problem.

For now, it's best to replace this message with `console.log()`. We can have decent status messages when xiphon's node magic gets merged for 14.1.