### PR TITLE
Async device open and create from device, passphrase entry, requires #5355

### DIFF
--- a/components/PassphraseDialog.qml
+++ b/components/PassphraseDialog.qml
@@ -1,0 +1,327 @@
+// Copyright (c) 2014-2019, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.1
+import QtQuick.Controls.Styles 1.4
+import QtQuick.Window 2.0
+
+import "../components" as MoneroComponents
+
+Item {
+    id: root
+    visible: false
+    z: parent.z + 2
+
+    property bool isHidden: true
+    property alias passphrase: passphaseInput1.text
+    property string walletName
+    property string errorText
+
+    // same signals as Dialog has
+    signal accepted()
+    signal rejected()
+    signal closeCallback()
+
+    function open(walletName, errorText) {
+        inactiveOverlay.visible = true
+
+        root.walletName = walletName ? walletName : ""
+        root.errorText = errorText ? errorText : "";
+
+        leftPanel.enabled = false
+        middlePanel.enabled = false
+        titleBar.enabled = false
+        show();
+        root.visible = true;
+        passphaseInput1.text = "";
+        passphaseInput2.text = "";
+        passphaseInput1.focus = true
+    }
+
+    function close() {
+        inactiveOverlay.visible = false
+        leftPanel.enabled = true
+        middlePanel.enabled = true
+        titleBar.enabled = true
+        root.visible = false;
+        closeCallback();
+    }
+    
+    function toggleIsHidden() {
+        passphaseInput1.echoMode = isHidden ? TextInput.Normal : TextInput.Password;
+        passphaseInput2.echoMode = isHidden ? TextInput.Normal : TextInput.Password;
+        isHidden = !isHidden;
+    }
+
+    function showError(errorText) {
+        open(root.walletName, errorText);
+    }
+
+    // TODO: implement without hardcoding sizes
+    width: 480
+    height: 360
+
+    // Make window draggable
+    MouseArea {
+        anchors.fill: parent
+        property point lastMousePos: Qt.point(0, 0)
+        onPressed: { lastMousePos = Qt.point(mouseX, mouseY); }
+        onMouseXChanged: root.x += (mouseX - lastMousePos.x)
+        onMouseYChanged: root.y += (mouseY - lastMousePos.y)
+    }
+
+    ColumnLayout {
+        z: inactiveOverlay.z + 1
+        id: mainLayout
+        spacing: 10
+        anchors { fill: parent; margins: 35 * scaleRatio }
+
+        ColumnLayout {
+            id: column
+
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignHCenter
+            Layout.maximumWidth: 400 * scaleRatio
+
+            Label {
+                text: root.walletName.length > 0 ? qsTr("Please enter wallet device passphrase for: ") + root.walletName : qsTr("Please enter wallet device passphrase")
+                Layout.fillWidth: true
+
+                font.pixelSize: 16 * scaleRatio
+                font.family: MoneroComponents.Style.fontLight.name
+
+                color: MoneroComponents.Style.defaultFontColor
+            }
+
+            Label {
+                text: qsTr("Warning: passphrase entry on host is a security risk as it can be captured by malware. It is advised to prefer device-based passphrase entry.");
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+
+                font.pixelSize: 14 * scaleRatio
+                font.family: MoneroComponents.Style.fontLight.name
+
+                color: MoneroComponents.Style.warningColor
+            }
+
+            Label {
+                text: root.errorText
+                visible: root.errorText
+
+                color: MoneroComponents.Style.errorColor
+                font.pixelSize: 16 * scaleRatio
+                font.family: MoneroComponents.Style.fontLight.name
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+            }
+
+            TextField {
+                id : passphaseInput1
+                Layout.topMargin: 6
+                Layout.fillWidth: true
+                horizontalAlignment: TextInput.AlignLeft
+                verticalAlignment: TextInput.AlignVCenter
+                font.family: MoneroComponents.Style.fontLight.name
+                font.pixelSize: 24 * scaleRatio
+                echoMode: TextInput.Password
+                bottomPadding: 10
+                leftPadding: 10
+                topPadding: 10
+                color: MoneroComponents.Style.defaultFontColor
+                selectionColor: MoneroComponents.Style.dimmedFontColor
+                selectedTextColor: MoneroComponents.Style.defaultFontColor
+                KeyNavigation.tab: passphaseInput2
+
+                background: Rectangle {
+                    radius: 2
+                    border.color: Qt.rgba(255, 255, 255, 0.35)
+                    border.width: 1
+                    color: "black"
+
+                    Image {
+                        width: 26 * scaleRatio
+                        height: 26 * scaleRatio
+                        opacity: 0.7
+                        fillMode: Image.PreserveAspectFit
+                        source: isHidden ? "../images/eyeShow.png" : "../images/eyeHide.png"
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.right: parent.right
+                        anchors.rightMargin: 20
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            hoverEnabled: true
+                            onClicked: {
+                                toggleIsHidden()
+                            }
+                            onEntered: {
+                                parent.opacity = 0.9
+                                parent.width = 28 * scaleRatio
+                                parent.height = 28 * scaleRatio
+                            }
+                            onExited: {
+                                parent.opacity = 0.7
+                                parent.width = 26 * scaleRatio
+                                parent.height = 26 * scaleRatio
+                            }
+                        }
+                    }
+                }
+
+                Keys.onEscapePressed: {
+                    root.close()
+                    root.rejected()
+                }
+            }
+
+            // padding
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                height: 10
+                opacity: 0
+                color: "black"
+            }
+
+            Label {
+                text: qsTr("Please re-enter")
+                Layout.fillWidth: true
+
+                font.pixelSize: 16 * scaleRatio
+                font.family: MoneroComponents.Style.fontLight.name
+
+                color: MoneroComponents.Style.defaultFontColor
+            }
+
+            TextField {
+                id : passphaseInput2
+                Layout.topMargin: 6
+                Layout.fillWidth: true
+                horizontalAlignment: TextInput.AlignLeft
+                verticalAlignment: TextInput.AlignVCenter
+                font.family: MoneroComponents.Style.fontLight.name
+                font.pixelSize: 24 * scaleRatio
+                echoMode: TextInput.Password
+                KeyNavigation.tab: okButton
+                bottomPadding: 10
+                leftPadding: 10
+                topPadding: 10
+                color: MoneroComponents.Style.defaultFontColor
+                selectionColor: MoneroComponents.Style.dimmedFontColor
+                selectedTextColor: MoneroComponents.Style.defaultFontColor
+
+                background: Rectangle {
+                    radius: 2
+                    border.color: Qt.rgba(255, 255, 255, 0.35)
+                    border.width: 1
+                    color: "black"
+
+                    Image {
+                        width: 26 * scaleRatio
+                        height: 26 * scaleRatio
+                        opacity: 0.7
+                        fillMode: Image.PreserveAspectFit
+                        source: isHidden ? "../images/eyeShow.png" : "../images/eyeHide.png"
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.right: parent.right
+                        anchors.rightMargin: 20
+                        MouseArea {
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            hoverEnabled: true
+                            onClicked: {
+                                toggleIsHidden()
+                            }
+                            onEntered: {
+                                parent.opacity = 0.9
+                                parent.width = 28 * scaleRatio
+                                parent.height = 28 * scaleRatio
+                            }
+                            onExited: {
+                                parent.opacity = 0.7
+                                parent.width = 26 * scaleRatio
+                                parent.height = 26 * scaleRatio
+                            }
+                        }
+                    }
+                }
+
+                Keys.onReturnPressed: {
+                    if (passphaseInput1.text === passphaseInput2.text) {
+                        root.close()
+                        root.accepted()
+                    }
+                }
+                Keys.onEscapePressed: {
+                    root.close()
+                    root.rejected()
+                }
+            }
+
+            // padding
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                height: 10
+                opacity: 0
+                color: "black"
+            }
+
+            // Ok/Cancel buttons
+            RowLayout {
+                id: buttons
+                spacing: 16 * scaleRatio
+                Layout.topMargin: 16
+                Layout.alignment: Qt.AlignRight
+
+                MoneroComponents.StandardButton {
+                    id: cancelButton
+                    text: qsTr("Cancel") + translationManager.emptyString
+                    KeyNavigation.tab: passphaseInput1
+                    onClicked: {
+                        root.close()
+                        root.rejected()
+                    }
+                }
+                MoneroComponents.StandardButton {
+                    id: okButton
+                    text: qsTr("Continue")
+                    KeyNavigation.tab: cancelButton
+                    enabled: passphaseInput1.text === passphaseInput2.text
+                    onClicked: {
+                        root.close()
+                        root.accepted()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/Style.qml
+++ b/components/Style.qml
@@ -17,6 +17,7 @@ QtObject {
     property string defaultFontColor: "white"
     property string dimmedFontColor: "#BBBBBB"
     property string lightGreyFontColor: "#DFDFDF"
+    property string warningColor: "#963E00"
     property string errorColor: "#FA6800"
     property string inputBoxBackground: "black"
     property string inputBoxBackgroundError: "#FFDDDD"

--- a/qml.qrc
+++ b/qml.qrc
@@ -117,6 +117,7 @@
         <file>pages/TxKey.qml</file>
         <file>pages/SharedRingDB.qml</file>
         <file>components/IconButton.qml</file>
+        <file>components/PassphraseDialog.qml</file>
         <file>components/PasswordDialog.qml</file>
         <file>components/NewPasswordDialog.qml</file>
         <file>components/InputDialog.qml</file>

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -75,6 +75,16 @@ public:
         emit m_wallet->refreshed();
     }
 
+    virtual void onDeviceButtonRequest(uint64_t code) override
+    {
+        emit m_wallet->deviceButtonRequest(code);
+    }
+
+    virtual void onDeviceButtonPressed() override
+    {
+        emit m_wallet->deviceButtonPressed();
+    }
+
 private:
     Wallet * m_wallet;
 };

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -322,6 +322,8 @@ signals:
     void newBlock(quint64 height, quint64 targetHeight);
     void historyModelChanged() const;
     void walletCreationHeightChanged();
+    void deviceButtonRequest(quint64 buttonCode);
+    void deviceButtonPressed();
 
     // emitted when transaction is created async
     void transactionCreated(PendingTransaction * transaction, QString address, QString paymentId, quint32 mixinCount);

--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -207,13 +207,9 @@ Rectangle {
                         }
                         wizardController.walletOptionsRestoreHeight = _restoreHeight;
                     }
-                    var written = wizardController.createWalletFromDevice();
-                    if(written){
-                        wizardController.walletOptionsIsRecoveringFromDevice = true;
-                        wizardStateView.state = "wizardCreateWallet2";
-                    } else {
-                        errorMsg.text = qsTr("Error writing wallet from hardware device. Check application logs.") + translationManager.emptyString;
-                    }
+
+                    wizardController.walletCreatedFromDevice.connect(onCreateWalletFromDeviceCompleted);
+                    wizardController.createWalletFromDevice();
                 }
             }
         }
@@ -229,5 +225,14 @@ Rectangle {
         if(previousView.viewName == "wizardHome"){
             walletInput.reset();
         }
+    }
+
+    function onCreateWalletFromDeviceCompleted(written){
+        if(written){
+            wizardStateView.state = "wizardCreateWallet2";
+        } else {
+            errorMsg.text = qsTr("Error writing wallet from hardware device. Check application logs.") + translationManager.emptyString;
+        }
+        wizardController.walletCreatedFromDevice.disconnect(onCreateWalletFromDeviceCompleted);
     }
 }


### PR DESCRIPTION
- Requires https://github.com/monero-project/monero-gui/pull/2019
- Passphrase entry on host added, requires early listener setting https://github.com/monero-project/monero/pull/5355
- Wallet open and create from device shows splash to indicate a possible long process
- Create from a device is async to support passphrase entry

<img width="1280" alt="Screenshot 2019-03-27 at 09 27 35" src="https://user-images.githubusercontent.com/1052761/55061209-75d70e00-5073-11e9-96b8-7f1c580ce0e4.png">
<img width="1280" alt="Screenshot 2019-03-27 at 09 27 48" src="https://user-images.githubusercontent.com/1052761/55061225-7ec7df80-5073-11e9-9dfb-9a00f359e497.png">
<img width="1280" alt="Screenshot 2019-03-27 at 09 28 22" src="https://user-images.githubusercontent.com/1052761/55061228-825b6680-5073-11e9-98be-2efcca5334aa.png">

## Building

In order to build this PR for testing you need to fetch my original branch

```bash
git clone --recursive https://github.com/monero-project/monero-gui.git
cd monero-gui
git remote add ph4r05 https://github.com/ph4r05/monero-gui.git
git fetch --all
git checkout -b trezor-pass ph4r05/trezor-pass

cd monero
git remote add ph4r05 https://github.com/ph4r05/monero.git
git fetch --all
git checkout -b trezor/api_pass ph4r05/trezor/api_pass
git submodule update --recursive
cd -
./build.sh
```

## Troubleshooting

If you experience `Bad offset calculation` error when creating a transaction the remote node you are using is probably running too old version.

The code is known to work with version `131076`. For testing purposes, try node `173.255.205.142:18089`, it should work smoothly.
