### PR TITLE
Resync translations for 0.14.0 (round two)

### DIFF
--- a/translations/monero-core.ts
+++ b/translations/monero-core.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3267,6 +3239,11 @@ Spending address index: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_ar.ts
+++ b/translations/monero-core_ar.ts
@@ -1356,6 +1356,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>لا توجد خيارات تخطيط بعد في وضع الهاتف المحمول.</translation>
@@ -2375,70 +2380,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>كلمه السر خاطئه</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>شبكه التجارب</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>شبكه تجارب</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>شبكه مونيرو</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2490,7 +2431,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>إختر ملف من فضلك</translation>
     </message>
@@ -2513,33 +2454,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">طول الإستعاده</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>إنشاء محفظه</translation>
     </message>
@@ -2575,6 +2526,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2884,6 +2843,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2953,6 +2917,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -3004,17 +2976,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>طول الإستعاده</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>عنوان الخادم</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>نوع الشبكه</translation>
     </message>
@@ -3022,22 +2994,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>إسم المحفظه</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>تصفح</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>من فضلك إختر مجلد</translation>
     </message>
@@ -3300,6 +3272,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>حطأ:</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_bg.ts
+++ b/translations/monero-core_bg.ts
@@ -1354,6 +1354,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation>След</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Смени езика</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Все още няма опции за изгледа в мобилен режим</translation>
@@ -2359,70 +2364,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Грешна парола</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>секунда (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>секунди (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>минута (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>минути (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>час (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>часа (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>ден (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>дни (преди)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Тестова мрежа</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Стейджнет</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Главна мрежа</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2474,7 +2415,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Моля изберете файл</translation>
     </message>
@@ -2497,33 +2438,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>В режим на ползване с хардуерно устройство.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Дата на създаване на портфейла във формат `ГГГГ-ММ-ДД` или височина за възстановяване</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Височина за възстановяване</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Брой събадреси за търсене (по подразбиране 200)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Грешка при записването на портфейла от хардуерното устройство. Моля проверете логовете на апликацията.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Обратно към менюто</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Създай портфейл</translation>
     </message>
@@ -2559,6 +2510,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Обратно към менюто</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2867,6 +2826,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>Портфейли използвани последно</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Обратно към менюто</translation>
@@ -2936,6 +2900,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2989,17 +2961,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>Височина за възстановяване</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Адрес на демона</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Стартов адрес</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Вид мрежа</translation>
     </message>
@@ -3007,22 +2979,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Име на портфейла</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Път до портфейла</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Търси</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Моля изберете директория</translation>
     </message>
@@ -3278,6 +3250,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Грешка: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_bn.ts
+++ b/translations/monero-core_bn.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3267,6 +3239,11 @@ Spending address index: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_cat.ts
+++ b/translations/monero-core_cat.ts
@@ -1355,6 +1355,11 @@ El fitxer antic de la memòria cau del moneder serà renombrat i es podrà recup
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Encara no hi ha opcions de disposició en el mode mòbil.</translation>
@@ -2367,70 +2372,6 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Contraseña incorrecta</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Xarxa de proves</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Xarxa de fase</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Xarxa principal</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2482,7 +2423,7 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Tria un fitxer</translation>
     </message>
@@ -2505,33 +2446,43 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Restaurar alçada</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Crea moneder</translation>
     </message>
@@ -2566,6 +2517,14 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2875,6 +2834,11 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2944,6 +2908,14 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2995,17 +2967,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Restaurar alçada</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Adreça del dimoni</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Tipus de xarxa</translation>
     </message>
@@ -3013,22 +2985,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">Nom del moneder</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Navega</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Tria un directori</translation>
     </message>
@@ -3363,6 +3335,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1503"/>
         <source>send to the same destination</source>
         <translation>envia al mateix destinatari</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_cs.ts
+++ b/translations/monero-core_cs.ts
@@ -1355,6 +1355,11 @@ Starý soubor s cache pamětí bude přejmenován a může být následně obnov
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>V mobilním zobrazení zatím nejsou dostupné možnosti úpravy vzhledu.</translation>
@@ -2374,70 +2379,6 @@ V případě odchozích plateb můžete získat doklad o výdajích, který dokl
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Špatné heslo</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testovací síť</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Hlavní síť</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2489,7 +2430,7 @@ V případě odchozích plateb můžete získat doklad o výdajích, který dokl
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Prosím vyberte soubor</translation>
     </message>
@@ -2512,33 +2453,43 @@ V případě odchozích plateb můžete získat doklad o výdajích, který dokl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Obnovit délku blockchainu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Vytvořit peněženku</translation>
     </message>
@@ -2573,6 +2524,14 @@ V případě odchozích plateb můžete získat doklad o výdajích, který dokl
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2882,6 +2841,11 @@ V případě odchozích plateb můžete získat doklad o výdajích, který dokl
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2951,6 +2915,14 @@ V případě odchozích plateb můžete získat doklad o výdajích, který dokl
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -3002,17 +2974,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Obnovit délku blockchainu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Adresa démona</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Typ sítě</translation>
     </message>
@@ -3020,22 +2992,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">Název peněženky</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Procházet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Prosím zvolte adresář</translation>
     </message>
@@ -3308,6 +3280,11 @@ Index výdajů: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Chyba: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_da.ts
+++ b/translations/monero-core_da.ts
@@ -1354,6 +1354,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Ingen layout indstillinger eksisterer ikke endnu for mobil versionen.</translation>
@@ -2360,70 +2365,6 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Forkert kodeord</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2475,7 +2416,7 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Vælg venligst en fil</translation>
     </message>
@@ -2498,33 +2439,43 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Genopret højde</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Opret tegnebog</translation>
     </message>
@@ -2559,6 +2510,14 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2868,6 +2827,11 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2937,6 +2901,14 @@ For the case of outgoing payments, you can get a &apos;Spend Proof&apos; that pr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2988,17 +2960,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Genopret højde</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Daemon adresse</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Netværkstype</translation>
     </message>
@@ -3006,22 +2978,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Gennemse</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Vælg venligst en destination</translation>
     </message>
@@ -3277,6 +3249,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Fejl: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_de.ts
+++ b/translations/monero-core_de.ts
@@ -1354,6 +1354,11 @@ Die alte Wallet-Cache-Datei wird umbenannt und kann später wiederhergestellt we
         <translation>nach</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Sprache ändern</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Im mobilen Modus gibt es noch keine Layout-Optionen.</translation>
@@ -2368,70 +2373,6 @@ Für einen reinen Sendenachweis muss die Empfängeradresse nicht angegeben werde
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Falsches Passwort</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>Sekunde her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>Sekunden her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>Minute her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>Minuten her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>Stunde her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>Stunden her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>Tag her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>Tage her</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ Für einen reinen Sendenachweis muss die Empfängeradresse nicht angegeben werde
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Bitte wähle eine Datei aus</translation>
     </message>
@@ -2506,33 +2447,43 @@ Für einen reinen Sendenachweis muss die Empfängeradresse nicht angegeben werde
         <translation>Eine Hardware-Wallet nutzen.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Erstellungsdatum der Wallet als `JJJJ-MM-TT` oder Wiederherstellungshöhe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Wiederherstellungshöhe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Subadressenvorschau (optional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Fehler bei Erstellung der Wallet vom Gerät. Bitte prüfe die Logs der Anwendung.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Zurück zum Menü</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Erstelle Wallet</translation>
     </message>
@@ -2568,6 +2519,14 @@ Für einen reinen Sendenachweis muss die Empfängeradresse nicht angegeben werde
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Zurück zum Menü</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2876,6 +2835,11 @@ Für einen reinen Sendenachweis muss die Empfängeradresse nicht angegeben werde
         <translation>Kürzlich verwendete Wallets</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Zurück zum Menü</translation>
@@ -2945,6 +2909,14 @@ Für einen reinen Sendenachweis muss die Empfängeradresse nicht angegeben werde
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2998,17 +2970,17 @@ Wenn du keinen eigenen Node betreiben kannst, gibt es die Möglichkeit, sich mit
         <translation>Wiederherstellungshöhe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Hintergrunddienst-Adresse</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Bootstrap-Adresse</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Netzwerktyp</translation>
     </message>
@@ -3016,22 +2988,22 @@ Wenn du keinen eigenen Node betreiben kannst, gibt es die Möglichkeit, sich mit
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Walletname</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Speicherort der Wallet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Durchsuchen</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Bitte wähle ein Verzeichnis</translation>
     </message>
@@ -3391,6 +3363,11 @@ Indizes der beteiligten Adressen: </translation>
         <location filename="../main.qml" line="1503"/>
         <source>send to the same destination</source>
         <translation>an den selben Empfänger senden</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="2002"/>

--- a/translations/monero-core_eo.ts
+++ b/translations/monero-core_eo.ts
@@ -1355,6 +1355,11 @@ La malnova monuj-kaŝmemoro renomiĝos kaj restaŭreblos poste.
         <translation>Post </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Ankoraŭ neniu dekoropcioj en la mobila moduso.</translation>
@@ -2368,70 +2373,6 @@ Kaze de Elspezpruvo, vi ne bezonas precizi la ricevantan adreson.</translation>
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Malĝusta pasvorto</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>sekundoj antaŭe</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>antaŭ kelkaj sekundoj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minuto antaŭe</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minutoj antaŭe</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>horo antaŭe</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>horoj antaŭe</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>tago antaŭe</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>tagoj antaŭe</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testreto</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Scenejreto</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Ĉefa reto</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ Kaze de Elspezpruvo, vi ne bezonas precizi la ricevantan adreson.</translation>
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Bonvolu elekti dosieron</translation>
     </message>
@@ -2506,33 +2447,43 @@ Kaze de Elspezpruvo, vi ne bezonas precizi la ricevantan adreson.</translation>
         <translation>Uzi eksteran aparaton.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Dato de la monujkreo, entajpi kiel &apos;JJJJ-MM-TT&apos; aŭ restaŭralteco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Restaŭralteco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Antaŭfaro de Subadreso (opcia)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Eraro dum la skribado de la monujo el la aparato. Kontrolu la protokolon de la aplikaĵo.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Reen al menuo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Krei monujon</translation>
     </message>
@@ -2568,6 +2519,14 @@ Kaze de Elspezpruvo, vi ne bezonas precizi la ricevantan adreson.</translation>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Reen al menuo</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2876,6 +2835,11 @@ Kaze de Elspezpruvo, vi ne bezonas precizi la ricevantan adreson.</translation>
         <translation>Plej freŝaj monujoj</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Reen al menuo</translation>
@@ -2945,6 +2909,14 @@ Kaze de Elspezpruvo, vi ne bezonas precizi la ricevantan adreson.</translation>
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2998,17 +2970,17 @@ Se vi ne havas eblecon funkciigi vian propra nodon, estas opcio konektiĝi kun f
         <translation>Restaŭralteco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Demonadreso</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Ekadreso</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Speco de reto</translation>
     </message>
@@ -3016,22 +2988,22 @@ Se vi ne havas eblecon funkciigi vian propra nodon, estas opcio konektiĝi kun f
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Monujnomo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Loko de la monujo</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Foliumi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Bonvolu elekti dosierujon</translation>
     </message>
@@ -3277,6 +3249,11 @@ Elspezadresindekso: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Eraro: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_es.ts
+++ b/translations/monero-core_es.ts
@@ -1360,6 +1360,11 @@ El archivo de caché anterior del monedero será renombrado y puede ser posterio
         <translation>Después</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Cambiar el lenguaje</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translatorcomment>Yet can be &quot;todavía&quot;,but &quot;aún&quot; is a synonym of that word and is shorter.</translatorcomment>
@@ -2380,70 +2385,6 @@ Para el caso de pagos salientes, puedes obtener una &quot;Prueba de pago&quot; q
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Contraseña incorrecta</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>hace un segundo</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>hace varios segundos</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>hace un minuto</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>hace varios minutos</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>hace una hora</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>hace horas</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>hace un día</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>hace varios días</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Red de pruebas</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Red principal</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2495,7 +2436,7 @@ Para el caso de pagos salientes, puedes obtener una &quot;Prueba de pago&quot; q
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Escoja un archivo</translation>
     </message>
@@ -2518,33 +2459,43 @@ Para el caso de pagos salientes, puedes obtener una &quot;Prueba de pago&quot; q
         <translation>Utilizando un dispositivo hardware.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Creación del monedero desde &apos;MM-DD-AAAA&apos; o altura de restauración</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Restaurar altura</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Vista de las subdirecciones (opcional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Error al copiar el monedero desde el dispositivo hardware. Revisar los registros de la aplicación.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Volver al menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Crear monedero</translation>
     </message>
@@ -2580,6 +2531,14 @@ Para el caso de pagos salientes, puedes obtener una &quot;Prueba de pago&quot; q
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Volver al menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2888,6 +2847,11 @@ Para el caso de pagos salientes, puedes obtener una &quot;Prueba de pago&quot; q
         <translation>Monederos recientes</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Volver al menu</translation>
@@ -2957,6 +2921,14 @@ Para el caso de pagos salientes, puedes obtener una &quot;Prueba de pago&quot; q
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -3010,17 +2982,17 @@ Si no tienes la opción de ejecutar tu propio nodo, hay una opción de conectars
         <translation>Restaurar altura</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Dirección del daemon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Dirección del bootstrap</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Typo de red</translation>
     </message>
@@ -3028,22 +3000,22 @@ Si no tienes la opción de ejecutar tu propio nodo, hay una opción de conectars
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Nombre del monedero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Ubicación del monedero</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Navegar</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Seleccione un directorio</translation>
     </message>
@@ -3379,6 +3351,11 @@ Comisión: </translation>
         <location filename="../main.qml" line="1503"/>
         <source>send to the same destination</source>
         <translation>enviar al mismo destinatario</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_fa.ts
+++ b/translations/monero-core_fa.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3267,6 +3239,11 @@ Spending address index: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_fi.ts
+++ b/translations/monero-core_fi.ts
@@ -1355,6 +1355,11 @@ Vanha lompakkovälimuistitiedosto nimetään uudelleen ja voidaan palauttaa myö
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Näkymävalintoja ei vielä saatavilla mobiilikäytössä</translation>
@@ -2359,70 +2364,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Väärä salasana</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testiverkko</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Stageverkko</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Pääverkko</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2474,7 +2415,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Valitse tiedosto</translation>
     </message>
@@ -2497,33 +2438,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Palautuskorkeus</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Luo lompakko</translation>
     </message>
@@ -2558,6 +2509,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2867,6 +2826,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2936,6 +2900,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2987,17 +2959,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Palautuskorkeus</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Daemon-osoite</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Verkon tyyppi</translation>
     </message>
@@ -3005,22 +2977,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">Lompakon nimi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Selaa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Valitse polku</translation>
     </message>
@@ -3276,6 +3248,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Virhe: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_fr.ts
+++ b/translations/monero-core_fr.ts
@@ -1355,6 +1355,11 @@ L&apos;ancien fichier du cache du portefeuille sera renommé et pourra être res
         <translation>Après</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Changer la langue</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Aucune option d&apos;agencement n&apos;est disponible pour le moment en mode mobile.</translation>
@@ -2369,70 +2374,6 @@ Pour le cas d&apos;une preuve de dépense, il n&apos;est pas nécessaire de spé
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Mot de passe incorrect</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>il y a une seconde</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>il y a quelques secondes</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>il y a une minute</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>il y a quelques minutes</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>il y a une heure</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>il y a quelques heures</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>il y a un jour</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>il y a quelques jours</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2484,7 +2425,7 @@ Pour le cas d&apos;une preuve de dépense, il n&apos;est pas nécessaire de spé
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Veuillez choisir un fichier</translation>
     </message>
@@ -2507,33 +2448,43 @@ Pour le cas d&apos;une preuve de dépense, il n&apos;est pas nécessaire de spé
         <translation>En utilisant un périphérique matériel.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Date de création du portefeuille au format &apos;AAAA-MM-JJ&apos; ou hauteur de restauration</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Hauteur de restauration</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Pré-génération de sous-adresses (facultatif)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Erreur d&apos;écriture du portefeuille à partir du périphérique matériel. Consultez les journaux de l&apos;application.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Retour au menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Créer un portefeuille</translation>
     </message>
@@ -2569,6 +2520,14 @@ Pour le cas d&apos;une preuve de dépense, il n&apos;est pas nécessaire de spé
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Retour au menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2877,6 +2836,11 @@ Pour le cas d&apos;une preuve de dépense, il n&apos;est pas nécessaire de spé
         <translation>Portefeuilles les plus récents</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Retour au menu</translation>
@@ -2946,6 +2910,14 @@ Pour le cas d&apos;une preuve de dépense, il n&apos;est pas nécessaire de spé
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2999,17 +2971,17 @@ Si vous n&apos;avez pas la possibilité d&apos;exécuter votre propre nœud, vou
         <translation>Hauteur de restauration</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Adresse du démon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Adresse d&apos;amorçage</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Type de réseau</translation>
     </message>
@@ -3017,22 +2989,22 @@ Si vous n&apos;avez pas la possibilité d&apos;exécuter votre propre nœud, vou
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Nom du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Emplacement du portefeuille</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Naviguer</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Veuillez choisir un répertoire</translation>
     </message>
@@ -3294,6 +3266,11 @@ Indice d&apos;adresse de dépense : </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Erreur : </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_ga.ts
+++ b/translations/monero-core_ga.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3267,6 +3239,11 @@ Spending address index: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_he.ts
+++ b/translations/monero-core_he.ts
@@ -1354,6 +1354,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2364,70 +2369,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>סיסמה שגויה</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2479,7 +2420,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">אנא בחר קובץ</translation>
     </message>
@@ -2502,33 +2443,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">שחזר גובה</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">צור ארנק</translation>
     </message>
@@ -2563,6 +2514,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2872,6 +2831,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2941,6 +2905,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2992,17 +2964,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">שחזר גובה</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">כתובת הדימון</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">סוג רשת</translation>
     </message>
@@ -3010,22 +2982,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">שם ארנק</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">דפדף</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">אנא בחר תיקייה</translation>
     </message>
@@ -3263,6 +3235,11 @@ Amount: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>שגיאה: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_hi.ts
+++ b/translations/monero-core_hi.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">कृपया निर्देशिका चुनें</translation>
     </message>
@@ -3242,6 +3214,11 @@ Fee: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_hr.ts
+++ b/translations/monero-core_hr.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2361,70 +2366,6 @@ U slučaju &quot;dokaza potrošnje&quot;, adresa primatelja ne mora se navesti.<
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Neispravna zaporka</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testna mreža</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Fazna mreža</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Glavna mreža</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2476,7 +2417,7 @@ U slučaju &quot;dokaza potrošnje&quot;, adresa primatelja ne mora se navesti.<
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Odaberite datoteku</translation>
     </message>
@@ -2499,33 +2440,43 @@ U slučaju &quot;dokaza potrošnje&quot;, adresa primatelja ne mora se navesti.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Povrati visinu bloka</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Kreiraj novčanik</translation>
     </message>
@@ -2560,6 +2511,14 @@ U slučaju &quot;dokaza potrošnje&quot;, adresa primatelja ne mora se navesti.<
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2869,6 +2828,11 @@ U slučaju &quot;dokaza potrošnje&quot;, adresa primatelja ne mora se navesti.<
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2938,6 +2902,14 @@ U slučaju &quot;dokaza potrošnje&quot;, adresa primatelja ne mora se navesti.<
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2989,17 +2961,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Povrati visinu bloka</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Adresa daemona</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Vrsta mreže</translation>
     </message>
@@ -3007,22 +2979,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">Naziv novčanika</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Pretraži</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Odaberite mapu</translation>
     </message>
@@ -3358,6 +3330,11 @@ Provizija: </translation>
         <location filename="../main.qml" line="1503"/>
         <source>send to the same destination</source>
         <translation>pošalji na isto odredište</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_hu.ts
+++ b/translations/monero-core_hu.ts
@@ -1354,6 +1354,11 @@ A régi gyorsítótár fájlja át lesz nevezve és bármikor visszaállítható
         <translation>Után</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Nyelv választása</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Nincs mobilos elrendezés</translation>
@@ -2360,70 +2365,6 @@ Egyszerű költési bizonylat esetén nem kell megadni a kedvezményezett címé
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Hibás jelszó</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>másodperce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>másodperce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>perce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>perce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>órája</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>órája</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>napja</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>napja</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2475,7 +2416,7 @@ Egyszerű költési bizonylat esetén nem kell megadni a kedvezményezett címé
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Válassz egy fájlt</translation>
     </message>
@@ -2498,33 +2439,43 @@ Egyszerű költési bizonylat esetén nem kell megadni a kedvezményezett címé
         <translation>Hardveres eszköz használata.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Tárca létrehozásának dátuma &quot;ÉÉÉÉ-HH-NN&quot; formátumban, vagy helyreállítási magasság megadása</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Alcím megtekintés (opcionális)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Hiba a tárca harveres írása közben. Nézd meg a naplót!</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Vissza a menübe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Tárca létrehozása</translation>
     </message>
@@ -2560,6 +2511,14 @@ Egyszerű költési bizonylat esetén nem kell megadni a kedvezményezett címé
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Vissza a menübe</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2868,6 +2827,11 @@ Egyszerű költési bizonylat esetén nem kell megadni a kedvezményezett címé
         <translation>Legújabb tárcák</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Vissza a menübe</translation>
@@ -2937,6 +2901,14 @@ Egyszerű költési bizonylat esetén nem kell megadni a kedvezményezett címé
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2990,17 +2962,17 @@ Ha nem tudsz saját csomópontot futtatni, csatlakozhatsz egy távolihoz.</trans
         <translation>blokkmagasság helyreállítása</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Daemon címe</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Bootstrap cím</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Hálózat típusa</translation>
     </message>
@@ -3008,22 +2980,22 @@ Ha nem tudsz saját csomópontot futtatni, csatlakozhatsz egy távolihoz.</trans
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Tárca neve</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Tárca helye</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Válassz könyvtárat</translation>
     </message>
@@ -3274,6 +3246,11 @@ Költő cím indexe: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Hiba: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_id.ts
+++ b/translations/monero-core_id.ts
@@ -1354,6 +1354,11 @@ File cache dompet lama akan diganti namanya dan dapat dikembalikan nanti.</trans
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Belum ada opsi tata letak pada mode mobile.</translation>
@@ -2357,70 +2362,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Kata sandi salah</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testnet (jaringan uji)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2472,7 +2413,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">&gt;Mohon memilih arsip</translation>
     </message>
@@ -2495,33 +2436,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Mengembalikan tinggi ke nilai asal</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Membuat dompet</translation>
     </message>
@@ -2556,6 +2507,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2865,6 +2824,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2934,6 +2898,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2985,17 +2957,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Mengembalikan tinggi ke nilai asal</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Alamat jurik</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Tipe Jaringan</translation>
     </message>
@@ -3003,22 +2975,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">Nama dompet</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Jelajahi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Silahkan pilih direktori</translation>
     </message>
@@ -3368,6 +3340,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1503"/>
         <source>send to the same destination</source>
         <translation>kirim ke tujuan yang sama</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="2002"/>

--- a/translations/monero-core_it.ts
+++ b/translations/monero-core_it.ts
@@ -1355,6 +1355,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation>Dopo</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Cambia lingua</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Non esiste ancora nessuna opzione per i layout nella modalità portatile.</translation>
@@ -2362,70 +2367,6 @@ In caso di prova di spesa, non serve specificare l&apos;indirizzo del ricevente.
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Password errata</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>secondo fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>secondi fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minuto fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minuti fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>ora fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>ore fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>giorno fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>giorni fa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2477,7 +2418,7 @@ In caso di prova di spesa, non serve specificare l&apos;indirizzo del ricevente.
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Seleziona un file</translation>
     </message>
@@ -2500,33 +2441,43 @@ In caso di prova di spesa, non serve specificare l&apos;indirizzo del ricevente.
         <translation>Utilizzando un dispositivo hardware.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Data creazione del portafoglio `AAAA-MM-GG` o altezza di ripristino</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Altezza di ripristino</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Sottoindirizzo lookahead (opzionale)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Errore durante la scrittura del portafoglio da dispositivo hardware. Controlla i registri dell&apos;applicazione.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Torna al menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Crea portafoglio</translation>
     </message>
@@ -2562,6 +2513,14 @@ In caso di prova di spesa, non serve specificare l&apos;indirizzo del ricevente.
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Torna al menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2870,6 +2829,11 @@ In caso di prova di spesa, non serve specificare l&apos;indirizzo del ricevente.
         <translation>portafogli più recenti</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Torna al menu</translation>
@@ -2939,6 +2903,14 @@ In caso di prova di spesa, non serve specificare l&apos;indirizzo del ricevente.
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2992,17 +2964,17 @@ Se non si ha la possibilità di operare un proprio nodo locale, ci si può conne
         <translation>Altezza di ripristino</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Indirizzo daemon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Indirizzo di bootstrap</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Tipo di rete</translation>
     </message>
@@ -3010,22 +2982,22 @@ Se non si ha la possibilità di operare un proprio nodo locale, ci si può conne
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Nome portafoglio</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Posizione del portafoglio</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Esplora</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Seleziona una cartella</translation>
     </message>
@@ -3282,6 +3254,11 @@ Indice indirizzo di spesa: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Errore: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_ja.ts
+++ b/translations/monero-core_ja.ts
@@ -1355,6 +1355,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation>あと</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>モバイルモードにはまだレイアウトオプションがありません。</translation>
@@ -2368,70 +2373,6 @@ Spend Proofの場合、宛先アドレスを指定する必要はありません
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>パスワードが間違っています</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>秒前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>秒前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>分前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>分前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>時間前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>時間前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>日前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>日前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>テストネット</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>ステージネット</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>メインネット</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ Spend Proofの場合、宛先アドレスを指定する必要はありません
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>ファイルを選択してください</translation>
     </message>
@@ -2506,33 +2447,43 @@ Spend Proofの場合、宛先アドレスを指定する必要はありません
         <translation>ハードウェアデバイスを使用</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">`YYYY-MM-DD`の形式でウォレットを作成した日時、または復元を開始するブロック高</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">復元するブロック高</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>サブアドレスの先読み (オプション)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>ハードウェアデバイスからウォレットを書き出すのに失敗しました。アプリケーションログをチェックしてください。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>メニューに戻る</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>ウォレットを作る</translation>
     </message>
@@ -2568,6 +2519,14 @@ Spend Proofの場合、宛先アドレスを指定する必要はありません
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>メニューに戻る</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2876,6 +2835,11 @@ Spend Proofの場合、宛先アドレスを指定する必要はありません
         <translation>最近開いたウォレット</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>メニューに戻る</translation>
@@ -2945,6 +2909,14 @@ Spend Proofの場合、宛先アドレスを指定する必要はありません
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2998,17 +2970,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>復元するブロック高</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>デーモンのアドレス</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>ブートストラップアドレス</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>ネットワークタイプ</translation>
     </message>
@@ -3016,22 +2988,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>ウォレット名</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>ウォレットの場所</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>ディレクトリを選択してください</translation>
     </message>
@@ -3387,6 +3359,11 @@ Fee: </source>
         <location filename="../main.qml" line="1343"/>
         <source>Monero</source>
         <translation>Monero</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="2002"/>

--- a/translations/monero-core_kmr.ts
+++ b/translations/monero-core_kmr.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3267,6 +3239,11 @@ Spending address index: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_ko.ts
+++ b/translations/monero-core_ko.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>잘못된 암호</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">테스트넷</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">파일을 선택하세요</translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">높이 복원</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">지갑 만들기</translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">높이 복원</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">데몬 주소</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">지갑 이름</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">디렉토리를 선택하세요</translation>
     </message>
@@ -3364,6 +3336,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1503"/>
         <source>send to the same destination</source>
         <translation>동일한 대상에게 송금하기</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="2002"/>

--- a/translations/monero-core_lt.ts
+++ b/translations/monero-core_lt.ts
@@ -1355,6 +1355,11 @@ Sena piniginės talpyklos rinkmena bus pervadinta ir vėliau galės būti atstat
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Kol kas mobiliojo ryšio režimu nėra išdėstymo parinkčių.</translation>
@@ -2368,70 +2373,6 @@ Jei naudojate &quot;Išleidimo įrodymas&quot;, jums nereikia nurodyti gavėjo a
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Neteisingas slaptažodis</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testavimo tinklas</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Tarpinis tinklas</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Pagrindinis tinklas</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ Jei naudojate &quot;Išleidimo įrodymas&quot;, jums nereikia nurodyti gavėjo a
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Pasirinkite rinkmeną</translation>
     </message>
@@ -2506,33 +2447,43 @@ Jei naudojate &quot;Išleidimo įrodymas&quot;, jums nereikia nurodyti gavėjo a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Atstatymo aukštis</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Sukurti piniginę</translation>
     </message>
@@ -2567,6 +2518,14 @@ Jei naudojate &quot;Išleidimo įrodymas&quot;, jums nereikia nurodyti gavėjo a
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2876,6 +2835,11 @@ Jei naudojate &quot;Išleidimo įrodymas&quot;, jums nereikia nurodyti gavėjo a
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2945,6 +2909,14 @@ Jei naudojate &quot;Išleidimo įrodymas&quot;, jums nereikia nurodyti gavėjo a
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2996,17 +2968,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Atstatymo aukštis</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Jungties adresas</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Tinklo tipas</translation>
     </message>
@@ -3014,22 +2986,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">Piniginės pavadinimas</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Naršyti</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Pasirinkite aplanką</translation>
     </message>
@@ -3296,6 +3268,11 @@ Išlaidų adreso rodyklė: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Klaida: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_nl.ts
+++ b/translations/monero-core_nl.ts
@@ -1366,6 +1366,11 @@ De naam van het oude cachebestand wordt gewijzigd, zodat het later kan worden he
         <translation>Na</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Verander taal</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Er zijn nog geen opmaakopties in de mobiele modus.</translation>
@@ -2380,70 +2385,6 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Verkeerd wachtwoord</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>seconde geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>seconden geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minuut geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minuten geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>uur geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>uren geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>dag geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>dagen geleden</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Hoofdnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2495,7 +2436,7 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Kies een bestand</translation>
     </message>
@@ -2518,33 +2459,43 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
         <translation>Gebruik makend van een hardware Apparaat.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Aanmaakdatum van portemonnee als &apos;JJJJ-MM-DD&apos; of herstelhoogte</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Herstelpunt (blokhoogte)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Subadres bekijken (optioneel)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Fout bij het Schrijven van de portemonnee vanop hardware Apparaat. Bekijk applicatielogboek.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Terug naar menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Portemonnee maken</translation>
     </message>
@@ -2580,6 +2531,14 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Terug naar menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2888,6 +2847,11 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
         <translation>Meest recente portemonnees</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Terug naar menu</translation>
@@ -2957,6 +2921,14 @@ Voor een betalingsbewijs hoeft u het adres van de ontvanger niet op te geven.</t
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -3010,17 +2982,17 @@ Als het niet mogelijk is om uw eigen node te draaien, dan is er een optie om ver
         <translation>Herstelpunt (blokhoogte)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Node-adres</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Bootstrap adres</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Soort netwerk</translation>
     </message>
@@ -3028,22 +3000,22 @@ Als het niet mogelijk is om uw eigen node te draaien, dan is er een optie om ver
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Naam van portemonnee</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Portemonnee locatie</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Bladeren</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Kies een locatie</translation>
     </message>
@@ -3379,6 +3351,11 @@ Vergoeding: </translation>
         <location filename="../main.qml" line="1503"/>
         <source>send to the same destination</source>
         <translation>naar hetzelfde adres verzenden</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_pl.ts
+++ b/translations/monero-core_pl.ts
@@ -1356,6 +1356,11 @@ Poprzednia pamięć podręczna portfela zostanie zapisana pod inną nazwą i mo�
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Brak opcji układu w trybie mobilnym.</translation>
@@ -2369,70 +2374,6 @@ W przypadku &apos;Dowodu wydania&apos; nie musisz podawać adresu odbiorcy.</tra
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Błędne hasło</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Sieć testowa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Sieć stopniowa</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Sieć główna</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2484,7 +2425,7 @@ W przypadku &apos;Dowodu wydania&apos; nie musisz podawać adresu odbiorcy.</tra
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Wybierz plik</translation>
     </message>
@@ -2507,33 +2448,43 @@ W przypadku &apos;Dowodu wydania&apos; nie musisz podawać adresu odbiorcy.</tra
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Data stworzenia portfela w formacie `YYYY-MM-DD` lub wysokość odzyskiwania portfela</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Wysokość odzyskiwania portfela</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished">Wróć do menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Utwórz portfel</translation>
     </message>
@@ -2569,6 +2520,14 @@ W przypadku &apos;Dowodu wydania&apos; nie musisz podawać adresu odbiorcy.</tra
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation type="unfinished">Wróć do menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2877,6 +2836,11 @@ W przypadku &apos;Dowodu wydania&apos; nie musisz podawać adresu odbiorcy.</tra
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Wróć do menu</translation>
@@ -2946,6 +2910,14 @@ W przypadku &apos;Dowodu wydania&apos; nie musisz podawać adresu odbiorcy.</tra
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2997,17 +2969,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>Wysokość odzyskiwania portfela</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Adres demona</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Typ sieci</translation>
     </message>
@@ -3015,22 +2987,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Nazwa portfela</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Lokalizacja portfela</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Przeglądaj</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Wybierz katalog</translation>
     </message>
@@ -3276,6 +3248,11 @@ Indeks adresu do wydawania: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Błąd: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_prt.ts
+++ b/translations/monero-core_prt.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2354,70 +2359,6 @@ Fer the case wit&apos; Spend Proof, you don&apos;t be needin&apos; to specify th
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Wrong passw&apos;rd ye mindless kidney-wipe!</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testnet!</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Stag&apos;net</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2469,7 +2410,7 @@ Fer the case wit&apos; Spend Proof, you don&apos;t be needin&apos; to specify th
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Sel&apos;ct a file ye filthy swine</translation>
     </message>
@@ -2492,33 +2433,43 @@ Fer the case wit&apos; Spend Proof, you don&apos;t be needin&apos; to specify th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Create ye wall&apos;t!</translation>
     </message>
@@ -2553,6 +2504,14 @@ Fer the case wit&apos; Spend Proof, you don&apos;t be needin&apos; to specify th
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2862,6 +2821,11 @@ Fer the case wit&apos; Spend Proof, you don&apos;t be needin&apos; to specify th
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2931,6 +2895,14 @@ Fer the case wit&apos; Spend Proof, you don&apos;t be needin&apos; to specify th
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2982,17 +2954,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3000,22 +2972,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Choose argh dir&apos;ctory ye bootless boar-pig!</translation>
     </message>
@@ -3272,6 +3244,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Blunder!</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_pt-br.ts
+++ b/translations/monero-core_pt-br.ts
@@ -1356,6 +1356,11 @@ O arquivo de cache da carteira antiga será renomeado e poderá ser restaurado p
         <translation>Após </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Mudar idioma</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Ainda não existem opções de layout para dispositivos móveis.</translation>
@@ -2369,70 +2374,6 @@ Para o caso com Spend Proof, você não precisa especificar o endereço do desti
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Senha incorreta</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>segundo</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>segundos</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minuto</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minutos</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>hora</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>horas</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>dia</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>dias</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2484,7 +2425,7 @@ Para o caso com Spend Proof, você não precisa especificar o endereço do desti
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Por favor escolha um arquivo</translation>
     </message>
@@ -2507,33 +2448,43 @@ Para o caso com Spend Proof, você não precisa especificar o endereço do desti
         <translation>Usando um dispositivo físico (hardware wallet). </translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Data da criação da carteira no formato `AAAA-MM-DD` ou altura do bloco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Restaurar da altura</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Busca avançada de subendereços (opcional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Erro ao criar carteira via dispositivo físico. Verifique os logs da aplicação.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Voltar ao menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Criar carteira</translation>
     </message>
@@ -2569,6 +2520,14 @@ Para o caso com Spend Proof, você não precisa especificar o endereço do desti
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Voltar ao menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2877,6 +2836,11 @@ Para o caso com Spend Proof, você não precisa especificar o endereço do desti
         <translation>Carteiras recentes</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Voltar ao menu</translation>
@@ -2946,6 +2910,14 @@ Para o caso com Spend Proof, você não precisa especificar o endereço do desti
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2999,17 +2971,17 @@ Se você não tiver a opção de executar seu próprio nó, você pode conectar 
         <translation>Restaurar da altura</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Endereço do daemon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Endereço bootstrap</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Tipo da rede</translation>
     </message>
@@ -3017,22 +2989,22 @@ Se você não tiver a opção de executar seu próprio nó, você pode conectar 
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Nome da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Diretório da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Navegar</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Por favor escolha um diretório</translation>
     </message>
@@ -3292,6 +3264,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Erro: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_pt-pt.ts
+++ b/translations/monero-core_pt-pt.ts
@@ -1357,6 +1357,11 @@ O ficheiro de cache antigo será renomeado e poderá ser restaurado mais tarde.
         <translation>Depois </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Alterar idioma</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Não existem ainda opções de Layout para o modo móvel.</translation>
@@ -2369,70 +2374,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Palavra-chave incorreta</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>segundo atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>segundos atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minuto atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minutos atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>hora atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>horas atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>dia atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>dias atrás</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2484,7 +2425,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Por favor escolha um ficheiro</translation>
     </message>
@@ -2507,33 +2448,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>Utilizar um dispositivo físico.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Data de criação da carteira como `AAAA-MM-DD` ou restaurar a partir de número de bloco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Restaurar a partir de número de bloco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Sub-endereços a utilizar (opcional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Erro a escrever a partir do dispositivo físico. Verifique os logs da aplicação.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>De volta ao menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Criar carteira</translation>
     </message>
@@ -2569,6 +2520,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Voltar ao menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2877,6 +2836,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>Carteiras recentes</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Voltar ao menu</translation>
@@ -2946,6 +2910,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2999,18 +2971,18 @@ Caso não tenha a possibilidade de usar o seu próprio node tem a opção de se 
         <translation>Restaurar a partir de número de bloco</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Endereço do Daemon</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translatorcomment>Endereço de Bootstrap?</translatorcomment>
         <translation>Endereço de Bootstrap</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Tipo de Rede</translation>
     </message>
@@ -3018,22 +2990,22 @@ Caso não tenha a possibilidade de usar o seu próprio node tem a opção de se 
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Nome da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Localização da carteira</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Navegar</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Por favor escolha uma diretoria</translation>
     </message>
@@ -3299,6 +3271,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Erro: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_ro.ts
+++ b/translations/monero-core_ro.ts
@@ -1355,6 +1355,11 @@ Vechiul fișier cache va fi redenumit și va putea fi restaurat mai tâziu.
         <translation>După</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Schimbă limba</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>În versiunea mobilă încă nu există o opțiune a așezării.</translation>
@@ -2368,70 +2373,6 @@ Pentru cazurile cu Dovadă de plată, nu e necesară adresa destinatarului.</tra
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Parolă incorectă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>secundă în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>secunde în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minut în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minute în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>oră în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>ore în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>zi în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>zile în urmă</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Rețea principală</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ Pentru cazurile cu Dovadă de plată, nu e necesară adresa destinatarului.</tra
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Alege un fișier</translation>
     </message>
@@ -2506,33 +2447,43 @@ Pentru cazurile cu Dovadă de plată, nu e necesară adresa destinatarului.</tra
         <translation>Folosind un dispozitiv hardware.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Data creării portofelului în formatul &apos;AAAA-LL-ZZ&apos; sau înălțimea de restaurare</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Înălțimea de revenire</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Verifică adresă secundară (opțional)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Eroare la scrierea portofelului din dispozitivul hardware. Verifică jurnalurile aplicației.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Înapoi la meniu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Creează portofel</translation>
     </message>
@@ -2568,6 +2519,14 @@ Pentru cazurile cu Dovadă de plată, nu e necesară adresa destinatarului.</tra
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Înapoi la meniu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2876,6 +2835,11 @@ Pentru cazurile cu Dovadă de plată, nu e necesară adresa destinatarului.</tra
         <translation>Cele mai recente portofele</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Înapoi la meniu</translation>
@@ -2945,6 +2909,14 @@ Pentru cazurile cu Dovadă de plată, nu e necesară adresa destinatarului.</tra
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2998,17 +2970,17 @@ Dacă nu aveți opțiunea de a rula propriul nod, există o opțiune de conectar
         <translation>Înălțimea de revenire</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Adresa serviciului</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Adresa bootstrap</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Tip rețea</translation>
     </message>
@@ -3016,22 +2988,22 @@ Dacă nu aveți opțiunea de a rula propriul nod, există o opțiune de conectar
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Nume portofel</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Locația portofelului</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Răsfoiește</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Alege un director</translation>
     </message>
@@ -3292,6 +3264,11 @@ Indexul adresei de cheltuit:</translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Eroare: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_ru.ts
+++ b/translations/monero-core_ru.ts
@@ -1355,6 +1355,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation>После </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Изменить язык</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Настройки интерфейса в мобильной версии пока не доступны.</translation>
@@ -2369,70 +2374,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Неверный пароль</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>секунда прошла</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>секунд прошло</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>минута прошла</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>минут прошло</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>час прошел</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>часов прошло</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>день прошел</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>дней прошло</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Тестовая сеть (Testnet)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Симуляция (Stagenet)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Основная сеть (Mainnet)</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2484,7 +2425,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Пожалуйста, выберите файл</translation>
     </message>
@@ -2507,33 +2448,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>Подключить аппаратный кошелек.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Дата создания кошелька в формате `YYYY-MM-DD` или высота восстановления</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Высота блока восстановления</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Субадрес (необязательно)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Ошибка подключения аппаратного кошелька. Проверьте журнал событий.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Вернуться в меню</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Создать кошелек</translation>
     </message>
@@ -2569,6 +2520,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Вернуться в меню</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2877,6 +2836,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>Часто используемые кошельки</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Вернуться в меню</translation>
@@ -2946,6 +2910,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2999,17 +2971,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>Высота блока восстановления</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Адрес демона</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Адрес ноды начальной загрузки</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Тип Сети</translation>
     </message>
@@ -3017,22 +2989,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Имя кошелька</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Путь к кошельку</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Обзор</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Пожалуйста, выберите папку</translation>
     </message>
@@ -3371,6 +3343,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1304"/>
         <source>Please wait...</source>
         <translation>Пожалуйста, подождите...</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="2002"/>

--- a/translations/monero-core_sk.ts
+++ b/translations/monero-core_sk.ts
@@ -1355,6 +1355,11 @@ Súbor starej cache bude premenovaný a môže byť obnovený neskôr.
         <translation>Po</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Zmena jazyka</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Nie sú k dispozícii žiadne úpravy v mobilnom móde</translation>
@@ -2368,70 +2373,6 @@ V prípade Spend Proof, nie je potrebné špecifikovať prijímateľovu adresu.<
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Nesprávne heslo</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>pred sekundou</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>pred sekundami</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>pred minútou</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>pred minútami</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>pred hodinou</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>pred hodinami</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>pred dňom</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>pred dňami</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Hlavná sieť</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ V prípade Spend Proof, nie je potrebné špecifikovať prijímateľovu adresu.<
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Prosím, vyberte súbor</translation>
     </message>
@@ -2506,33 +2447,43 @@ V prípade Spend Proof, nie je potrebné špecifikovať prijímateľovu adresu.<
         <translation>Použitie hw zariadenie.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Dátum vytvorenia peňaženky v tvare `YYYY-MM-DD` alebo obnoviť výšku bloku</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Obnoviť výšku</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Podadresa lookahead (voliteľne)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Chyba zápisu z hw zariadenia. Skontrolujte logy aplikácie.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Návrat do menu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Vytvoriť peňaženku</translation>
     </message>
@@ -2568,6 +2519,14 @@ V prípade Spend Proof, nie je potrebné špecifikovať prijímateľovu adresu.<
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Návrat do menu</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2876,6 +2835,11 @@ V prípade Spend Proof, nie je potrebné špecifikovať prijímateľovu adresu.<
         <translation>Posledné peňaženky</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Návrat do menu</translation>
@@ -2945,6 +2909,14 @@ V prípade Spend Proof, nie je potrebné špecifikovať prijímateľovu adresu.<
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2998,17 +2970,17 @@ Ak nemáte možnosť spustiť vlastný uzol, existuje možnosť pripojenia k vzd
         <translation>Obnoviť výšku</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Adresa daemonu</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Bootstrap adresa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Typ siete</translation>
     </message>
@@ -3016,22 +2988,22 @@ Ak nemáte možnosť spustiť vlastný uzol, existuje možnosť pripojenia k vzd
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Názov peňaženky</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Umiestnenie peňaženky</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Prehliadať</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Prosím, vyberte priečinok</translation>
     </message>
@@ -3297,6 +3269,11 @@ Index míňacej adresy (spending): </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Chyba: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_sl.ts
+++ b/translations/monero-core_sl.ts
@@ -1354,6 +1354,11 @@ Stara datoteka predpomnilnika denarnice bo preimenovana in se jo lahko obnovi po
         <translation>Čez </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Zamenjaj jezik</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>V mobilnem načinu še ni možnosti postavitve.</translation>
@@ -2367,70 +2372,6 @@ V primeru dokazila o plačilu, naslov prejemnika ni potreben.</translation>
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Napačno geslo</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>sekundo nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>sekund nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minuto nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minut nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>uro nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>ur nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>dan nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>dni nazaj</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2482,7 +2423,7 @@ V primeru dokazila o plačilu, naslov prejemnika ni potreben.</translation>
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Izberi datoteko</translation>
     </message>
@@ -2505,33 +2446,43 @@ V primeru dokazila o plačilu, naslov prejemnika ni potreben.</translation>
         <translation>Uporaba hardverske denarnice.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">Datum ustvaritve denarnice v obliki `YYYY-MM-DD` ali obnovitvena višina</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Višina obnovitve</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Napaka pri kreiranju denarnice iz hardvare naprave. Preveri poročilo v aplikaciji.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Nazaj na meni</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Ustvari denarnico</translation>
     </message>
@@ -2567,6 +2518,14 @@ V primeru dokazila o plačilu, naslov prejemnika ni potreben.</translation>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Nazaj na meni</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2875,6 +2834,11 @@ V primeru dokazila o plačilu, naslov prejemnika ni potreben.</translation>
         <translation>Zadnje denarnice</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Nazaj na meni</translation>
@@ -2944,6 +2908,14 @@ V primeru dokazila o plačilu, naslov prejemnika ni potreben.</translation>
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2997,17 +2969,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>Višina obnovitve</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Naslov prikritega procesa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Bootstrap naslov</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Tip omrežja</translation>
     </message>
@@ -3015,22 +2987,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Ime denarnice</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Lokacija denarnice</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Brskaj</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Izberite mapo</translation>
     </message>
@@ -3253,6 +3225,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Napaka: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_sr.ts
+++ b/translations/monero-core_sr.ts
@@ -1354,6 +1354,11 @@ Stari fajl keša novčanika će biti preimenovan i može se povratiti kasnije.</
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Opcije za Raspored još ne postoje u mobilnom modu.</translation>
@@ -2367,70 +2372,6 @@ U slučaju sa Dokazom Troška, ne morate navesti adresu primaoca.</translation>
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Pogrešna lozinka</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished">Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished">Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished">Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2482,7 +2423,7 @@ U slučaju sa Dokazom Troška, ne morate navesti adresu primaoca.</translation>
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished">Molimo odaberite fajl</translation>
     </message>
@@ -2505,33 +2446,43 @@ U slučaju sa Dokazom Troška, ne morate navesti adresu primaoca.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Odaberi početnu tačku sinhronizacije blokčejna</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished">Napravi novčanik</translation>
     </message>
@@ -2566,6 +2517,14 @@ U slučaju sa Dokazom Troška, ne morate navesti adresu primaoca.</translation>
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2875,6 +2834,11 @@ U slučaju sa Dokazom Troška, ne morate navesti adresu primaoca.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2944,6 +2908,14 @@ U slučaju sa Dokazom Troška, ne morate navesti adresu primaoca.</translation>
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2995,17 +2967,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Odaberi početnu tačku sinhronizacije blokčejna</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Daemon adresa</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Tip Mreže</translation>
     </message>
@@ -3013,22 +2985,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished">Naziv novčanika</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Pretraži</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Odaberite direktorijum</translation>
     </message>
@@ -3301,6 +3273,11 @@ Indeks adrese za potrošnju: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Greška: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_sv.ts
+++ b/translations/monero-core_sv.ts
@@ -1355,6 +1355,11 @@ Den gamla plånbokens cache-fil kommer att ändra namn och kan återställas sen
         <translation>Efter </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Ändra språk</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Inga alternativ för utseendet existerar i mobilversionen ännu.</translation>
@@ -2368,70 +2373,6 @@ I fallet med spenderbevis behöver du inte ange mottagaradressen.</translation>
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Fel lösenord</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>sekund sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>sekunder sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>minut sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>minuter sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>timme sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>timmar sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>dag sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>dagar sedan</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Mainnet</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ I fallet med spenderbevis behöver du inte ange mottagaradressen.</translation>
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Välj en fil</translation>
     </message>
@@ -2506,33 +2447,43 @@ I fallet med spenderbevis behöver du inte ange mottagaradressen.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Återställningshöjd</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Återgå till meny</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Skapa plånbok</translation>
     </message>
@@ -2568,6 +2519,14 @@ I fallet med spenderbevis behöver du inte ange mottagaradressen.</translation>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Återgå till meny</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2876,6 +2835,11 @@ I fallet med spenderbevis behöver du inte ange mottagaradressen.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Återgå till meny</translation>
@@ -2945,6 +2909,14 @@ I fallet med spenderbevis behöver du inte ange mottagaradressen.</translation>
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2996,17 +2968,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>Återställningshöjd</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Daemonadress</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Nätverkstyp</translation>
     </message>
@@ -3014,22 +2986,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Plånboksnamn</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Bläddra</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Välj en mapp</translation>
     </message>
@@ -3296,6 +3268,11 @@ Index för spenderingsadress: </translation>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Fel: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_tr.ts
+++ b/translations/monero-core_tr.ts
@@ -1355,6 +1355,11 @@ Aşağıdaki bilgiler silinecek
         <translation>Sonra</translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">Dili değiştir</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Mobil modda henüz düzen seçeneği yok.</translation>
@@ -2362,70 +2367,6 @@ Harcama Kanıtı ile ilgili davada, alıcı adresini belirtmeniz gerekmez. </tra
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Yanlış parola</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>saniye önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>saniye önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>dakika önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>dakika önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>saat önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>saat önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>gün önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>gün önce</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Prova ağı (Stagenet)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Ana ağ (mainnet)</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2477,7 +2418,7 @@ Harcama Kanıtı ile ilgili davada, alıcı adresini belirtmeniz gerekmez. </tra
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Lütfen bir dosya seçin</translation>
     </message>
@@ -2500,33 +2441,43 @@ Harcama Kanıtı ile ilgili davada, alıcı adresini belirtmeniz gerekmez. </tra
         <translation>Bir donanım aygıtı kullanarak.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">&apos;YYYY-AA-GG&apos; olarak cüzdan oluşturma tarihi veya geri yükleme yüksekliği</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Geri yükleme yüksekliği</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>Alt adres ileri-bakışı (isteğe bağlı)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>Donanım aygıtından cüzdana yazma hatası. Uygulama kayıtlarını kontrol et.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>Menüye dön</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Cüzdan oluştur</translation>
     </message>
@@ -2562,6 +2513,14 @@ Harcama Kanıtı ile ilgili davada, alıcı adresini belirtmeniz gerekmez. </tra
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>Menüye dön</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2870,6 +2829,11 @@ Harcama Kanıtı ile ilgili davada, alıcı adresini belirtmeniz gerekmez. </tra
         <translation>En yeni cüzdanlar</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>Menüye dön</translation>
@@ -2939,6 +2903,14 @@ Harcama Kanıtı ile ilgili davada, alıcı adresini belirtmeniz gerekmez. </tra
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2992,17 +2964,17 @@ Kendi düğümünüzü çalıştırma seçeneğiniz yoksa, uzaktaki bir düğüm
         <translation>Geri yükleme yüksekliği</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>Daemon adresi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>Önyükleme adresi</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>Ağ tipi</translation>
     </message>
@@ -3010,22 +2982,22 @@ Kendi düğümünüzü çalıştırma seçeneğiniz yoksa, uzaktaki bir düğüm
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>Cüzdan adı</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>Cüzdan yeri</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>Göster</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>Lütfen bir dizin seçin</translation>
     </message>
@@ -3281,6 +3253,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>Hata: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_uk.ts
+++ b/translations/monero-core_uk.ts
@@ -1354,6 +1354,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>Налаштування інтерфейсу в мобільній версії поки не доступні.</translation>
@@ -2366,70 +2371,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>Невірний пароль</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Тестова мережа (testnet)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Тестова мережа (stagenet)</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>Основна мережа (Mainnet)</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2481,7 +2422,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>Будь ласка, виберіть файл</translation>
     </message>
@@ -2504,33 +2445,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">Висота блока відновлення</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>Створити гаманець</translation>
     </message>
@@ -2566,6 +2517,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2875,6 +2834,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2944,6 +2908,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2995,17 +2967,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished">Висота блока відновлення</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished">Адрес демона</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished">Тип Мережі</translation>
     </message>
@@ -3013,22 +2985,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished">Огляд</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished">Будь ласка, виберіть папку</translation>
     </message>
@@ -3367,6 +3339,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1304"/>
         <source>Please wait...</source>
         <translation>Будь ласка, зачекайте...</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="2002"/>

--- a/translations/monero-core_ur.ts
+++ b/translations/monero-core_ur.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3267,6 +3239,11 @@ Spending address index: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/monero-core_zh-cn.ts
+++ b/translations/monero-core_zh-cn.ts
@@ -1355,6 +1355,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation>之后 </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">切换语言</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>移动版尚不支持界面设定。</translation>
@@ -2365,70 +2370,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>密码错误</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>秒前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>秒前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>分钟前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>分钟前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>小时前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>小时前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>天前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>天前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>测试网</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>专用网</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>主网</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2480,7 +2421,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>请选择一个文件</translation>
     </message>
@@ -2503,33 +2444,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>使用硬件设备.</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">钱包创建日期格式为“年-月-日”或还原的区块高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">恢复特定区块高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>子地址预取（可选）</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>从硬件设备写入钱包错误。请检查相关应用日志。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>返回菜单</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>创建钱包</translation>
     </message>
@@ -2565,6 +2516,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>返回菜单</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2873,6 +2832,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>最近的钱包</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>返回菜单</translation>
@@ -2942,6 +2906,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2993,17 +2965,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>恢复特定区块高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>后台进程(daemon)位置</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>引导节点地址</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>网络类型</translation>
     </message>
@@ -3011,22 +2983,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>钱包名称</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>钱包位置</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>浏览</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>请选择一个目录</translation>
     </message>
@@ -3287,6 +3259,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>错误: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_zh-tw.ts
+++ b/translations/monero-core_zh-tw.ts
@@ -1355,6 +1355,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation>超過 </translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished">切換語言</translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation>行動裝置版本中尚無介面選項。</translation>
@@ -2368,70 +2373,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation>密碼錯誤</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation>秒前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation>秒前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation>分鐘前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation>分鐘前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation>小時前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation>小時前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation>天前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation>天前</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation>Testnet 網路</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation>Stagenet 網路</translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation>主網路</translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2483,7 +2424,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation>請選擇一個檔案</translation>
     </message>
@@ -2506,33 +2447,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>使用硬體錢包裝置。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished">錢包建立的時間 &apos;YYYY-MM-DD&apos; 或是指定一個區塊高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished">回復區塊高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation>子地址預取 (選填)</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation>從硬體錢包裝置建立錢包時發生錯誤，請檢查程式日誌以獲得更多資訊。</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation>回到選單</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation>建立錢包</translation>
     </message>
@@ -2568,6 +2519,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
         <translation>回到選單</translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2876,6 +2835,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation>最近使用過的錢包</translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation>回到選單</translation>
@@ -2945,6 +2909,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2998,17 +2970,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation>回復區塊高度</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation>節點位置</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation>引導節點位址</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation>網路類型</translation>
     </message>
@@ -3016,22 +2988,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation>錢包名稱</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation>錢包檔案位置</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation>瀏覽</translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation>請選擇一個目錄</translation>
     </message>
@@ -3297,6 +3269,11 @@ Spending address index: </source>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
         <translation>錯誤: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="1858"/>

--- a/translations/monero-core_zu.ts
+++ b/translations/monero-core_zu.ts
@@ -1348,6 +1348,11 @@ The old wallet cache file will be renamed and can be restored later.
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../pages/settings/SettingsLayout.qml" line="171"/>
+        <source>Change language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../pages/settings/SettingsLayout.qml" line="183"/>
         <source>No Layout options exist yet in mobile mode.</source>
         <translation type="unfinished"></translation>
@@ -2351,70 +2356,6 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
-    <name>Utils</name>
-    <message>
-        <location filename="../js/Utils.js" line="42"/>
-        <source>Wrong password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="61"/>
-        <source>second ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="63"/>
-        <source>seconds ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="67"/>
-        <source>minute ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="69"/>
-        <source>minutes ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="73"/>
-        <source>hour ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="75"/>
-        <source>hours ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="79"/>
-        <location filename="../js/Utils.js" line="83"/>
-        <source>day ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="85"/>
-        <source>days ago</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Testnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Stagenet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../js/Utils.js" line="94"/>
-        <source>Mainnet</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>WizardAskPassword</name>
     <message>
         <location filename="../wizard/WizardAskPassword.qml" line="41"/>
@@ -2466,7 +2407,7 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
 <context>
     <name>WizardController</name>
     <message>
-        <location filename="../wizard/WizardController.qml" line="258"/>
+        <location filename="../wizard/WizardController.qml" line="260"/>
         <source>Please choose a file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2489,33 +2430,43 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="92"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="90"/>
+        <source>Create a new wallet from device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="103"/>
+        <source>Restore a wallet from device. Use this if you used your hardware wallet before.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="125"/>
         <source>Wallet creation date as `YYYY-MM-DD` or restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="95"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="128"/>
         <source>Restore height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="106"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="139"/>
         <source>Subaddress lookahead (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="134"/>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="183"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="167"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="216"/>
         <source>Error writing wallet from hardware device. Check application logs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="157"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="190"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardCreateDevice1.qml" line="158"/>
+        <location filename="../wizard/WizardCreateDevice1.qml" line="191"/>
         <source>Create wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2550,6 +2501,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     <message>
         <location filename="../wizard/WizardCreateWallet1.qml" line="135"/>
         <source>Back to menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WizardCreateWallet2</name>
+    <message>
+        <location filename="../wizard/WizardCreateWallet2.qml" line="78"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2859,6 +2818,11 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../wizard/WizardOpenWallet1.qml" line="201"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../wizard/WizardOpenWallet1.qml" line="228"/>
         <source>Back to menu</source>
         <translation type="unfinished"></translation>
@@ -2928,6 +2892,14 @@ For the case with Spend Proof, you don&apos;t need to specify the recipient addr
     </message>
 </context>
 <context>
+    <name>WizardRestoreWallet2</name>
+    <message>
+        <location filename="../wizard/WizardRestoreWallet2.qml" line="77"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WizardRestoreWallet3</name>
     <message>
         <location filename="../wizard/WizardRestoreWallet3.qml" line="65"/>
@@ -2979,17 +2951,17 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="76"/>
+        <location filename="../wizard/WizardSummary.qml" line="82"/>
         <source>Daemon address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="83"/>
+        <location filename="../wizard/WizardSummary.qml" line="89"/>
         <source>Bootstrap address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardSummary.qml" line="89"/>
+        <location filename="../wizard/WizardSummary.qml" line="95"/>
         <source>Network Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2997,22 +2969,22 @@ If you don&apos;t have the option to run your own node, there&apos;s an option t
 <context>
     <name>WizardWalletInput</name>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="66"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="71"/>
         <source>Wallet name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="80"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="85"/>
         <source>Wallet location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="86"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="91"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizard/WizardWalletInput.qml" line="101"/>
+        <location filename="../wizard/WizardWalletInput.qml" line="106"/>
         <source>Please choose a directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3267,6 +3239,11 @@ Spending address index: </source>
     <message>
         <location filename="../main.qml" line="1261"/>
         <source>Error: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="1803"/>
+        <source>Failed to fetch remote nodes from third-party server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Last PR before branching. Resynced all language files after the last merge.

Results (since last resync #1986 ):
```
    Found 612 source text(s) (7 new and 605 already existing)
    Removed 12 obsolete entries
```

To make the review process easier you can reproduce this PR following these steps:

1. Pull latest master
2. Run `lupdate -pro monero-wallet-gui.pro -ts translations/monero-core.ts -no-obsolete
` and `lupdate -pro monero-wallet-gui.pro -ts translations/monero-core_*.ts -no-obsolete
`