### PR TITLE
invalidate wallet name after creation

### DIFF
--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -184,4 +184,10 @@ Rectangle {
         wizardCreateDevice1.update();
         console.log()
     }
+
+    function onPageCompleted(previousView){
+        if(previousView.viewName == "wizardHome"){
+            walletInput.reset();
+        }
+    }
 }

--- a/wizard/WizardCreateWallet1.qml
+++ b/wizard/WizardCreateWallet1.qml
@@ -144,4 +144,10 @@ Rectangle {
             }
         }
     }
+
+    function onPageCompleted(previousView){
+        if(previousView.viewName == "wizardHome"){
+            walletInput.reset();
+        }
+    }
 }

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -305,6 +305,7 @@ Rectangle {
     function onPageCompleted(previousView){
         if(previousView.viewName == "wizardHome"){
             // cleanup
+            walletInput.reset();
             seedInput.text = "";
             addressLine.text = "";
             spendKeyLine.text = "";

--- a/wizard/WizardWalletInput.qml
+++ b/wizard/WizardWalletInput.qml
@@ -52,6 +52,11 @@ GridLayout {
         return false;
     }
 
+    function reset() {
+        walletName.error = !walletName.verify();
+        walletLocation.error = walletLocation.text === "";
+    }
+
     MoneroComponents.LineEdit {
         id: walletName
         Layout.fillWidth: true


### PR DESCRIPTION
Fixes:

1. Create a wallet with the name "test"
2. Logout 
3. Create a new wallet with the same name, wizard isn’t complaining. If you close the GUI instead of logout, it will complain if you use the same wallet name.

Found by @selsta 