### PR TITLE
main: automatically fix common wallet cache errors

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2014-2019, The Monero Project
 //
 // All rights reserved.
 //
@@ -436,12 +436,30 @@ ApplicationWindow {
                 wizard.wizardState = "wizardHome";
                 rootItem.state = "wizard";
             }
-            // opening with password but password doesn't match
-            console.error("Error opening wallet with password: ", wallet.errorString);
-            passwordDialog.showError(qsTr("Couldn't open wallet: ") + wallet.errorString);
-            console.log("closing wallet async : " + wallet.address)
-            closeWallet();
-            return;
+            // try to resolve common wallet cache errors automatically
+            switch (wallet.errorString) {
+                case "basic_string::_M_replace_aux":
+                    walletManager.clearWalletCache(wallet.path);
+                    walletPassword = passwordDialog.password;
+                    appWindow.initialize();
+                    console.error("Repairing wallet cache with error: ", wallet.errorString);
+                    appWindow.showStatusMessage(qsTr("Repairing incompatible wallet cache. Resyncing wallet."),6);
+                    return;
+                case "std::bad_alloc":
+                    walletManager.clearWalletCache(wallet.path);
+                    walletPassword = passwordDialog.password;
+                    appWindow.initialize();
+                    console.error("Repairing wallet cache with error: ", wallet.errorString);
+                    appWindow.showStatusMessage(qsTr("Repairing incompatible wallet cache. Resyncing wallet."),6);
+                    return;
+                default:
+                    // opening with password but password doesn't match
+                    console.error("Error opening wallet with password: ", wallet.errorString);
+                    passwordDialog.showError(qsTr("Couldn't open wallet: ") + wallet.errorString);
+                    console.log("closing wallet async : " + wallet.address)
+                    closeWallet();
+                    return;
+            }
         }
 
         // wallet opened successfully, subscribing for wallet updates
@@ -450,7 +468,6 @@ ApplicationWindow {
         // Force switch normal view
         rootItem.state = "normal";
     }
-
 
     function onWalletClosed(walletAddress) {
         console.log(">>> wallet closed: " + walletAddress)


### PR DESCRIPTION
Gracefully fixes wallet opening issues such as #1738 #1730 

Clears wallet cache for common error messages which normally require manual user intervention.
Handles cases involving basic_string::_M_replace_aux and std::bad_alloc error.
Old wallet cache remains and is renamed by walletManager.clearWalletCache.

Before
![bef](https://user-images.githubusercontent.com/40871101/54182060-a9a01a00-445d-11e9-8aa5-4b386c872056.gif)

After
![aft1](https://user-images.githubusercontent.com/40871101/54182065-ab69dd80-445d-11e9-9a28-c3bcf26b0202.gif)
