### PR TITLE
Use pkg-config to find libusb and protobuf (Trezor dependencies)

### DIFF
--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -10,6 +10,12 @@ QT += qml quick widgets
 WALLET_ROOT=$$PWD/monero
 
 CONFIG += c++11 link_pkgconfig
+packagesExist(libusb-1.0) {
+    PKGCONFIG += libusb-1.0
+}
+packagesExist(protobuf) {
+    PKGCONFIG += protobuf
+}
 packagesExist(hidapi-libusb) {
     PKGCONFIG += hidapi-libusb
 }


### PR DESCRIPTION
This patch finds dependencies required to make Trezor support viable.