### PR TITLE
main: enable slow-hash JIT

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -88,7 +88,8 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_WIN
     bool isWindows = true;
 #endif
-
+    // enable slow-hash JIT
+    putenv((char*)"MONERO_USE_CNV4_JIT=1");
     // disable "QApplication: invalid style override passed" warning
     if (isDesktop) putenv((char*)"QT_STYLE_OVERRIDE=fusion");
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
```
18:31 <+moneromooo> dEBRUYNE: can you call putenv in the GUI before running monerod ?
18:31 <+moneromooo> ie, forcing JIT on.
18:32 <+moneromooo> putenv("MONERO_USE_CN_JIT=1");
```

Doesn’t seem to work for me though on macOS. ~114H/s with and without this patch.