### PR TITLE
Add high-res images for mode selection wizard icons

### DIFF
--- a/qml.qrc
+++ b/qml.qrc
@@ -267,8 +267,11 @@
         <file>images/create-wallet@2x.png</file>
         <file>images/create-wallet.png</file>
         <file>images/remote-node.png</file>
+        <file>images/remote-node@2x.png</file>
         <file>images/local-node.png</file>
+        <file>images/local-node@2x.png</file>
         <file>images/local-node-full.png</file>
+        <file>images/local-node-full@2x.png</file>
         <file>wizard/WizardNavProgressDot.qml</file>
         <file>wizard/WizardOpenWallet1.qml</file>
     </qresource>


### PR DESCRIPTION
Static assets already included in repo, forgot to add to qml.qrc.