### PR TITLE
Makes placeholder string untranslatable

### DIFF
--- a/wizard/WizardCreateWallet1.qml
+++ b/wizard/WizardCreateWallet1.qml
@@ -91,7 +91,7 @@ Rectangle {
                     copyButton: false
                     readOnly: true
 
-                    placeholderText: qsTr("-") + translationManager.emptyString
+                    placeholderText: "-"
                     text: wizardController.walletOptionsSeed
                 }
 


### PR DESCRIPTION
This placeholder was marked as translatable, but there isn't really anything to translate. This resulted in a basically empty string that translators had to work on (see [example on Pootle](https://translate.getmonero.org/it/monero-gui/translate/#search=-&sfields=source,target&unit=220533&offset=0))

This PR makes the string untranslatable.