### PR TITLE
sign, receive: fix reference errors

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -221,7 +221,6 @@ Rectangle {
 
             MoneroComponents.CheckBox { 
                 id: addNewAccountCheckbox 
-                visible: !selectAndSend
                 border: false
                 checkedIcon: "qrc:///images/plus-in-circle-medium-white.png" 
                 uncheckedIcon: "qrc:///images/plus-in-circle-medium-white.png" 

--- a/pages/Sign.qml
+++ b/pages/Sign.qml
@@ -118,7 +118,6 @@ Rectangle {
                 id: modeText
                 Layout.fillWidth: true
                 Layout.topMargin: 12 * scaleRatio
-                Layout.preferredWidth: (instructionsRect.width - 80) * scaleRatio
                 text: qsTr("Mode") + translationManager.emptyString
                 wrapMode: Text.Wrap
                 font.family: MoneroComponents.Style.fontRegular.name


### PR DESCRIPTION
```
WARN 	frontend	src/wallet/api/wallet.cpp:367	qrc:/pages/Sign.qml:121: ReferenceError: instructionsRect is not defined
WARN 	frontend	src/wallet/api/wallet.cpp:367	qrc:/pages/Receive.qml:224: ReferenceError: selectAndSend is not defined
