### PR TITLE
[Bugfix] Restore height option for hardware wallet restore

### DIFF
--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -111,12 +111,11 @@ Rectangle {
                 }
             }
 
-            GridLayout {
+            ColumnLayout {
                 Layout.topMargin: 10 * scaleRatio
                 Layout.fillWidth: true
 
-                columnSpacing: 20 * scaleRatio
-                columns: 2
+                spacing: 20 * scaleRatio
 
                 MoneroComponents.LineEdit {
                     id: restoreHeight


### PR DESCRIPTION
Recent UI revamps seem to have broken the `Restore height` option in the hardware wallet setup process.

Right now it looks like this:

![restore_non_fixxed](https://user-images.githubusercontent.com/6190023/54485407-35f47780-4878-11e9-80b2-e8a64740493c.gif)

And with this PR it will look like this:

![restore_fixxed](https://user-images.githubusercontent.com/6190023/54485417-43116680-4878-11e9-8351-12a204233e37.png)

Cosmetic UI details, but I needed this to work properly.