### PR TITLE
[Qt 5.9] Remove scaleRatio

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -120,8 +120,8 @@ Rectangle {
                 anchors.topMargin: 20
                 anchors.leftMargin: 20
                 anchors.verticalCenter: parent.verticalCenter
-                height: 490 * scaleRatio
-                width: 260 * scaleRatio
+                height: 490
+                width: 260
 
                 Image {
                     id: card
@@ -173,8 +173,8 @@ Rectangle {
                 }
 
                 Rectangle {
-                    height: (logoutImage.height + 8) * scaleRatio
-                    width: (logoutImage.width + 8) * scaleRatio
+                    height: (logoutImage.height + 8)
+                    width: (logoutImage.width + 8)
                     color: "transparent"
                     anchors.right: parent.right
                     anchors.rightMargin: 8
@@ -185,8 +185,8 @@ Rectangle {
                         id: logoutImage
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
-                        height: 16 * scaleRatio
-                        width: 13 * scaleRatio
+                        height: 16
+                        width: 13
                         source: "qrc:///images/logout.png"
                     }
 
@@ -210,8 +210,8 @@ Rectangle {
                 anchors.topMargin: 20
                 anchors.leftMargin: 20
                 anchors.verticalCenter: parent.verticalCenter
-                height: 490 * scaleRatio
-                width: 50 * scaleRatio
+                height: 490
+                width: 50
 
                 MoneroComponents.TextPlain {
                     visible: !isMobile
@@ -672,7 +672,7 @@ Rectangle {
             anchors.leftMargin: 0
             anchors.rightMargin: 0
             anchors.bottom: networkStatus.top;
-            height: 10 * scaleRatio
+            height: 10
             color: "transparent"
         }
 
@@ -680,11 +680,11 @@ Rectangle {
             id: networkStatus
             anchors.left: parent.left
             anchors.right: parent.right
-            anchors.leftMargin: 5 * scaleRatio
+            anchors.leftMargin: 5
             anchors.rightMargin: 0
             anchors.bottom: (progressBar.visible)? progressBar.top : parent.bottom;
             connected: Wallet.ConnectionStatus_Disconnected
-            height: 48 * scaleRatio
+            height: 48
         }
 
         MoneroComponents.ProgressBar {
@@ -692,7 +692,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: daemonProgressBar.top
-            height: 48 * scaleRatio
+            height: 48
             syncType: qsTr("Wallet") + translationManager.emptyString
             visible: networkStatus.connected
         }
@@ -704,7 +704,7 @@ Rectangle {
             anchors.bottom: parent.bottom
             syncType: qsTr("Daemon") + translationManager.emptyString
             visible: networkStatus.connected
-            height: 62 * scaleRatio
+            height: 62
         }
     }
 }

--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -51,7 +51,7 @@ Rectangle {
     property string balanceText
     property string unlockedBalanceLabelText: qsTr("Unlocked Balance") + translationManager.emptyString
     property string unlockedBalanceText
-    property int minHeight: (appWindow.height > 800) ? appWindow.height : 800 * scaleRatio
+    property int minHeight: (appWindow.height > 800) ? appWindow.height : 800
     property alias contentHeight: mainFlickable.contentHeight
     property alias flickable: mainFlickable
 
@@ -125,11 +125,11 @@ Rectangle {
             State {
                 name: "History"
                 PropertyChanges { target: root; currentView: historyView }
-                PropertyChanges { target: mainFlickable; contentHeight: historyView.contentHeight + 100 * scaleRatio}
+                PropertyChanges { target: mainFlickable; contentHeight: historyView.contentHeight + 100}
             }, State {
                 name: "Transfer"
                 PropertyChanges { target: root; currentView: transferView }
-                PropertyChanges { target: mainFlickable; contentHeight: 700 * scaleRatio }
+                PropertyChanges { target: mainFlickable; contentHeight: 700 }
             }, State {
                name: "Receive"
                PropertyChanges { target: root; currentView: receiveView }
@@ -141,7 +141,7 @@ Rectangle {
             }, State {
                name: "TxKey"
                PropertyChanges { target: root; currentView: txkeyView }
-               PropertyChanges { target: mainFlickable; contentHeight: 1200 * scaleRatio  }
+               PropertyChanges { target: mainFlickable; contentHeight: 1200  }
             }, State {
                name: "SharedRingDB"
                PropertyChanges { target: root; currentView: sharedringdbView }
@@ -153,7 +153,7 @@ Rectangle {
             }, State {
                 name: "Sign"
                PropertyChanges { target: root; currentView: signView }
-               PropertyChanges { target: mainFlickable; contentHeight: 1000 * scaleRatio  }
+               PropertyChanges { target: mainFlickable; contentHeight: 1000  }
             }, State {
                 name: "Settings"
                PropertyChanges { target: root; currentView: settingsView }
@@ -161,7 +161,7 @@ Rectangle {
             }, State {
                 name: "Mining"
                 PropertyChanges { target: root; currentView: miningView }
-                PropertyChanges { target: mainFlickable; contentHeight: 700 * scaleRatio}
+                PropertyChanges { target: mainFlickable; contentHeight: 700}
             }, State {
                 name: "Keys"
                 PropertyChanges { target: root; currentView: keysView }
@@ -196,10 +196,10 @@ Rectangle {
             if(currentView === merchantView || currentView === historyView)
                 return 0;
 
-            return 20 * scaleRatio;
+            return 20;
         }
 
-        anchors.topMargin: appWindow.persistentSettings.customDecorations ? 50 * scaleRatio : 0
+        anchors.topMargin: appWindow.persistentSettings.customDecorations ? 50 : 0
         spacing: 0
 
         Flickable {

--- a/components/CheckBox.qml
+++ b/components/CheckBox.qml
@@ -38,16 +38,16 @@ Item {
     property alias text: label.text
     property string checkedIcon: "qrc:///images/check-white.svg"
     property string uncheckedIcon
-    property int imgWidth: 13 * scaleRatio
-    property int imgHeight: 13 * scaleRatio
+    property int imgWidth: 13
+    property int imgHeight: 13
     property bool checked: false
     property alias background: backgroundRect.color
     property bool border: true
-    property int fontSize: 14 * scaleRatio
+    property int fontSize: 14
     property alias fontColor: label.color
     property bool iconOnTheLeft: true
     signal clicked()
-    height: 25 * scaleRatio
+    height: 25
     width: checkBoxLayout.width
 
     function toggle(){
@@ -58,7 +58,7 @@ Item {
     RowLayout {
         id: checkBoxLayout
         layoutDirection: iconOnTheLeft ? Qt.LeftToRight : Qt.RightToLeft
-        spacing: (!isMobile ? 10 : 8) * scaleRatio
+        spacing: (!isMobile ? 10 : 8)
 
         Item {
             id: checkMark

--- a/components/CheckBox2.qml
+++ b/components/CheckBox2.qml
@@ -39,11 +39,11 @@ RowLayout {
     id: checkBox
     property alias text: label.text
     property bool checked: false
-    property int fontSize: 14 * scaleRatio
+    property int fontSize: 14
     property alias fontColor: label.color
-    property int textMargin: 8 * scaleRatio
+    property int textMargin: 8
     signal clicked()
-    height: 25 * scaleRatio
+    height: 25
 
     function toggle(){
         checkBox.checked = !checkBox.checked
@@ -75,13 +75,13 @@ RowLayout {
                 anchors.left: label.right
                 anchors.leftMargin: textMargin
                 color: "transparent"
-                rotation: checkBox.checked ? 180  * scaleRatio : 0
+                rotation: checkBox.checked ? 180  : 0
 
                 MoneroEffects.ImageMask {
                     id: indicatorImage
                     anchors.centerIn: parent
-                    width: 12 * scaleRatio
-                    height: 8 * scaleRatio
+                    width: 12
+                    height: 8
                     image: "qrc:///images/whiteDropIndicator.png"
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1 : 0.75

--- a/components/DaemonConsole.qml
+++ b/components/DaemonConsole.qml
@@ -92,9 +92,9 @@ Window {
         id: mainLayout
 
         anchors.fill: parent
-        anchors.topMargin: 20 * scaleRatio
-        anchors.margins: 35 * scaleRatio
-        spacing: 20 * scaleRatio
+        anchors.topMargin: 20
+        anchors.margins: 35
+        spacing: 20
 
         Item {
             Layout.fillHeight: true
@@ -118,7 +118,7 @@ Window {
                     selectByMouse: true
                     selectByKeyboard: true
                     font.family: MoneroComponents.Style.defaultFontColor
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                     color: MoneroComponents.Style.defaultFontColor
                     selectionColor: MoneroComponents.Style.textSelectionColor
                     wrapMode: TextEdit.Wrap

--- a/components/DatePicker.qml
+++ b/components/DatePicker.qml
@@ -94,7 +94,7 @@ Item {
     Item {
         id: head
         anchors.top: inputLabelRect.bottom
-        anchors.topMargin: 6 * scaleRatio
+        anchors.topMargin: 6
         anchors.left: parent.left
         anchors.right: parent.right
         height: 28
@@ -237,7 +237,7 @@ Item {
                 Image {
                     id: button
                     anchors.right: parent.right
-                    anchors.rightMargin: 10 * scaleRatio
+                    anchors.rightMargin: 10
                     anchors.verticalCenter: parent.verticalCenter
                     source: "qrc:///images/whiteDropIndicator.png"
                     visible: false
@@ -266,7 +266,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: head.bottom
-        anchors.topMargin: 10 * scaleRatio
+        anchors.topMargin: 10
         color: MoneroComponents.Style.middlePanelBackgroundColor
         border.width: 1
         border.color: MoneroComponents.Style.appWindowBorderColor
@@ -293,7 +293,7 @@ Item {
             anchors.right: parent.right
             anchors.top: parent.top
             anchors.margins: 1
-            anchors.bottomMargin: 10 * scaleRatio
+            anchors.bottomMargin: 10
             height: 220
             frameVisible: false
 
@@ -396,7 +396,7 @@ Item {
 
                     Item {
                         anchors.left: parent.left
-                        anchors.leftMargin: 4 * scaleRatio
+                        anchors.leftMargin: 4
                         anchors.top: parent.top
                         anchors.bottom: parent.bottom
                         width: height
@@ -425,7 +425,7 @@ Item {
 
                     Item {
                         anchors.right: parent.right
-                        anchors.rightMargin: 4 * scaleRatio
+                        anchors.rightMargin: 4
                         anchors.top: parent.top
                         anchors.bottom: parent.bottom
                         width: height

--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -70,7 +70,7 @@ ListView {
     }
 
     footer: Rectangle {
-        height: 127 * scaleRatio
+        height: 127
         width: listView.width
         color: "transparent"
 
@@ -86,12 +86,12 @@ ListView {
     delegate: Rectangle {
         id: delegate
         property bool collapsed: index ? false : true
-        height: collapsed ? 180 * scaleRatio : 70 * scaleRatio
+        height: collapsed ? 180 : 70
         width: listView.width
         color: "transparent"
 
         function collapse(){
-            delegate.height = 180 * scaleRatio;
+            delegate.height = 180;
         }
 
         // borders
@@ -130,29 +130,29 @@ ListView {
         Rectangle {
             id: row1
             anchors.left: parent.left
-            anchors.leftMargin: 20 * scaleRatio
+            anchors.leftMargin: 20
             anchors.right: parent.right
-            anchors.rightMargin: 20 * scaleRatio
+            anchors.rightMargin: 20
             anchors.top: parent.top
-            anchors.topMargin: 15 * scaleRatio
-            height: 40 * scaleRatio
+            anchors.topMargin: 15
+            height: 40
             color: "transparent"
 
             Image {
                 id: arrowImage
                 source: isOut ? "qrc:///images/downArrow.png" : confirmationsRequired === 60  ? "qrc:///images/miningxmr.png" : "qrc:///images/upArrow-green.png"
-                height: 18 * scaleRatio
-                width: (confirmationsRequired === 60  ? 18 : 12) * scaleRatio
+                height: 18
+                width: (confirmationsRequired === 60  ? 18 : 12)
                 anchors.top: parent.top
-                anchors.topMargin: 12 * scaleRatio
+                anchors.topMargin: 12
             }
 
             MoneroComponents.TextPlain {
                 id: txrxLabel
                 anchors.left: arrowImage.right
-                anchors.leftMargin: 18 * scaleRatio
+                anchors.leftMargin: 18
                 font.family: MoneroComponents.Style.fontLight.name
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: isOut ? qsTr("Sent") + translationManager.emptyString : qsTr("Received") + translationManager.emptyString
                 color: "#808080"
             }
@@ -160,11 +160,11 @@ ListView {
             MoneroComponents.TextPlain {
                 id: amountLabel
                 anchors.left: arrowImage.right
-                anchors.leftMargin: 18 * scaleRatio
+                anchors.leftMargin: 18
                 anchors.top: txrxLabel.bottom
-                anchors.topMargin: 0 * scaleRatio
+                anchors.topMargin: 0
                 font.family: MoneroComponents.Style.fontBold.name
-                font.pixelSize: 18 * scaleRatio
+                font.pixelSize: 18
                 font.bold: true
                 text: {
                     var _amount = amount;
@@ -198,7 +198,7 @@ ListView {
 
             Rectangle {
                 anchors.right: parent.right
-                width: 300 * scaleRatio
+                width: 300
                 height: parent.height
                 color: "transparent"
 
@@ -206,7 +206,7 @@ ListView {
                     id: dateLabel
                     anchors.left: parent.left
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                     text: date
                     color: "#808080"
                 }
@@ -214,10 +214,10 @@ ListView {
                 MoneroComponents.TextPlain {
                     id: timeLabel
                     anchors.left: dateLabel.right
-                    anchors.leftMargin: 7 * scaleRatio
+                    anchors.leftMargin: 7
                     anchors.top: parent.top
-                    anchors.topMargin: 1 * scaleRatio
-                    font.pixelSize: 12 * scaleRatio
+                    anchors.topMargin: 1
+                    font.pixelSize: 12
                     text: time
                     color: "#808080"
                 }
@@ -230,7 +230,7 @@ ListView {
                     anchors.top: dateLabel.bottom
                     anchors.topMargin: 0
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: {
                         if(isOut){
                             address = TxUtils.destinationsToAddress(destinations);
@@ -266,16 +266,16 @@ ListView {
                 }
 
                 Rectangle {
-                    height: 24 * scaleRatio
-                    width: 24 * scaleRatio
+                    height: 24
+                    width: 24
                     color: "transparent"
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
 
                     Image {
                         id: dropdownImage
-                        height: 8 * scaleRatio
-                        width: 12 * scaleRatio
+                        height: 8
+                        width: 12
                         source: "qrc:///images/whiteDropIndicator.png"
                         rotation: delegate.collapsed ? 180 : 0
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -297,19 +297,19 @@ ListView {
         Rectangle {
             id: row2
             anchors.left: parent.left
-            anchors.leftMargin: 20 * scaleRatio
+            anchors.leftMargin: 20
             anchors.right: parent.right
-            anchors.rightMargin: 20 * scaleRatio
+            anchors.rightMargin: 20
             anchors.top: row1.bottom
-            anchors.topMargin: 15 * scaleRatio
-            height: 40 * scaleRatio
+            anchors.topMargin: 15
+            height: 40
             color: "transparent"
             visible: delegate.collapsed
 
             // left column
             MoneroComponents.HistoryTableInnerColumn{
                 anchors.left: parent.left
-                anchors.leftMargin: 30 * scaleRatio
+                anchors.leftMargin: 30
 
                 labelHeader: qsTr("Transaction ID") + translationManager.emptyString
                 labelValue: hash.substring(0, 18) + "..."
@@ -319,8 +319,8 @@ ListView {
             // right column
             MoneroComponents.HistoryTableInnerColumn{
                 anchors.right: parent.right
-                anchors.rightMargin: 100 * scaleRatio
-                width: 200 * scaleRatio
+                anchors.rightMargin: 100
+                width: 200
                 height: parent.height
                 color: "transparent"
 
@@ -345,19 +345,19 @@ ListView {
         Rectangle {
             id: row3
             anchors.left: parent.left
-            anchors.leftMargin: 20 * scaleRatio
+            anchors.leftMargin: 20
             anchors.right: parent.right
-            anchors.rightMargin: 20 * scaleRatio
+            anchors.rightMargin: 20
             anchors.top: row2.bottom
-            anchors.topMargin: 15 * scaleRatio
-            height: 40 * scaleRatio
+            anchors.topMargin: 15
+            height: 40
             color: "transparent"
             visible: delegate.collapsed
 
             // left column
             MoneroComponents.HistoryTableInnerColumn{
                 anchors.left: parent.left
-                anchors.leftMargin: 30 * scaleRatio
+                anchors.leftMargin: 30
                 labelHeader: qsTr("Blockheight")
                 labelValue: {
                     if (!isPending)
@@ -377,8 +377,8 @@ ListView {
             // right column
             MoneroComponents.HistoryTableInnerColumn {
                 anchors.right: parent.right
-                anchors.rightMargin: 80 * scaleRatio
-                width: 220 * scaleRatio
+                anchors.rightMargin: 80
+                width: 220
                 height: parent.height
                 color: "transparent"
                 hashValue: hash
@@ -407,12 +407,12 @@ ListView {
                 id: proofButton
                 visible: isOut
                 color: "#404040"
-                height: 24 * scaleRatio
-                width: 24 * scaleRatio
+                height: 24
+                width: 24
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 36
-                radius: 20 * scaleRatio
+                radius: 20
 
                 MouseArea {
                     id: proofButtonMouseArea
@@ -449,19 +449,19 @@ ListView {
                     text: "P"
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                 }
             }
 
             Rectangle {
                 id: detailsButton
                 color: "#404040"
-                height: 24 * scaleRatio
-                width: 24 * scaleRatio
+                height: 24
+                width: 24
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 6
-                radius: 20 * scaleRatio
+                radius: 20
 
                 MouseArea {
                     id: detailsButtonMouseArea
@@ -496,7 +496,7 @@ ListView {
                     text: "?"
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                 }
             }
         }

--- a/components/InlineButton.qml
+++ b/components/InlineButton.qml
@@ -46,9 +46,9 @@ Item {
     property string releasedColor: "#FF6C3C"
     property string icon: ""
     property string textColor: MoneroComponents.Style.inlineButtonTextColor
-    property int fontSize: small ? 14 * scaleRatio : 16 * scaleRatio
-    property int rectHeight: small ? 24 * scaleRatio : 24 * scaleRatio
-    property int rectHMargin: small ? 16 * scaleRatio : 22 * scaleRatio
+    property int fontSize: small ? 14 : 16
+    property int rectHeight: small ? 24 : 24
+    property int rectHMargin: small ? 16 : 22
     property alias text: inlineText.text
     property alias fontPixelSize: inlineText.font.pixelSize
     property alias fontFamily: inlineText.font.family
@@ -64,13 +64,13 @@ Item {
     Rectangle{
         id: rect
         color: MoneroComponents.Style.buttonInlineBackgroundColor
-        height: 24 * scaleRatio
-        width: inlineText.text ? (inlineText.width + 16) * scaleRatio : inlineButton.icon ? (inlineImage.width + 16) * scaleRatio : rect.height
+        height: 24
+        width: inlineText.text ? (inlineText.width + 16) : inlineButton.icon ? (inlineImage.width + 16) : rect.height
         radius: 4
 
         anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
-        anchors.rightMargin: 4 * scaleRatio
+        anchors.rightMargin: 4
 
         MoneroComponents.TextPlain {
             id: inlineText

--- a/components/Input.qml
+++ b/components/Input.qml
@@ -33,7 +33,7 @@ import "../components" as MoneroComponents
 
 TextField {
     font.family: MoneroComponents.Style.fontRegular.name
-    font.pixelSize: 18 * scaleRatio
+    font.pixelSize: 18
     font.bold: true
     horizontalAlignment: TextInput.AlignLeft
     selectByMouse: true

--- a/components/InputDialog.qml
+++ b/components/InputDialog.qml
@@ -75,13 +75,13 @@ Item {
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
-            Layout.maximumWidth: 400 * scaleRatio
+            Layout.maximumWidth: 400
 
             Label {
                 id: label
                 Layout.fillWidth: true
 
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name
 
                 color: MoneroComponents.Style.defaultFontColor
@@ -95,7 +95,7 @@ Item {
                 horizontalAlignment: TextInput.AlignLeft
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: MoneroComponents.Style.fontLight.name
-                font.pixelSize: 24 * scaleRatio
+                font.pixelSize: 24
                 KeyNavigation.tab: okButton
                 bottomPadding: 10
                 leftPadding: 10
@@ -124,7 +124,7 @@ Item {
             // Ok/Cancel buttons
             RowLayout {
                 id: buttons
-                spacing: 16 * scaleRatio
+                spacing: 16
                 Layout.topMargin: 16
                 Layout.alignment: Qt.AlignRight
 

--- a/components/InputMulti.qml
+++ b/components/InputMulti.qml
@@ -33,7 +33,7 @@ import "../js/TxUtils.js" as TxUtils
 import "../components" as MoneroComponents
 
 TextArea {
-    property int fontSize: 18 * scaleRatio
+    property int fontSize: 18
     property bool fontBold: false
     property string fontColor: MoneroComponents.Style.defaultFontColor
 
@@ -51,7 +51,7 @@ TextArea {
     selectionColor: MoneroComponents.Style.textSelectionColor
     selectedTextColor: MoneroComponents.Style.textSelectedColor
 
-    property int minimumHeight: 100 * scaleRatio
+    property int minimumHeight: 100
     height: contentHeight > minimumHeight ? contentHeight : minimumHeight
 
     onTextChanged: {

--- a/components/Label.qml
+++ b/components/Label.qml
@@ -37,7 +37,7 @@ Item {
     property alias color: label.color
     property int textFormat: Text.PlainText
     property string tipText: ""
-    property int fontSize: 16 * scaleRatio
+    property int fontSize: 16
     property bool fontBold: false
     property string fontColor: MoneroComponents.Style.defaultFontColor
     property string fontFamily: ""
@@ -47,14 +47,14 @@ Item {
     property alias textWidth: label.width
     property alias themeTransition: label.themeTransition
     signal linkActivated()
-    height: label.height * scaleRatio
-    width: label.width * scaleRatio
-    Layout.topMargin: 10 * scaleRatio
+    height: label.height
+    width: label.width
+    Layout.topMargin: 10
 
     MoneroComponents.TextPlain {
         id: label
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: 2 * scaleRatio
+        anchors.bottomMargin: 2
         anchors.left: parent.left
         font.family: {
             if(fontFamily){

--- a/components/LabelSubheader.qml
+++ b/components/LabelSubheader.qml
@@ -33,7 +33,7 @@ import "../components/effects/" as MoneroEffects
 
 Label {
     id: item
-    fontSize: 18 * scaleRatio
+    fontSize: 18
 
     Rectangle {
         anchors.top: item.bottom

--- a/components/LanguageSidebar.qml
+++ b/components/LanguageSidebar.qml
@@ -48,7 +48,7 @@ Drawer {
         isOpened = true;
     }
 
-    width: 240 * scaleRatio
+    width: 240
     height: parent.height - (persistentSettings.customDecorations ? 50 : 0)
     y: titleBar.height
 
@@ -77,13 +77,13 @@ Drawer {
                 id: item
                 color: "transparent"
                 width: sideBar.width
-                height: 32 * scaleRatio
+                height: 32
 
                 MoneroComponents.TextPlain {
                     anchors.left: parent.left
-                    anchors.leftMargin: 16 * scaleRatio
+                    anchors.leftMargin: 16
                     font.bold: true
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                     color: MoneroComponents.Style.defaultFontColor
                     text: display_name
                     anchors.verticalCenter: parent.verticalCenter

--- a/components/LineEdit.qml
+++ b/components/LineEdit.qml
@@ -40,7 +40,7 @@ Item {
     property bool placeholderCenter: false
     property string placeholderFontFamily: MoneroComponents.Style.fontRegular.name
     property bool placeholderFontBold: false
-    property int placeholderFontSize: 18 * scaleRatio
+    property int placeholderFontSize: 18
     property string placeholderColor: MoneroComponents.Style.defaultFontColor
     property real placeholderOpacity: 0.35
 
@@ -65,7 +65,7 @@ Item {
         }
     }
 
-    property int fontSize: 18 * scaleRatio
+    property int fontSize: 18
     property bool fontBold: false
     property alias fontColor: input.color
     property bool error: false
@@ -74,19 +74,19 @@ Item {
     property alias labelTextFormat: inputLabel.textFormat
     property string backgroundColor: "transparent"
     property string tipText: ""
-    property int labelFontSize: 16 * scaleRatio
+    property int labelFontSize: 16
     property bool labelFontBold: false
     property alias labelWrapMode: inputLabel.wrapMode
     property alias labelHorizontalAlignment: inputLabel.horizontalAlignment
     property bool showingHeader: inputLabel.text !== "" || copyButton
-    property int inputHeight: 42 * scaleRatio
+    property int inputHeight: 42
 
     signal labelLinkActivated(); // input label, rich text <a> signal
     signal editingFinished();
     signal accepted();
     signal textUpdated();
 
-    height: showingHeader ? (inputLabel.height + inputItem.height + 2) * scaleRatio : 42 * scaleRatio
+    height: showingHeader ? (inputLabel.height + inputItem.height + 2) : 42
 
     onTextUpdated: {
         // check to remove placeholder text when there is content
@@ -141,9 +141,9 @@ Item {
 
     Item{
         id: inputItem
-        height: inputHeight * scaleRatio
+        height: inputHeight
         anchors.top: showingHeader ? inputLabel.bottom : parent.top
-        anchors.topMargin: showingHeader ? 12 * scaleRatio : 2 * scaleRatio
+        anchors.topMargin: showingHeader ? 12 : 2
         width: parent.width
         clip: true
 
@@ -157,14 +157,14 @@ Item {
                 if(placeholderCenter){
                     return undefined;
                 }
-                else if(inlineIcon.visible){ return 50 * scaleRatio; }
-                else { return 10 * scaleRatio; }
+                else if(inlineIcon.visible){ return 50; }
+                else { return 10; }
             }
 
             opacity: item.placeholderOpacity
             color: item.placeholderColor
             font.family: item.placeholderFontFamily
-            font.pixelSize: placeholderFontSize * scaleRatio
+            font.pixelSize: placeholderFontSize
             font.bold: item.placeholderFontBold
             text: ""
             z: 3
@@ -172,7 +172,7 @@ Item {
 
         Rectangle {
             anchors.fill: parent
-            anchors.topMargin: 1 * scaleRatio
+            anchors.topMargin: 1
             color: "transparent"
         }
 
@@ -187,12 +187,12 @@ Item {
 
         Image {
             id: inlineIcon
-            width: 26 * scaleRatio
-            height: 26 * scaleRatio
+            width: 26
+            height: 26
             anchors.top: parent.top
-            anchors.topMargin: 8 * scaleRatio
+            anchors.topMargin: 8
             anchors.left: parent.left
-            anchors.leftMargin: 12 * scaleRatio
+            anchors.leftMargin: 12
             source: "qrc:///images/moneroIcon-28x28.png"
             visible: false
         }
@@ -200,21 +200,21 @@ Item {
         MoneroComponents.Input {
             id: input
             anchors.fill: parent
-            anchors.leftMargin: inlineIcon.visible ? 44 * scaleRatio : 0
+            anchors.leftMargin: inlineIcon.visible ? 44 : 0
             font.pixelSize: item.fontSize
             font.bold: item.fontBold
             onEditingFinished: item.editingFinished()
             onAccepted: item.accepted();
             onTextChanged: item.textUpdated()
-            topPadding: 10 * scaleRatio
-            bottomPadding: 10 * scaleRatio
+            topPadding: 10
+            bottomPadding: 10
         }
 
         MoneroComponents.InlineButton {
             id: inlineButtonId
             visible: item.inlineButtonText ? true : false
             anchors.right: parent.right
-            anchors.rightMargin: 8 * scaleRatio
+            anchors.rightMargin: 8
         }
     }
 }

--- a/components/LineEditMulti.qml
+++ b/components/LineEditMulti.qml
@@ -41,16 +41,16 @@ ColumnLayout {
     property alias labelButtonText: labelButton.text
     property alias placeholderText: placeholderLabel.text
 
-    property int inputPaddingLeft: 10 * scaleRatio
-    property int inputPaddingRight: 10 * scaleRatio
-    property int inputPaddingTop: 10 * scaleRatio
-    property int inputPaddingBottom: 10 * scaleRatio
+    property int inputPaddingLeft: 10
+    property int inputPaddingRight: 10
+    property int inputPaddingTop: 10
+    property int inputPaddingBottom: 10
     property int inputRadius: 4
 
     property bool placeholderCenter: false
     property string placeholderFontFamily: MoneroComponents.Style.fontRegular.name
     property bool placeholderFontBold: false
-    property int placeholderFontSize: 18 * scaleRatio
+    property int placeholderFontSize: 18
     property string placeholderColor: MoneroComponents.Style.defaultFontColor
     property real placeholderOpacity: 0.35
 
@@ -69,12 +69,12 @@ ColumnLayout {
 
     property string labelFontColor: MoneroComponents.Style.defaultFontColor
     property bool labelFontBold: false
-    property int labelFontSize: 16 * scaleRatio
+    property int labelFontSize: 16
     property bool labelButtonVisible: false
 
     property string fontColor: MoneroComponents.Style.defaultFontColor
     property bool fontBold: false
-    property int fontSize: 16 * scaleRatio
+    property int fontSize: 16
 
     property bool mouseSelection: true
     property alias readOnly: input.readOnly
@@ -100,7 +100,7 @@ ColumnLayout {
         id: inputLabelRect
         color: "transparent"
         Layout.fillWidth: true
-        height: (inputLabel.height + 10) * scaleRatio
+        height: (inputLabel.height + 10)
         visible: showingHeader ? true : false
 
         MoneroComponents.TextPlain {
@@ -123,7 +123,7 @@ ColumnLayout {
 
         RowLayout {
             anchors.right: parent.right
-            spacing: 16 * scaleRatio
+            spacing: 16
 
             MoneroComponents.LabelButton {
                 id: labelButton
@@ -177,7 +177,7 @@ ColumnLayout {
             visible: input.text ? false : true
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
-            anchors.leftMargin: 10 * scaleRatio
+            anchors.leftMargin: 10
             opacity: item.placeholderOpacity
             color: item.placeholderColor
             font.family: item.placeholderFontFamily
@@ -200,7 +200,7 @@ ColumnLayout {
             id: inlineButtonId
             visible: (inlineButtonId.text || inlineButtonId.icon) && inlineButtonVisible ? true : false
             anchors.right: parent.right
-            anchors.rightMargin: 8 * scaleRatio
+            anchors.rightMargin: 8
         }
     }
 }

--- a/components/MenuButton.qml
+++ b/components/MenuButton.qml
@@ -52,7 +52,7 @@ Rectangle {
         var offset = 0
         var item = button
         while (item.under) {
-            offset += 20 * scaleRatio
+            offset += 20
             item = item.under
         }
         return offset
@@ -60,7 +60,7 @@ Rectangle {
 
     color: "transparent"
     property bool present: !under || under.checked || checked || under.numSelectedChildren > 0
-    height: present ? ((appWindow.height >= 800) ? 44 * scaleRatio  : 38 * scaleRatio ) : 0
+    height: present ? ((appWindow.height >= 800) ? 44  : 38 ) : 0
 
     LinearGradient {
         visible: isOpenGL && button.checked
@@ -88,7 +88,7 @@ Rectangle {
     // button decorations that are subject to leftMargin offsets
     Rectangle {
         anchors.left: parent.left
-        anchors.leftMargin: parent.getOffset() + 20 * scaleRatio
+        anchors.leftMargin: parent.getOffset() + 20
         height: parent.height
         width: button.checked ? 20: 10
         color: "transparent"
@@ -97,9 +97,9 @@ Rectangle {
         Rectangle {
             id: dot
             anchors.centerIn: parent
-            width: button.checked ? 20 * scaleRatio : 8 * scaleRatio
-            height: button.checked ? 20 * scaleRatio : 8 * scaleRatio
-            radius: button.checked ? 20 * scaleRatio : 4 * scaleRatio
+            width: button.checked ? 20 : 8
+            height: button.checked ? 20 : 8
+            radius: button.checked ? 20 : 4
             color: button.dotColor
             // arrow if checked
             Image {
@@ -118,9 +118,9 @@ Rectangle {
             themeTransitionWhiteColor: MoneroComponents.Style._w_menuButtonTextColor
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.right
-            anchors.leftMargin: 8 * scaleRatio
+            anchors.leftMargin: 8
             font.bold: true
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
         }
     }
 
@@ -129,7 +129,7 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         anchors.leftMargin: parent.getOffset()
         anchors.right: parent.right
-        anchors.rightMargin: 20 * scaleRatio
+        anchors.rightMargin: 20
         height: 14
         width: 8
         image: MoneroComponents.Style.menuButtonImageRightSource
@@ -140,9 +140,9 @@ Rectangle {
     MoneroComponents.TextPlain {
         id: symbolText
         anchors.right: parent.right
-        anchors.rightMargin: 44 * scaleRatio
+        anchors.rightMargin: 44
         anchors.verticalCenter: parent.verticalCenter
-        font.pixelSize: 12 * scaleRatio
+        font.pixelSize: 12
         font.bold: true
         color: button.checked || buttonArea.containsMouse ? MoneroComponents.Style.menuButtonTextColor : dot.color
         visible: appWindow.ctrlPressed

--- a/components/MobileHeader.qml
+++ b/components/MobileHeader.qml
@@ -11,16 +11,16 @@ Rectangle {
     anchors.leftMargin: 1
     anchors.rightMargin: 1
     Layout.fillWidth: true
-    Layout.preferredHeight: 64 * scaleRatio
+    Layout.preferredHeight: 64
     color: "#FFFFFF"
 
     Image {
         id: logo
-        visible: appWindow.width > 460 * scaleRatio
+        visible: appWindow.width > 460
         anchors.verticalCenter: parent.verticalCenter
         anchors.verticalCenterOffset: -5
         anchors.left: parent.left
-        anchors.leftMargin: 50 * scaleRatio
+        anchors.leftMargin: 50
         source: "qrc:///images/moneroLogo2.png"
     }
 
@@ -29,7 +29,7 @@ Rectangle {
         visible: !logo.visible
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
-        anchors.leftMargin: 40 * scaleRatio 
+        anchors.leftMargin: 40
         source: "qrc:///images/moneroIcon.png"
     }
 
@@ -37,16 +37,16 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.topMargin: 10 * scaleRatio
-        width: 256 * scaleRatio
+        anchors.topMargin: 10
+        width: 256
         columns: 3
 
         MoneroComponents.TextPlain {
             id: balanceLabel
-            width: 116 * scaleRatio
-            height: 20 * scaleRatio
+            width: 116
+            height: 20
             font.family: "Arial"
-            font.pixelSize: 12 * scaleRatio
+            font.pixelSize: 12
             font.letterSpacing: -1
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft
@@ -57,10 +57,10 @@ Rectangle {
 
         MoneroComponents.TextPlain {
             id: balanceText
-            width: 110 * scaleRatio
-            height: 20 * scaleRatio
+            width: 110
+            height: 20
             font.family: "Arial"
-            font.pixelSize: 18 * scaleRatio
+            font.pixelSize: 18
             font.letterSpacing: -1
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft
@@ -70,8 +70,8 @@ Rectangle {
         }
 
         Item {
-            height: 20 * scaleRatio
-            width: 20 * scaleRatio
+            height: 20
+            width: 20
 
             Image {
                 anchors.verticalCenter: parent.verticalCenter
@@ -81,10 +81,10 @@ Rectangle {
         }
 
         MoneroComponents.TextPlain {
-            width: 116 * scaleRatio
-            height: 20 * scaleRatio
+            width: 116
+            height: 20
             font.family: "Arial"
-            font.pixelSize: 12 * scaleRatio
+            font.pixelSize: 12
             font.letterSpacing: -1
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft
@@ -95,10 +95,10 @@ Rectangle {
 
         MoneroComponents.TextPlain {
             id: availableBalanceText
-            width: 110 * scaleRatio
-            height: 20 * scaleRatio
+            width: 110
+            height: 20
             font.family: "Arial"
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             font.letterSpacing: -1
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft

--- a/components/NetworkStatusItem.qml
+++ b/components/NetworkStatusItem.qml
@@ -58,12 +58,12 @@ Rectangle {
     }
 
     RowLayout {
-        Layout.preferredHeight: 40 * scaleRatio
+        Layout.preferredHeight: 40
 
         Item {
             id: iconItem
-            width: 40 * scaleRatio
-            height: 40 * scaleRatio
+            width: 40
+            height: 40
             opacity: {
                 if(item.connected == Wallet.ConnectionStatus_Connected){
                     return 1
@@ -74,9 +74,9 @@ Rectangle {
 
             Image {
                 anchors.top: parent.top
-                anchors.topMargin: !appWindow.isMining ? 6 * scaleRatio : 4 * scaleRatio
+                anchors.topMargin: !appWindow.isMining ? 6 : 4
                 anchors.right: parent.right
-                anchors.rightMargin: !appWindow.isMining ? 11 * scaleRatio : 0
+                anchors.rightMargin: !appWindow.isMining ? 11 : 0
                 source: {
                     if(appWindow.isMining) {
                        return "qrc:///images/miningxmr.png"
@@ -102,8 +102,8 @@ Rectangle {
         }
 
         Item {
-            height: 40 * scaleRatio
-            width: 260 * scaleRatio
+            height: 40
+            width: 260
 
             MoneroComponents.TextPlain {
                 id: statusText
@@ -112,7 +112,7 @@ Rectangle {
                 anchors.topMargin: 0
                 font.family: MoneroComponents.Style.fontMedium.name
                 font.bold: true
-                font.pixelSize: 13 * scaleRatio
+                font.pixelSize: 13
                 color: MoneroComponents.Style.dimmedFontColor
                 opacity: MoneroComponents.Style.blackTheme ? 0.65 : 0.5
                 text: qsTr("Network status") + translationManager.emptyString
@@ -125,7 +125,7 @@ Rectangle {
                 anchors.top: parent.top
                 anchors.topMargin: 14
                 font.family: MoneroComponents.Style.fontMedium.name
-                font.pixelSize: 20 * scaleRatio
+                font.pixelSize: 20
                 color: MoneroComponents.Style.defaultFontColor
                 text: getConnectionStatusString(item.connected) + translationManager.emptyString
                 opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.7

--- a/components/NewPasswordDialog.qml
+++ b/components/NewPasswordDialog.qml
@@ -96,20 +96,20 @@ Item {
         z: inactiveOverlay.z + 1
         id: mainLayout
         spacing: 10
-        anchors { fill: parent; margins: 35 * scaleRatio }
+        anchors { fill: parent; margins: 35 }
 
         ColumnLayout {
             id: column
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
-            Layout.maximumWidth: 400 * scaleRatio
+            Layout.maximumWidth: 400
 
             Label {
                 text: qsTr("Please enter new password") + translationManager.emptyString
                 Layout.fillWidth: true
 
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name
 
                 color: MoneroComponents.Style.defaultFontColor
@@ -122,7 +122,7 @@ Item {
                 horizontalAlignment: TextInput.AlignLeft
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: MoneroComponents.Style.fontLight.name
-                font.pixelSize: 24 * scaleRatio
+                font.pixelSize: 24
                 echoMode: TextInput.Password
                 bottomPadding: 10
                 leftPadding: 10
@@ -139,8 +139,8 @@ Item {
                     color: MoneroComponents.Style.blackTheme ? "black" : "#A9FFFFFF"
 
                     Image {
-                        width: 26 * scaleRatio
-                        height: 26 * scaleRatio
+                        width: 26
+                        height: 26
                         opacity: 0.7
                         fillMode: Image.PreserveAspectFit
                         source: isHidden ? "qrc:///images/eyeShow.png" : "qrc:///images/eyeHide.png"
@@ -156,13 +156,13 @@ Item {
                             }
                             onEntered: {
                                 parent.opacity = 0.9
-                                parent.width = 28 * scaleRatio
-                                parent.height = 28 * scaleRatio
+                                parent.width = 28
+                                parent.height = 28
                             }
                             onExited: {
                                 parent.opacity = 0.7
-                                parent.width = 26 * scaleRatio
-                                parent.height = 26 * scaleRatio
+                                parent.width = 26
+                                parent.height = 26
                             }
                         }
                     }
@@ -187,7 +187,7 @@ Item {
                 text: qsTr("Please confirm new password") + translationManager.emptyString
                 Layout.fillWidth: true
 
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name
 
                 color: MoneroComponents.Style.defaultFontColor
@@ -200,7 +200,7 @@ Item {
                 horizontalAlignment: TextInput.AlignLeft
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: MoneroComponents.Style.fontLight.name
-                font.pixelSize: 24 * scaleRatio
+                font.pixelSize: 24
                 echoMode: TextInput.Password
                 KeyNavigation.tab: okButton
                 bottomPadding: 10
@@ -217,8 +217,8 @@ Item {
                     color: MoneroComponents.Style.blackTheme ? "black" : "#A9FFFFFF"
 
                     Image {
-                        width: 26 * scaleRatio
-                        height: 26 * scaleRatio
+                        width: 26
+                        height: 26
                         opacity: 0.7
                         fillMode: Image.PreserveAspectFit
                         source: isHidden ? "qrc:///images/eyeShow.png" : "qrc:///images/eyeHide.png"
@@ -235,13 +235,13 @@ Item {
                             }
                             onEntered: {
                                 parent.opacity = 0.9
-                                parent.width = 28 * scaleRatio
-                                parent.height = 28 * scaleRatio
+                                parent.width = 28
+                                parent.height = 28
                             }
                             onExited: {
                                 parent.opacity = 0.7
-                                parent.width = 26 * scaleRatio
-                                parent.height = 26 * scaleRatio
+                                parent.width = 26
+                                parent.height = 26
                             }
                         }
                     }
@@ -271,7 +271,7 @@ Item {
             // Ok/Cancel buttons
             RowLayout {
                 id: buttons
-                spacing: 16 * scaleRatio
+                spacing: 16
                 Layout.topMargin: 16
                 Layout.alignment: Qt.AlignRight
 

--- a/components/PassphraseDialog.qml
+++ b/components/PassphraseDialog.qml
@@ -107,20 +107,20 @@ Item {
         z: inactiveOverlay.z + 1
         id: mainLayout
         spacing: 10
-        anchors { fill: parent; margins: 35 * scaleRatio }
+        anchors { fill: parent; margins: 35 }
 
         ColumnLayout {
             id: column
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
-            Layout.maximumWidth: 400 * scaleRatio
+            Layout.maximumWidth: 400
 
             Label {
                 text: (root.walletName.length > 0 ? qsTr("Please enter wallet device passphrase for: ") + root.walletName : qsTr("Please enter wallet device passphrase")) + translationManager.emptyString
                 Layout.fillWidth: true
 
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name
 
                 color: MoneroComponents.Style.defaultFontColor
@@ -131,7 +131,7 @@ Item {
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
 
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 font.family: MoneroComponents.Style.fontLight.name
 
                 color: MoneroComponents.Style.warningColor
@@ -142,7 +142,7 @@ Item {
                 visible: root.errorText
 
                 color: MoneroComponents.Style.errorColor
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
@@ -155,7 +155,7 @@ Item {
                 horizontalAlignment: TextInput.AlignLeft
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: MoneroComponents.Style.fontLight.name
-                font.pixelSize: 24 * scaleRatio
+                font.pixelSize: 24
                 echoMode: TextInput.Password
                 bottomPadding: 10
                 leftPadding: 10
@@ -172,8 +172,8 @@ Item {
                     color: MoneroComponents.Style.blackTheme ? "black" : "#A9FFFFFF"
 
                     Image {
-                        width: 26 * scaleRatio
-                        height: 26 * scaleRatio
+                        width: 26
+                        height: 26
                         opacity: 0.7
                         fillMode: Image.PreserveAspectFit
                         source: isHidden ? "qrc:///images/eyeShow.png" : "qrc:///images/eyeHide.png"
@@ -189,13 +189,13 @@ Item {
                             }
                             onEntered: {
                                 parent.opacity = 0.9
-                                parent.width = 28 * scaleRatio
-                                parent.height = 28 * scaleRatio
+                                parent.width = 28
+                                parent.height = 28
                             }
                             onExited: {
                                 parent.opacity = 0.7
-                                parent.width = 26 * scaleRatio
-                                parent.height = 26 * scaleRatio
+                                parent.width = 26
+                                parent.height = 26
                             }
                         }
                     }
@@ -220,7 +220,7 @@ Item {
                 text: qsTr("Please re-enter") + translationManager.emptyString
                 Layout.fillWidth: true
 
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name
 
                 color: MoneroComponents.Style.defaultFontColor
@@ -233,7 +233,7 @@ Item {
                 horizontalAlignment: TextInput.AlignLeft
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: MoneroComponents.Style.fontLight.name
-                font.pixelSize: 24 * scaleRatio
+                font.pixelSize: 24
                 echoMode: TextInput.Password
                 KeyNavigation.tab: okButton
                 bottomPadding: 10
@@ -250,8 +250,8 @@ Item {
                     color: MoneroComponents.Style.blackTheme ? "black" : "#A9FFFFFF"
 
                     Image {
-                        width: 26 * scaleRatio
-                        height: 26 * scaleRatio
+                        width: 26
+                        height: 26
                         opacity: 0.7
                         fillMode: Image.PreserveAspectFit
                         source: isHidden ? "qrc:///images/eyeShow.png" : "qrc:///images/eyeHide.png"
@@ -267,13 +267,13 @@ Item {
                             }
                             onEntered: {
                                 parent.opacity = 0.9
-                                parent.width = 28 * scaleRatio
-                                parent.height = 28 * scaleRatio
+                                parent.width = 28
+                                parent.height = 28
                             }
                             onExited: {
                                 parent.opacity = 0.7
-                                parent.width = 26 * scaleRatio
-                                parent.height = 26 * scaleRatio
+                                parent.width = 26
+                                parent.height = 26
                             }
                         }
                     }
@@ -303,7 +303,7 @@ Item {
             // Ok/Cancel buttons
             RowLayout {
                 id: buttons
-                spacing: 16 * scaleRatio
+                spacing: 16
                 Layout.topMargin: 16
                 Layout.alignment: Qt.AlignRight
 

--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -95,20 +95,20 @@ Item {
         z: inactiveOverlay.z + 1
         id: mainLayout
         spacing: 10
-        anchors { fill: parent; margins: 35 * scaleRatio }
+        anchors { fill: parent; margins: 35 }
 
         ColumnLayout {
             id: column
 
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
-            Layout.maximumWidth: 400 * scaleRatio
+            Layout.maximumWidth: 400
 
             Label {
                 text: (root.walletName.length > 0 ? qsTr("Please enter wallet password for: ") + root.walletName : qsTr("Please enter wallet password")) + translationManager.emptyString
                 Layout.fillWidth: true
 
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name
 
                 color: MoneroComponents.Style.defaultFontColor
@@ -119,7 +119,7 @@ Item {
                 visible: root.errorText || text !== ""
 
                 color: MoneroComponents.Style.errorColor
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 font.family: MoneroComponents.Style.fontLight.name                
                 Layout.fillWidth: true
                 wrapMode: Text.Wrap
@@ -132,7 +132,7 @@ Item {
                 horizontalAlignment: TextInput.AlignLeft
                 verticalAlignment: TextInput.AlignVCenter
                 font.family: MoneroComponents.Style.fontLight.name
-                font.pixelSize: 24 * scaleRatio
+                font.pixelSize: 24
                 echoMode: TextInput.Password
                 KeyNavigation.tab: okButton
                 bottomPadding: 10
@@ -166,8 +166,8 @@ Item {
                     }
 
                     Image {
-                        width: 26 * scaleRatio
-                        height: 26 * scaleRatio
+                        width: 26
+                        height: 26
                         opacity: 0.7
                         fillMode: Image.PreserveAspectFit
                         source: isHidden ? "qrc:///images/eyeShow.png" : "qrc:///images/eyeHide.png"
@@ -185,13 +185,13 @@ Item {
                             }
                             onEntered: {
                                 parent.opacity = 0.9
-                                parent.width = 28 * scaleRatio
-                                parent.height = 28 * scaleRatio
+                                parent.width = 28
+                                parent.height = 28
                             }
                             onExited: {
                                 parent.opacity = 0.7
-                                parent.width = 26 * scaleRatio
-                                parent.height = 26 * scaleRatio
+                                parent.width = 26
+                                parent.height = 26
                             }
                         }
                     }
@@ -227,7 +227,7 @@ Item {
             // Ok/Cancel buttons
             RowLayout {
                 id: buttons
-                spacing: 16 * scaleRatio
+                spacing: 16
                 Layout.topMargin: 16
                 Layout.alignment: Qt.AlignRight
 

--- a/components/ProcessingSplash.qml
+++ b/components/ProcessingSplash.qml
@@ -41,8 +41,8 @@ Rectangle {
     property alias messageText: messageTitle.text
     property alias heightProgressText : heightProgress.text
 
-    width: 200 * scaleRatio
-    height: 100 * scaleRatio
+    width: 200
+    height: 100
     opacity: 0.7
 
     function show() {
@@ -60,8 +60,8 @@ Rectangle {
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
 
-        anchors.leftMargin: 30 * scaleRatio
-        anchors.rightMargin: 30 * scaleRatio
+        anchors.leftMargin: 30
+        anchors.rightMargin: 30
 
         spacing: 12
 
@@ -74,7 +74,7 @@ Rectangle {
             id: messageTitle
             text: "Please wait..."
             font {
-                pixelSize: 22 * scaleRatio
+                pixelSize: 22
             }
             horizontalAlignment: Text.AlignHCenter
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
@@ -87,7 +87,7 @@ Rectangle {
         MoneroComponents.TextPlain {
             id: heightProgress
             font {
-                pixelSize: 18 * scaleRatio
+                pixelSize: 18
             }
             horizontalAlignment: Text.AlignHCenter
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter

--- a/components/ProgressBar.qml
+++ b/components/ProgressBar.qml
@@ -56,9 +56,9 @@ Rectangle {
 
     Item {
         anchors.top: item.top
-        anchors.topMargin: 10 * scaleRatio
-        anchors.leftMargin: 15 * scaleRatio
-        anchors.rightMargin: 15 * scaleRatio
+        anchors.topMargin: 10
+        anchors.leftMargin: 15
+        anchors.rightMargin: 15
         anchors.fill: parent
 
         MoneroComponents.TextPlain {
@@ -66,11 +66,11 @@ Rectangle {
             anchors.top: parent.top
             anchors.topMargin: 6
             font.family: MoneroComponents.Style.fontMedium.name
-            font.pixelSize: 13 * scaleRatio
+            font.pixelSize: 13
             font.bold: MoneroComponents.Style.progressBarProgressTextBold
             color: MoneroComponents.Style.defaultFontColor
             text: qsTr("Synchronizing %1").arg(syncType) + translationManager.emptyString
-            height: 18 * scaleRatio
+            height: 18
         }
 
         MoneroComponents.TextPlain {
@@ -79,10 +79,10 @@ Rectangle {
             anchors.topMargin: 6
             anchors.right: parent.right
             font.family: MoneroComponents.Style.fontMedium.name
-            font.pixelSize: 13 * scaleRatio
+            font.pixelSize: 13
             font.bold: MoneroComponents.Style.progressBarProgressTextBold
             color: MoneroComponents.Style.defaultFontColor
-            height:18 * scaleRatio
+            height:18
         }
 
         Rectangle {
@@ -91,8 +91,8 @@ Rectangle {
             anchors.right: parent.right
             anchors.top: progressText.bottom
             anchors.topMargin: 4
-            height: 8 * scaleRatio
-            radius: 8 * scaleRatio
+            height: 8
+            radius: 8
             color: MoneroComponents.Style.progressBarBackgroundColor
 
             states: [
@@ -118,7 +118,7 @@ Rectangle {
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
                 height: bar.height
-                property int maxWidth: bar.width * scaleRatio
+                property int maxWidth: bar.width
                 width: (maxWidth * fillLevel) / 100
                 radius: 8
                 color: "#FA6800"
@@ -128,7 +128,7 @@ Rectangle {
                 color:"#333"
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
-                anchors.leftMargin: 8 * scaleRatio
+                anchors.leftMargin: 8
             }
         }
 

--- a/components/RadioButton.qml
+++ b/components/RadioButton.qml
@@ -35,10 +35,10 @@ Item {
     id: radioButton
     property alias text: label.text
     property bool checked: false
-    property int fontSize: 14 * scaleRatio
+    property int fontSize: 14
     property alias fontColor: label.color
     signal clicked()
-    height: 26 * scaleRatio
+    height: 26
     width: layout.width
     // legacy properties
     property var checkedColor: MoneroComponents.Style.blackTheme ? "white" : "#666666"
@@ -65,8 +65,8 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
                 color: checkedColor
-                width: 10 * scaleRatio
-                height: 10 * scaleRatio
+                width: 10
+                height: 10
                 radius: 10
                 opacity: 0.8
             }
@@ -74,7 +74,7 @@ Item {
 
         MoneroComponents.TextPlain {
             id: label
-            Layout.leftMargin: (!isMobile ? 10 : 8) * scaleRatio
+            Layout.leftMargin: (!isMobile ? 10 : 8)
             color: MoneroComponents.Style.defaultFontColor
             font.family: MoneroComponents.Style.fontRegular.name
             font.pixelSize: radioButton.fontSize

--- a/components/RemoteNodeEdit.qml
+++ b/components/RemoteNodeEdit.qml
@@ -47,16 +47,16 @@ GridLayout {
     // the wizards get redesigned to the black-theme
     property string placeholderFontFamily: MoneroComponents.Style.fontRegular.name
     property bool placeholderFontBold: false
-    property int placeholderFontSize: 15 * scaleRatio
+    property int placeholderFontSize: 15
     property string placeholderColor: MoneroComponents.Style.defaultFontColor
     property real placeholderOpacity: 0.35
-    property int labelFontSize: 14 * scaleRatio
+    property int labelFontSize: 14
 
     property string lineEditBackgroundColor: "transparent"
     property string lineEditBorderColor: MoneroComponents.Style.inputBorderColorInActive
     property string lineEditFontColor: MoneroComponents.Style.defaultFontColor
     property bool lineEditFontBold: false
-    property int lineEditFontSize: 15 * scaleRatio
+    property int lineEditFontSize: 15
 
     signal editingFinished()
     signal textChanged()

--- a/components/StandardButton.qml
+++ b/components/StandardButton.qml
@@ -39,14 +39,14 @@ Item {
     property bool small: false
     property alias text: label.text
     property int fontSize: {
-        if(small) return 14 * scaleRatio;
-        else return 16 * scaleRatio;
+        if(small) return 14;
+        else return 16;
     }
     property alias label: label
     signal clicked()
 
-    height: small ?  30 * scaleRatio : 36 * scaleRatio
-    width: buttonLayout.width + 22 * scaleRatio
+    height: small ?  30 : 36
+    width: buttonLayout.width + 22
     implicitHeight: height
     implicitWidth: width
 
@@ -100,7 +100,7 @@ Item {
     RowLayout {
         id: buttonLayout
         height: button.height
-        spacing: 11 * scaleRatio
+        spacing: 11
         anchors.centerIn: parent
 
         MoneroComponents.TextPlain {
@@ -127,8 +127,8 @@ Item {
         Image {
             visible: button.rightIcon !== ""
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-            width: button.small ? 16 * scaleRatio : 20 * scaleRatio
-            height: button.small ? 16 * scaleRatio : 20 * scaleRatio
+            width: button.small ? 16 : 20
+            height: button.small ? 16 : 20
             source: {
                 if(button.rightIconInactive !== "" && !button.enabled) {
                     return button.rightIconInactive;

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -97,23 +97,23 @@ Rectangle {
     }
 
     // TODO: implement without hardcoding sizes
-    width: isMobile ? screenWidth : 520 * scaleRatio
-    height: isMobile ? screenHeight : 380 * scaleRatio
+    width: isMobile ? screenWidth : 520
+    height: isMobile ? screenHeight : 380
 
     ColumnLayout {
         id: mainLayout
-        spacing: 10 * scaleRatio
+        spacing: 10
         anchors.fill: parent
-        anchors.margins: (isMobile? 17 : 20) * scaleRatio
+        anchors.margins: (isMobile? 17 : 20)
 
         RowLayout {
             id: column
-            Layout.topMargin: 14 * scaleRatio
+            Layout.topMargin: 14
             Layout.fillWidth: true
 
             MoneroComponents.Label {
                 id: dialogTitle
-                fontSize: 18 * scaleRatio
+                fontSize: 18
                 fontFamily: "Arial"
                 color: MoneroComponents.Style.defaultFontColor
             }
@@ -122,7 +122,7 @@ Rectangle {
         Item {
             Layout.fillHeight: true
             Layout.fillWidth: true
-            Layout.preferredHeight: 240 * scaleRatio
+            Layout.preferredHeight: 240
 
             Flickable {
                 id: flickable
@@ -137,7 +137,7 @@ Rectangle {
                     font.family: MoneroComponents.Style.fontLight.name
                     textFormat: TextEdit.AutoText
                     readOnly: true
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                     selectByMouse: false
                     wrapMode: TextEdit.Wrap
                     color: MoneroComponents.Style.defaultFontColor
@@ -162,7 +162,7 @@ Rectangle {
         // Ok/Cancel buttons
         RowLayout {
             id: buttons
-            spacing: 60 * scaleRatio
+            spacing: 60
             Layout.alignment: Qt.AlignHCenter
 
             MoneroComponents.StandardButton {
@@ -191,14 +191,14 @@ Rectangle {
         id: closeButton
         anchors.top: parent.top
         anchors.right: parent.right
-        width: 48 * scaleRatio
-        height: 48 * scaleRatio
+        width: 48
+        height: 48
         color: "transparent"
 
         MoneroEffects.ImageMask {
             anchors.centerIn: parent
-            width: 16 * scaleRatio
-            height: 16 * scaleRatio
+            width: 16
+            height: 16
             image: MoneroComponents.Style.titleBarCloseSource
             color: MoneroComponents.Style.defaultFontColor
             opacity: 0.75
@@ -218,7 +218,7 @@ Rectangle {
 
     // window borders
     Rectangle{
-        width: 1 * scaleRatio
+        width: 1
         color: MoneroComponents.Style.grey
         anchors.left: parent.left
         anchors.top: parent.top
@@ -226,7 +226,7 @@ Rectangle {
     }
 
     Rectangle{
-        width: 1 * scaleRatio
+        width: 1
         color: MoneroComponents.Style.grey
         anchors.right: parent.right
         anchors.top: parent.top
@@ -234,7 +234,7 @@ Rectangle {
     }
 
     Rectangle{
-        height: 1 * scaleRatio
+        height: 1
         color: MoneroComponents.Style.grey
         anchors.left: parent.left
         anchors.top: parent.top
@@ -242,7 +242,7 @@ Rectangle {
     }
 
     Rectangle{
-        height: 1 * scaleRatio
+        height: 1
         color: MoneroComponents.Style.grey
         anchors.left: parent.left
         anchors.bottom: parent.bottom

--- a/components/StandardDropdown.qml
+++ b/components/StandardDropdown.qml
@@ -44,8 +44,8 @@ Item {
     property alias currentIndex: columnid.currentIndex
     property bool expanded: false
     property int dropdownHeight: 42
-    property int fontHeaderSize: 16 * scaleRatio
-    property int fontItemSize: 14 * scaleRatio
+    property int fontHeaderSize: 16
+    property int fontItemSize: 14
     property string colorBorder: MoneroComponents.Style.inputBorderColorInActive
     property string colorHeaderBackground: "transparent"
     property bool headerBorder: true
@@ -94,7 +94,7 @@ Item {
             id: firstColText
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
-            anchors.leftMargin: 12 * scaleRatio
+            anchors.leftMargin: 12
             elide: Text.ElideRight
             font.family: MoneroComponents.Style.fontRegular.name
             font.bold: dropdown.headerFontBold
@@ -107,7 +107,7 @@ Item {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             anchors.right: parent.right
-            width: 32 * scaleRatio
+            width: 32
 
             Image {
                 id: dropdownIcon
@@ -120,7 +120,7 @@ Item {
                 source: dropdownIcon
                 anchors.fill: dropdownIcon
                 color: MoneroComponents.Style.defaultFontColor
-                rotation: dropdown.expanded ? 180  * scaleRatio : 0
+                rotation: dropdown.expanded ? 180  : 0
                 opacity: 1
             }
         }
@@ -146,14 +146,14 @@ Item {
         Rectangle {
             anchors.left: parent.left
             anchors.top: parent.top
-            width: 3 * scaleRatio; height: 3 * scaleRatio
+            width: 3; height: 3
             color: dropdown.pressedColor
         }
 
         Rectangle {
             anchors.right: parent.right
             anchors.top: parent.top
-            width: 3 * scaleRatio; height: 3 * scaleRatio
+            width: 3; height: 3
             color: dropdown.pressedColor
         }
 
@@ -186,7 +186,7 @@ Item {
                 delegate: Rectangle {
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    height: (dropdown.dropdownHeight * 0.75) * scaleRatio
+                    height: (dropdown.dropdownHeight * 0.75)
                     //radius: index === repeater.count - 1 ? 4 : 0
                     color: itemArea.containsMouse || index === columnid.currentIndex || itemArea.containsMouse ? dropdown.releasedColor : dropdown.pressedColor
 
@@ -195,7 +195,7 @@ Item {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
                         anchors.right: col2Text.left
-                        anchors.leftMargin: 12 * scaleRatio
+                        anchors.leftMargin: 12
                         anchors.rightMargin: 0
                         font.family: MoneroComponents.Style.fontRegular.name
                         font.bold: true
@@ -208,9 +208,9 @@ Item {
                         id: col2Text
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.right: parent.right
-                        anchors.rightMargin: 45 * scaleRatio
+                        anchors.rightMargin: 45
                         font.family: MoneroComponents.Style.fontRegular.name
-                        font.pixelSize: 14 * scaleRatio
+                        font.pixelSize: 14
                         color: "#FFFFFF"
                         text: ""
                     }
@@ -218,14 +218,14 @@ Item {
                     Rectangle {
                         anchors.left: parent.left
                         anchors.top: parent.top
-                        width: 3 * scaleRatio; height: 3 * scaleRatio
+                        width: 3; height: 3
                         color: parent.color
                     }
 
                     Rectangle {
                         anchors.right: parent.right
                         anchors.top: parent.top
-                        width: 3 * scaleRatio; height: 3 * scaleRatio
+                        width: 3; height: 3
                         color: parent.color
                     }
 

--- a/components/TextPlain.qml
+++ b/components/TextPlain.qml
@@ -14,7 +14,7 @@ Text {
     property string themeTransitionWhiteColor: ""
     font.family: MoneroComponents.Style.fontMedium.name
     font.bold: false
-    font.pixelSize: 14 * scaleRatio
+    font.pixelSize: 14
     textFormat: Text.PlainText
 
     MoneroEffects.ColorTransition {

--- a/components/TextPlainArea.qml
+++ b/components/TextPlainArea.qml
@@ -10,7 +10,7 @@ TextArea {
     property string colorBlackTheme: ""
     color: MoneroComponents.Style.defaultFontColor
     font.family: MoneroComponents.Style.fontRegular.name
-    font.pixelSize: 14 * scaleRatio
+    font.pixelSize: 14
     selectByMouse: false
     wrapMode: Text.WordWrap;
     textMargin: 0

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -46,7 +46,7 @@ Rectangle {
 
     height: {
         if(!persistentSettings.customDecorations || isMobile) return 0;
-        return 50 * scaleRatio;
+        return 50;
     }
 
     z: 1
@@ -132,7 +132,7 @@ Rectangle {
             Text {
                 text: FontAwesome.globe
                 font.family: FontAwesome.fontFamily
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 color: MoneroComponents.Style.defaultFontColor
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -158,7 +158,7 @@ Rectangle {
             Text {
                 text: MoneroComponents.Style.blackTheme ? FontAwesome.lightbulbO : FontAwesome.moonO
                 font.family: FontAwesome.fontFamily
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 color: MoneroComponents.Style.defaultFontColor
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter

--- a/components/WarningBox.qml
+++ b/components/WarningBox.qml
@@ -8,7 +8,7 @@ Rectangle {
     id: root
     property alias text: content.text
     property alias textColor: content.color
-    property int fontSize: 15 * scaleRatio
+    property int fontSize: 15
 
     Layout.fillWidth: true
     Layout.preferredHeight: warningLayout.height
@@ -28,12 +28,12 @@ Rectangle {
 
         Image {
             Layout.alignment: Qt.AlignVCenter
-            Layout.preferredHeight: 33 * scaleRatio
-            Layout.preferredWidth: 33 * scaleRatio
-            Layout.rightMargin: 12 * scaleRatio
-            Layout.leftMargin: 18 * scaleRatio
-            Layout.topMargin: 12 * scaleRatio
-            Layout.bottomMargin: 12 * scaleRatio
+            Layout.preferredHeight: 33
+            Layout.preferredWidth: 33
+            Layout.rightMargin: 12
+            Layout.leftMargin: 18
+            Layout.topMargin: 12
+            Layout.bottomMargin: 12
             source: "qrc:///images/warning.png"
         }
 
@@ -48,10 +48,10 @@ Rectangle {
             textFormat: Text.RichText
             wrapMode: Text.WordWrap
             textMargin: 0
-            leftPadding: 4 * scaleRatio
-            rightPadding: 18 * scaleRatio
-            topPadding: 10 * scaleRatio
-            bottomPadding: 10 * scaleRatio
+            leftPadding: 4
+            rightPadding: 18
+            topPadding: 10
+            bottomPadding: 10
             readOnly: true
             onLinkActivated: root.linkActivated();
 

--- a/main.cpp
+++ b/main.cpp
@@ -282,11 +282,6 @@ int main(int argc, char *argv[])
 
     engine.rootContext()->setContextProperty("screenWidth", geo.width());
     engine.rootContext()->setContextProperty("screenHeight", geo.height());
-#ifdef Q_OS_ANDROID
-    engine.rootContext()->setContextProperty("scaleRatio", calculated_ratio);
-#else
-    engine.rootContext()->setContextProperty("scaleRatio", 1);
-#endif
 
 #ifndef Q_OS_IOS
     const QString desktopFolder = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);

--- a/main.qml
+++ b/main.qml
@@ -1411,7 +1411,7 @@ ApplicationWindow {
             visible: isMobile
             anchors.left: parent.left
             anchors.right: parent.right
-            height: visible? 65 * scaleRatio : 0
+            height: visible? 65 : 0
 
             MouseArea {
                 enabled: persistentSettings.customDecorations
@@ -1769,7 +1769,7 @@ ApplicationWindow {
                 y: 6
                 lineHeight: 0.7
                 font.family: "Arial"
-                font.pixelSize: 12 * scaleRatio
+                font.pixelSize: 12
                 color: "#FFFFFF"
             }
         }
@@ -1866,15 +1866,15 @@ ApplicationWindow {
         visible: false
         property alias text: statusMessageText.text
         anchors.bottom: parent.bottom
-        width: statusMessageText.contentWidth + 20 * scaleRatio
+        width: statusMessageText.contentWidth + 20
         anchors.horizontalCenter: parent.horizontalCenter
         color: MoneroComponents.Style.blackTheme ? "black" : "white"
-        height: 40 * scaleRatio
+        height: 40
         MoneroComponents.TextPlain {
             id: statusMessageText
             anchors.fill: parent
-            anchors.margins: 10 * scaleRatio
-            font.pixelSize: 14 * scaleRatio
+            anchors.margins: 10
+            font.pixelSize: 14
             color: MoneroComponents.Style.defaultFontColor
             themeTransition: false
         }

--- a/pages/Account.qml
+++ b/pages/Account.qml
@@ -64,14 +64,14 @@ Rectangle {
     /* main layout */
     ColumnLayout {
         id: mainLayout
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
 
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
 
-        spacing: 20 * scaleRatio
+        spacing: 20
 
         ColumnLayout {
             id: balanceRow
@@ -85,7 +85,7 @@ Rectangle {
             }
 
             RowLayout {
-                Layout.topMargin: 22 * scaleRatio
+                Layout.topMargin: 22
 
                 MoneroComponents.TextPlain {
                     text: qsTr("Total balance: ") + translationManager.emptyString
@@ -118,7 +118,7 @@ Rectangle {
             }
 
             RowLayout {
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
 
                 MoneroComponents.TextPlain {
                     text: qsTr("Total unlocked balance: ") + translationManager.emptyString
@@ -164,8 +164,8 @@ Rectangle {
 
             ColumnLayout {
                 id: subaddressAccountListRow
-                property int subaddressAccountListItemHeight: 50 * scaleRatio
-                Layout.topMargin: 6 * scaleRatio
+                property int subaddressAccountListItemHeight: 50
+                Layout.topMargin: 6
                 Layout.fillWidth: true
                 Layout.minimumWidth: 240
                 Layout.preferredHeight: subaddressAccountListItemHeight * subaddressAccountListView.count
@@ -202,8 +202,8 @@ Rectangle {
 
                         Rectangle {
                             anchors.fill: parent
-                            anchors.topMargin: 5 * scaleRatio
-                            anchors.rightMargin: 80 * scaleRatio
+                            anchors.topMargin: 5
+                            anchors.rightMargin: 80
                             color: "transparent"
 
                             MoneroComponents.Label {
@@ -211,8 +211,8 @@ Rectangle {
                                 color: index === appWindow.current_subaddress_account_table_index ? MoneroComponents.Style.defaultFontColor : "#757575"
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: parent.left
-                                anchors.leftMargin: 6 * scaleRatio
-                                fontSize: 14 * scaleRatio
+                                anchors.leftMargin: 6
+                                fontSize: 14
                                 fontBold: true
                                 text: "#" + index
                                 themeTransition: false
@@ -223,8 +223,8 @@ Rectangle {
                                 color: MoneroComponents.Style.dimmedFontColor
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: idLabel.right
-                                anchors.leftMargin: 6 * scaleRatio
-                                fontSize: 14 * scaleRatio
+                                anchors.leftMargin: 6
+                                fontSize: 14
                                 fontBold: true
                                 text: label
                                 elide: Text.ElideRight
@@ -237,8 +237,8 @@ Rectangle {
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: balanceLabel.left
-                                anchors.leftMargin: (mainLayout.width < 510 ? -70 : -125) * scaleRatio
-                                fontSize: 14 * scaleRatio
+                                anchors.leftMargin: (mainLayout.width < 510 ? -70 : -125)
+                                fontSize: 14
                                 fontBold: true
                                 text: TxUtils.addressTruncate(address, mainLayout.width < 510 ? 3 : 6)
                                 themeTransition: false
@@ -249,8 +249,8 @@ Rectangle {
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: parent.right
-                                anchors.leftMargin: (mainLayout.width < 510 ? -120 : -180) * scaleRatio
-                                fontSize: 14 * scaleRatio
+                                anchors.leftMargin: (mainLayout.width < 510 ? -120 : -180)
+                                fontSize: 14
                                 fontBold: true
                                 text: qsTr("Balance: ") + balance
                                 elide: mainLayout.width < 510 ? Text.ElideRight : Text.ElideNone
@@ -339,10 +339,10 @@ Rectangle {
                 border: false
                 checkedIcon: "qrc:///images/plus-in-circle-medium-white.png" 
                 uncheckedIcon: "qrc:///images/plus-in-circle-medium-white.png" 
-                fontSize: 14 * scaleRatio 
+                fontSize: 14
                 iconOnTheLeft: true
                 Layout.fillWidth: true
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 text: qsTr("Create new account") + translationManager.emptyString; 
                 onClicked: { 
                     inputDialog.labelText = qsTr("Set the label of the new account:") + translationManager.emptyString

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -51,14 +51,14 @@ Rectangle {
 
     ColumnLayout {
         id: mainLayout
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
 
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
 
-        spacing: 20 * scaleRatio
+        spacing: 20
 
         ColumnLayout {
             id: addressBookEmptyLayout
@@ -71,7 +71,7 @@ Rectangle {
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.defaultFontColor
                 font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 32 * scaleRatio
+                font.pixelSize: 32
                 horizontalAlignment: TextInput.AlignLeft
                 selectByMouse: false
                 wrapMode: Text.WordWrap;
@@ -94,7 +94,7 @@ Rectangle {
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dimmedFontColor
                 font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 horizontalAlignment: TextInput.AlignLeft
                 selectByMouse: false
                 wrapMode: Text.WordWrap;
@@ -130,13 +130,13 @@ Rectangle {
 
             MoneroComponents.Label {
                 Layout.bottomMargin: 20
-                fontSize: 32 * scaleRatio
+                fontSize: 32
                 text: qsTr("Address book") + translationManager.emptyString
             }
 
             ColumnLayout {
                 id: addressBookListRow
-                property int addressBookListItemHeight: 50 * scaleRatio
+                property int addressBookListItemHeight: 50
                 Layout.fillWidth: true
                 Layout.minimumWidth: 240
                 Layout.preferredHeight: addressBookListItemHeight * addressBookListView.count
@@ -177,8 +177,8 @@ Rectangle {
 
                         Rectangle {
                             anchors.fill: parent
-                            anchors.topMargin: 5 * scaleRatio
-                            anchors.rightMargin: 110 * scaleRatio
+                            anchors.topMargin: 5
+                            anchors.rightMargin: 110
                             color: "transparent"
 
                             MoneroComponents.Label {
@@ -186,8 +186,8 @@ Rectangle {
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: parent.left
-                                anchors.leftMargin: 6 * scaleRatio
-                                fontSize: 16 * scaleRatio
+                                anchors.leftMargin: 6
+                                fontSize: 16
                                 text: description
                                 elide: Text.ElideRight
                                 textWidth: addressLabel.x - descriptionLabel.x - 1
@@ -198,9 +198,9 @@ Rectangle {
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: parent.right
-                                anchors.leftMargin: -addressLabel.width - 5  * scaleRatio
+                                anchors.leftMargin: -addressLabel.width - 5
 
-                                fontSize: 16 * scaleRatio
+                                fontSize: 16
                                 fontFamily: MoneroComponents.Style.fontMonoRegular.name;
                                 text: TxUtils.addressTruncatePretty(address, mainLayout.width < 540 ? 1 : (mainLayout.width < 700 ? 2 : 3));
                             }
@@ -285,10 +285,10 @@ Rectangle {
                 border: false
                 checkedIcon: "qrc:///images/plus-in-circle-medium-white.png"
                 uncheckedIcon: "qrc:///images/plus-in-circle-medium-white.png"
-                fontSize: 16 * scaleRatio
+                fontSize: 16
                 iconOnTheLeft: true
                 Layout.fillWidth: true
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 text: qsTr("Add address") + translationManager.emptyString;
                 onClicked: {
                     root.showAddAddress();
@@ -302,7 +302,7 @@ Rectangle {
             spacing: 0
 
             MoneroComponents.Label {
-                fontSize: 32 * scaleRatio
+                fontSize: 32
                 wrapMode: Text.WordWrap
                 text: (root.editEntry ? qsTr("Edit an address") : qsTr("Add an address")) + translationManager.emptyString
             }
@@ -424,7 +424,7 @@ Rectangle {
                 Text {
                     id: cancelButton
                     Layout.leftMargin: 20
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     font.bold: false
                     color: MoneroComponents.Style.defaultFontColor
                     text: qsTr("Cancel") + translationManager.emptyString
@@ -441,7 +441,7 @@ Rectangle {
                     id: deleteButton
                     visible: root.editEntry
                     Layout.leftMargin: 20
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     font.bold: false
                     color: MoneroComponents.Style.defaultFontColor
                     text: qsTr("Delete") + translationManager.emptyString

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -47,7 +47,7 @@ import "../js/TxUtils.js" as TxUtils
 Rectangle {
     id: root
     property var model
-    property int sideMargin: 50 * scaleRatio
+    property int sideMargin: 50
     property var initialized: false
     property int txMax: 5
     property int txOffset: 0
@@ -69,7 +69,7 @@ Rectangle {
 
     ColumnLayout {
         id: pageRoot
-        anchors.topMargin: 40 * scaleRatio
+        anchors.topMargin: 40
 
         anchors.left: parent.left
         anchors.top: parent.top
@@ -80,10 +80,10 @@ Rectangle {
             Layout.preferredWidth: parent.width - root.sideMargin
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
-            Layout.bottomMargin: 10 * scaleRatio
+            Layout.bottomMargin: 10
 
             MoneroComponents.Label {
-                fontSize: 24 * scaleRatio
+                fontSize: 24
                 text: qsTr("Transactions") + translationManager.emptyString
             }
 
@@ -97,12 +97,12 @@ Rectangle {
                 Layout.alignment: Qt.AlignRight | Qt.AlignBottom
                 Layout.preferredWidth: 100
                 Layout.preferredHeight: 15
-                spacing: 8 * scaleRatio
+                spacing: 8
 
                 MoneroComponents.TextPlain {
                     Layout.alignment: Qt.AlignVCenter
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 15 * scaleRatio
+                    font.pixelSize: 15
                     text: qsTr("Sort & filter") + translationManager.emptyString
                     color: MoneroComponents.Style.defaultFontColor
 
@@ -119,8 +119,8 @@ Rectangle {
                 MoneroEffects.ImageMask {
                     id: sortCollapsedIcon
                     Layout.alignment: Qt.AlignVCenter
-                    height: 8 * scaleRatio
-                    width: 12 * scaleRatio
+                    height: 8
+                    width: 12
                     image: "qrc:///images/whiteDropIndicator.png"
                     fontAwesomeFallbackIcon: FontAwesome.arrowDown
                     fontAwesomeFallbackSize: 14
@@ -141,7 +141,7 @@ Rectangle {
 
         ColumnLayout {
             Layout.fillWidth: true
-            Layout.topMargin: 8 * scaleRatio
+            Layout.topMargin: 8
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
             visible: sortAndFilter.collapsed
@@ -149,12 +149,12 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: searchInput
                 Layout.fillWidth: true
-                input.topPadding: 6 * scaleRatio
-                input.bottomPadding: 6 * scaleRatio
-                fontSize: 16 * scaleRatio
-                labelFontSize: 14 * scaleRatio
+                input.topPadding: 6
+                input.bottomPadding: 6
+                fontSize: 16
+                labelFontSize: 14
                 placeholderText: qsTr("Search...") + translationManager.emptyString
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 inputHeight: 34
                 onTextUpdated: {
                     if(searchInput.text != null && searchInput.text.length >= 3){
@@ -173,19 +173,19 @@ Rectangle {
         GridLayout {
             visible: sortAndFilter.collapsed
             Layout.fillWidth: true
-            Layout.topMargin: 4 * scaleRatio
+            Layout.topMargin: 4
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
             columns: 2
-            columnSpacing: 20 * scaleRatio
+            columnSpacing: 20
             z: 6
 
             MoneroComponents.DatePicker {
                 id: fromDatePicker
                 Layout.fillWidth: true
-                width: 100 * scaleRatio
+                width: 100
                 inputLabel.text: qsTr("Date from") + translationManager.emptyString
-                inputLabel.font.pixelSize: 14 * scaleRatio
+                inputLabel.font.pixelSize: 14
                 onCurrentDateChanged: {
                     if(root.initialized){
                         root.reset();
@@ -197,7 +197,7 @@ Rectangle {
             MoneroComponents.DatePicker {
                 id: toDatePicker
                 Layout.fillWidth: true
-                width: 100 * scaleRatio
+                width: 100
                 inputLabel.text: qsTr("Date to") + translationManager.emptyString
 
                 onCurrentDateChanged: {
@@ -210,8 +210,8 @@ Rectangle {
         }
 
         RowLayout {
-            Layout.topMargin: 20 * scaleRatio
-            Layout.bottomMargin: 20 * scaleRatio
+            Layout.topMargin: 20
+            Layout.bottomMargin: 20
             Layout.fillWidth: true
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
@@ -219,12 +219,12 @@ Rectangle {
             Rectangle {
                 visible: sortAndFilter.collapsed
                 color: "transparent"
-                Layout.preferredWidth: childrenRect.width + 38 * scaleRatio
+                Layout.preferredWidth: childrenRect.width + 38
                 Layout.preferredHeight: 20
 
                 MoneroComponents.TextPlain {
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 15 * scaleRatio
+                    font.pixelSize: 15
                     text: qsTr("Sort by") + ":"
                     color: MoneroComponents.Style.defaultFontColor
                     anchors.verticalCenter: parent.verticalCenter
@@ -235,7 +235,7 @@ Rectangle {
                 visible: sortAndFilter.collapsed
                 id: sortBlockheight
                 color: "transparent"
-                Layout.preferredWidth: sortBlockheightText.width + 42 * scaleRatio
+                Layout.preferredWidth: sortBlockheightText.width + 42
                 Layout.preferredHeight: 20
 
                 RowLayout {
@@ -245,7 +245,7 @@ Rectangle {
                     MoneroComponents.TextPlain {
                         id: sortBlockheightText
                         font.family: MoneroComponents.Style.fontRegular.name
-                        font.pixelSize: 15 * scaleRatio
+                        font.pixelSize: 15
                         text: qsTr("Blockheight") + translationManager.emptyString
                         color: root.sortBy === "blockheight" ? MoneroComponents.Style.defaultFontColor : MoneroComponents.Style.dimmedFontColor
                         anchors.verticalCenter: parent.verticalCenter
@@ -253,8 +253,8 @@ Rectangle {
                     }
 
                     MoneroEffects.ImageMask {
-                        height: 8 * scaleRatio
-                        width: 12 * scaleRatio
+                        height: 8
+                        width: 12
                         visible: root.sortBy === "blockheight" ? true : false
                         opacity: root.sortBy === "blockheight" ? 1 : 0.2
                         image: "qrc:///images/whiteDropIndicator.png"
@@ -295,7 +295,7 @@ Rectangle {
             Rectangle {
                 visible: sortAndFilter.collapsed
                 color: "transparent"
-                Layout.preferredWidth: sortDateText.width + 42 * scaleRatio
+                Layout.preferredWidth: sortDateText.width + 42
                 Layout.preferredHeight: 20
 
                 RowLayout {
@@ -305,7 +305,7 @@ Rectangle {
                     MoneroComponents.TextPlain {
                         id: sortDateText
                         font.family: MoneroComponents.Style.fontRegular.name
-                        font.pixelSize: 15 * scaleRatio
+                        font.pixelSize: 15
                         text: qsTr("Date") + translationManager.emptyString
                         color: root.sortBy === "timestamp" ? MoneroComponents.Style.defaultFontColor : MoneroComponents.Style.dimmedFontColor
                         themeTransition: false
@@ -313,8 +313,8 @@ Rectangle {
                     }
 
                     MoneroEffects.ImageMask {
-                        height: 8 * scaleRatio
-                        width: 12 * scaleRatio
+                        height: 8
+                        width: 12
                         visible: root.sortBy === "timestamp" ? true : false
                         opacity: root.sortBy === "timestamp" ? 1 : 0.2
                         image: "qrc:///images/whiteDropIndicator.png"
@@ -355,7 +355,7 @@ Rectangle {
             Rectangle {
                 visible: sortAndFilter.collapsed
                 color: "transparent"
-                Layout.preferredWidth: sortAmountText.width + 42 * scaleRatio
+                Layout.preferredWidth: sortAmountText.width + 42
                 Layout.preferredHeight: 20
 
                 RowLayout {
@@ -365,7 +365,7 @@ Rectangle {
                     MoneroComponents.TextPlain {
                         id: sortAmountText
                         font.family: MoneroComponents.Style.fontRegular.name
-                        font.pixelSize: 15 * scaleRatio
+                        font.pixelSize: 15
                         text: qsTr("Amount") + translationManager.emptyString
                         color: root.sortBy === "amount" ? MoneroComponents.Style.defaultFontColor : MoneroComponents.Style.dimmedFontColor
                         themeTransition: false
@@ -373,8 +373,8 @@ Rectangle {
                     }
 
                     MoneroEffects.ImageMask {
-                        height: 8 * scaleRatio
-                        width: 12 * scaleRatio
+                        height: 8
+                        width: 12
                         visible: root.sortBy === "amount" ? true : false
                         opacity: root.sortBy === "amount" ? 1 : 0.2
                         image: "qrc:///images/whiteDropIndicator.png"
@@ -419,7 +419,7 @@ Rectangle {
                 MoneroComponents.TextPlain {
                     // status message
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 15 * scaleRatio
+                    font.pixelSize: 15
                     text: root.historyStatusMessage
 
                     color: MoneroComponents.Style.defaultFontColor
@@ -440,12 +440,12 @@ Rectangle {
 
                 Rectangle {
                     color: "transparent"
-                    Layout.preferredWidth: childrenRect.width + 2 * scaleRatio
+                    Layout.preferredWidth: childrenRect.width + 2
                     Layout.preferredHeight: 20
 
                     MoneroComponents.TextPlain {
                         font.family: MoneroComponents.Style.fontRegular.name
-                        font.pixelSize: 15 * scaleRatio
+                        font.pixelSize: 15
                         text: qsTr("Page") + ":"
                         color: MoneroComponents.Style.defaultFontColor
                         anchors.verticalCenter: parent.verticalCenter
@@ -454,9 +454,9 @@ Rectangle {
 
                 Rectangle {
                     color: "transparent"
-                    Layout.preferredWidth: childrenRect.width + 10 * scaleRatio
-                    Layout.leftMargin: 4 * scaleRatio
-                    Layout.preferredHeight: 20 * scaleRatio
+                    Layout.preferredWidth: childrenRect.width + 10
+                    Layout.leftMargin: 4
+                    Layout.preferredHeight: 20
 
                     MoneroComponents.TextPlain {
                         id: paginationText
@@ -496,8 +496,8 @@ Rectangle {
 
                 Rectangle {
                     id: paginationPrev
-                    Layout.preferredWidth: 18 * scaleRatio
-                    Layout.preferredHeight: 20 * scaleRatio
+                    Layout.preferredWidth: 18
+                    Layout.preferredHeight: 20
                     color: "transparent"
                     opacity: enabled ? 1.0 : 0.2
                     enabled: false
@@ -506,8 +506,8 @@ Rectangle {
                         id: prevIcon
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
-                        height: 8 * scaleRatio
-                        width: 12 * scaleRatio
+                        height: 8
+                        width: 12
                         image: "qrc:///images/whiteDropIndicator.png"
                         fontAwesomeFallbackIcon: FontAwesome.arrowDown
                         fontAwesomeFallbackSize: 14
@@ -528,8 +528,8 @@ Rectangle {
 
                 Rectangle {
                     id: paginationNext
-                    Layout.preferredWidth: 18 * scaleRatio
-                    Layout.preferredHeight: 20 * scaleRatio
+                    Layout.preferredWidth: 18
+                    Layout.preferredHeight: 20
                     color: "transparent"
                     opacity: enabled ? 1.0 : 0.2
                     enabled: false
@@ -538,8 +538,8 @@ Rectangle {
                         id: nextIcon
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.right: parent.right
-                        height: 8 * scaleRatio
-                        width: 12 * scaleRatio
+                        height: 8
+                        width: 12
                         image: "qrc:///images/whiteDropIndicator.png"
                         fontAwesomeFallbackIcon: FontAwesome.arrowDown
                         fontAwesomeFallbackSize: 14
@@ -591,11 +591,11 @@ Rectangle {
 
                     Rectangle {
                         anchors.top: parent.top
-                        anchors.topMargin: 24 * scaleRatio
+                        anchors.topMargin: 24
                         anchors.horizontalCenter: parent.horizontalCenter
-                        width: 10 * scaleRatio
-                        height: 10 * scaleRatio
-                        radius: 8 * scaleRatio
+                        width: 10
+                        height: 10
+                        radius: 8
                         color: isout ? "#d85a00" : "#2eb358"
                     }
                 }
@@ -633,7 +633,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: isout ? qsTr("Sent") : qsTr("Received") + translationManager.emptyString
                                     color: MoneroComponents.Style.historyHeaderTextColor
                                     anchors.verticalCenter: parent.verticalCenter
@@ -649,7 +649,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: _amount + " XMR"
                                     color: MoneroComponents.Style.defaultFontColor
                                     anchors.verticalCenter: parent.verticalCenter
@@ -683,7 +683,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: isout ? qsTr("Fee") : confirmationsRequired === 60 ? qsTr("Mined") : qsTr("Fee") + translationManager.emptyString
                                     color: MoneroComponents.Style.historyHeaderTextColor
                                     themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -699,7 +699,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: {
                                         if(!isout && confirmationsRequired === 60) return qsTr("Yes") + translationManager.emptyString;
                                         if(fee !== "") return fee + " XMR";
@@ -744,7 +744,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: qsTr("Blockheight") + translationManager.emptyString
                                     color: MoneroComponents.Style.historyHeaderTextColor
                                     themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -760,7 +760,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 14 * scaleRatio
+                                    font.pixelSize: 14
                                     text: blockheight > 0 ? blockheight : qsTr('Pending') + translationManager.emptyString;
 
                                     color: MoneroComponents.Style.defaultFontColor
@@ -795,7 +795,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: qsTr("Confirmations") + translationManager.emptyString
                                     color: MoneroComponents.Style.historyHeaderTextColor
                                     themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -812,7 +812,7 @@ Rectangle {
                                 MoneroComponents.TextPlain {
                                     property bool confirmed: confirmations < confirmationsRequired ? false : true
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: confirmed ? confirmations : confirmations + "/" + confirmationsRequired
                                     color: MoneroComponents.Style.defaultFontColor
                                     anchors.verticalCenter: parent.verticalCenter
@@ -852,7 +852,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: qsTr("Date")
                                     color: MoneroComponents.Style.historyHeaderTextColor
                                     themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -868,7 +868,7 @@ Rectangle {
 
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
-                                    font.pixelSize: 15 * scaleRatio
+                                    font.pixelSize: 15
                                     text: persistentSettings.historyHumanDates ? dateHuman : date + "  " + time
 
                                     color: MoneroComponents.Style.defaultFontColor
@@ -909,8 +909,8 @@ Rectangle {
                                     text: FontAwesome.info
                                     small: true
                                     label.font.family: FontAwesome.fontFamily
-                                    fontSize: 18 * scaleRatio
-                                    width: 28 * scaleRatio
+                                    fontSize: 18
+                                    width: 28
 
                                     MouseArea {
                                         state: "details"
@@ -926,7 +926,7 @@ Rectangle {
                                 Image {
                                     visible: !isout && confirmationsRequired === 60
                                     anchors.left: btnDetails.right
-                                    anchors.leftMargin: 16 * scaleRatio
+                                    anchors.leftMargin: 16
                                     width: 28
                                     height: 28
                                     source: "qrc:///images/miningxmr.png"
@@ -935,12 +935,12 @@ Rectangle {
                                 MoneroComponents.StandardButton {
                                     visible: isout
                                     anchors.left: btnDetails.right
-                                    anchors.leftMargin: 10 * scaleRatio
+                                    anchors.leftMargin: 10
                                     text: FontAwesome.productHunt
                                     small: true
                                     label.font.family: FontAwesome.fontFamily
-                                    fontSize: 18 * scaleRatio
-                                    width: 36 * scaleRatio
+                                    fontSize: 18
+                                    width: 36
 
                                     MouseArea {
                                         state: "proof"
@@ -968,7 +968,7 @@ Rectangle {
 
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: qsTr("Description") + translationManager.emptyString
                                 color: MoneroComponents.Style.historyHeaderTextColor
                                 themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -985,7 +985,7 @@ Rectangle {
                             MoneroComponents.TextPlain {
                                 id: txNoteText
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: tx_note !== "" ? tx_note : "-"
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
@@ -1002,7 +1002,7 @@ Rectangle {
                             MoneroEffects.ImageMask {
                                 anchors.top: parent.top
                                 anchors.left: txNoteText.right
-                                anchors.leftMargin: 12 * scaleRatio
+                                anchors.leftMargin: 12
                                 image: "qrc:///images/edit.svg"
                                 fontAwesomeFallbackIcon: FontAwesome.pencilSquare
                                 fontAwesomeFallbackSize: 22
@@ -1036,7 +1036,7 @@ Rectangle {
 
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: qsTr("Transaction ID") + translationManager.emptyString
                                 color: MoneroComponents.Style.historyHeaderTextColor
                                 themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -1052,7 +1052,7 @@ Rectangle {
 
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: hash
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
@@ -1080,7 +1080,7 @@ Rectangle {
 
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: qsTr("Transaction key") + translationManager.emptyString
                                 color: MoneroComponents.Style.historyHeaderTextColor
                                 themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -1096,7 +1096,7 @@ Rectangle {
 
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: {
                                     var txKey = currentWallet.getTxKey(hash)
                                     if(txKey) return txKey;
@@ -1130,7 +1130,7 @@ Rectangle {
 
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: qsTr("Address sent to") + translationManager.emptyString
                                 color: MoneroComponents.Style.historyHeaderTextColor
                                 themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor
@@ -1147,7 +1147,7 @@ Rectangle {
 
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
-                                font.pixelSize: 15 * scaleRatio
+                                font.pixelSize: 15
                                 text: {
                                     if(isout && address !== ""){
                                         return TxUtils.addressTruncate(address, 24);
@@ -1230,10 +1230,10 @@ Rectangle {
                     MoneroEffects.ImageMask {
                         id: collapsedIcon
                         anchors.top: parent.top
-                        anchors.topMargin: 24 * scaleRatio
+                        anchors.topMargin: 24
                         anchors.horizontalCenter: parent.horizontalCenter
-                        height: 8 * scaleRatio
-                        width: 12 * scaleRatio
+                        height: 8
+                        width: 12
                         image: "qrc:///images/whiteDropIndicator.png"
                         rotation: delegate.collapsed ? 180 : 0
                         color: MoneroComponents.Style.defaultFontColor
@@ -1272,8 +1272,8 @@ Rectangle {
 
         Item {
             visible: sortAndFilter.collapsed
-            Layout.topMargin: 10 * scaleRatio
-            Layout.bottomMargin: 10 * scaleRatio
+            Layout.topMargin: 10
+            Layout.bottomMargin: 10
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
 
@@ -1282,7 +1282,7 @@ Rectangle {
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignHCenter
                 font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 15 * scaleRatio
+                font.pixelSize: 15
                 text: root.historyStatusMessage;
                 color: MoneroComponents.Style.dimmedFontColor
                 themeTransitionBlackColor: MoneroComponents.Style._b_dimmedFontColor
@@ -1292,8 +1292,8 @@ Rectangle {
 
         MoneroComponents.CheckBox2 {
             id: showAdvancedCheckbox
-            Layout.topMargin: 30 * scaleRatio
-            Layout.bottomMargin: 20 * scaleRatio
+            Layout.topMargin: 30
+            Layout.bottomMargin: 20
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
             checked: persistentSettings.historyShowAdvanced
@@ -1305,7 +1305,7 @@ Rectangle {
             visible: persistentSettings.historyShowAdvanced
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             MoneroComponents.CheckBox {
                 id: humanDatesCheckBox

--- a/pages/Keys.qml
+++ b/pages/Keys.qml
@@ -40,7 +40,7 @@ import "." 1.0
 Rectangle {
     id: page
     property bool viewOnly: false
-    property int keysHeight: mainLayout.height + 100 * scaleRatio // Ensure sufficient height for QR code, even in minimum width window case.
+    property int keysHeight: mainLayout.height + 100 // Ensure sufficient height for QR code, even in minimum width window case.
 
     color: "transparent"
 
@@ -52,10 +52,10 @@ Rectangle {
         anchors.top: parent.top
         anchors.right: parent.right
 
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
 
-        spacing: 30 * scaleRatio
+        spacing: 30
         Layout.fillWidth: true
 
         MoneroComponents.WarningBox {
@@ -68,17 +68,17 @@ Rectangle {
 
             MoneroComponents.Label {
                 Layout.fillWidth: true
-                fontSize: 22 * scaleRatio
-                Layout.topMargin: 10 * scaleRatio
+                fontSize: 22
+                Layout.topMargin: 10
                 text: qsTr("Mnemonic seed") + translationManager.emptyString
             }
 
             Rectangle {
                 Layout.fillWidth: true
-                height: 2 * scaleRatio
+                height: 2
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
-                Layout.bottomMargin: 10 * scaleRatio
+                Layout.bottomMargin: 10
             }
 
             MoneroComponents.WarningBox {
@@ -101,8 +101,8 @@ Rectangle {
 
             MoneroComponents.Label {
                 Layout.fillWidth: true
-                fontSize: 22 * scaleRatio
-                Layout.topMargin: 10 * scaleRatio
+                fontSize: 22
+                Layout.topMargin: 10
                 text: qsTr("Keys") + translationManager.emptyString
             }
             Rectangle {
@@ -110,7 +110,7 @@ Rectangle {
                 height: 2
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
-                Layout.bottomMargin: 10 * scaleRatio
+                Layout.bottomMargin: 10
             }
             MoneroComponents.LineEdit {
                 Layout.fillWidth: true
@@ -118,34 +118,34 @@ Rectangle {
                 readOnly: true
                 copyButton: true
                 labelText: qsTr("Secret view key") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
+                fontSize: 16
             }
             MoneroComponents.LineEdit {
                 Layout.fillWidth: true
-                Layout.topMargin: 25 * scaleRatio
+                Layout.topMargin: 25
                 id: publicViewKey
                 readOnly: true
                 copyButton: true
                 labelText: qsTr("Public view key") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
+                fontSize: 16
             }
             MoneroComponents.LineEdit {
                 Layout.fillWidth: true
-                Layout.topMargin: 25 * scaleRatio
+                Layout.topMargin: 25
                 id: secretSpendKey
                 readOnly: true
                 copyButton: true
                 labelText: qsTr("Secret spend key") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
+                fontSize: 16
             }
             MoneroComponents.LineEdit {
                 Layout.fillWidth: true
-                Layout.topMargin: 25 * scaleRatio
+                Layout.topMargin: 25
                 id: publicSpendKey
                 readOnly: true
                 copyButton: true
                 labelText: qsTr("Public spend key") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
+                fontSize: 16
             }
         }
 
@@ -154,8 +154,8 @@ Rectangle {
 
             MoneroComponents.Label {
                 Layout.fillWidth: true
-                fontSize: 22 * scaleRatio
-                Layout.topMargin: 10 * scaleRatio
+                fontSize: 22
+                Layout.topMargin: 10
                 text: qsTr("Export wallet") + translationManager.emptyString
             }
             Rectangle {
@@ -163,7 +163,7 @@ Rectangle {
                 height: 2
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
-                Layout.bottomMargin: 10 * scaleRatio
+                Layout.bottomMargin: 10
             }
 
             ColumnLayout {
@@ -187,14 +187,14 @@ Rectangle {
                         showFullQr.checked = false
                     }
                 }
-                Layout.bottomMargin: 30 * scaleRatio
+                Layout.bottomMargin: 30
             }
 
             Image {
                 visible: !viewOnlyQRCode.visible
                 id: fullWalletQRCode
                 Layout.fillWidth: true
-                Layout.minimumHeight: 180 * scaleRatio
+                Layout.minimumHeight: 180
                 smooth: false
                 fillMode: Image.PreserveAspectFit
             }
@@ -203,7 +203,7 @@ Rectangle {
                 visible: false
                 id: viewOnlyQRCode
                 Layout.fillWidth: true
-                Layout.minimumHeight: 180 * scaleRatio
+                Layout.minimumHeight: 180
                 smooth: false
                 fillMode: Image.PreserveAspectFit
             }
@@ -211,7 +211,7 @@ Rectangle {
             MoneroComponents.TextPlain {
                 Layout.fillWidth: true
                 font.bold: true
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
                 color: MoneroComponents.Style.defaultFontColor
                 text: (viewOnlyQRCode.visible) ? qsTr("View Only Wallet") + translationManager.emptyString : qsTr("Spendable Wallet") + translationManager.emptyString
                 horizontalAlignment: Text.AlignHCenter

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -40,27 +40,27 @@ Rectangle {
     ColumnLayout {
         id: mainLayout
         Layout.fillWidth: true
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
-        spacing: 20 * scaleRatio
+        spacing: 20
 
         MoneroComponents.Label {
             id: soloTitleLabel
-            fontSize: 24 * scaleRatio
+            fontSize: 24
             text: qsTr("Solo mining") + translationManager.emptyString
         }
 
         MoneroComponents.WarningBox {
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.bottomMargin: 8
             text: qsTr("Mining is only available on local daemons.") + translationManager.emptyString
             visible: !walletManager.isDaemonLocal(appWindow.currentDaemonAddress)
         }
 
         MoneroComponents.WarningBox {
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.bottomMargin: 8
             text: qsTr("Your daemon must be synchronized before you can start mining") + translationManager.emptyString
             visible: walletManager.isDaemonLocal(appWindow.currentDaemonAddress) && !appWindow.daemonSynced
         }
@@ -71,22 +71,22 @@ Rectangle {
             wrapMode: Text.Wrap
             Layout.fillWidth: true
             font.family: MoneroComponents.Style.fontRegular.name
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             color: MoneroComponents.Style.defaultFontColor
         }
 
         MoneroComponents.WarningBox {
             id: warningLabel
-            Layout.topMargin: 8 * scaleRatio
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.topMargin: 8
+            Layout.bottomMargin: 8
             text: qsTr("Mining may reduce the performance of other running applications and processes.") + translationManager.emptyString
         }
 
         GridLayout {
             columns: 2
             Layout.fillWidth: true
-            columnSpacing: 20 * scaleRatio
-            rowSpacing: 16 * scaleRatio
+            columnSpacing: 20
+            rowSpacing: 16
 
             ColumnLayout {
                 Layout.fillWidth: true
@@ -96,18 +96,18 @@ Rectangle {
                     id: soloMinerThreadsLabel
                     color: MoneroComponents.Style.defaultFontColor
                     text: qsTr("CPU threads") + translationManager.emptyString
-                    fontSize: 16 * scaleRatio
+                    fontSize: 16
                     wrapMode: Text.WordWrap
                 }
             }
 
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 16 * scaleRatio
+                spacing: 16
 
                 MoneroComponents.LineEdit {
                     id: soloMinerThreadsLine
-                    Layout.minimumWidth: 200 * scaleRatio
+                    Layout.minimumWidth: 200
                     text: "1"
                     validator: IntValidator { bottom: 1; top: idealThreadCount }
                 }
@@ -117,7 +117,7 @@ Rectangle {
                     text: qsTr("Max # of CPU threads available for mining: ") + idealThreadCount + translationManager.emptyString
                     wrapMode: Text.WordWrap
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                     color: MoneroComponents.Style.defaultFontColor
                 }
 
@@ -175,7 +175,7 @@ Rectangle {
                     id: manageSoloMinerLabel
                     color: MoneroComponents.Style.defaultFontColor
                     text: qsTr("Manage miner") + translationManager.emptyString
-                    fontSize: 16 * scaleRatio
+                    fontSize: 16
                     wrapMode: Text.Wrap
                     Layout.preferredWidth: manageSoloMinerLabel.textWidth
                 }
@@ -183,7 +183,7 @@ Rectangle {
 
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 16 * scaleRatio
+                spacing: 16
 
                 RowLayout {
                     MoneroComponents.StandardButton {
@@ -227,17 +227,17 @@ Rectangle {
                     id: statusLabel
                     color: MoneroComponents.Style.defaultFontColor
                     text: qsTr("Status") + translationManager.emptyString
-                    fontSize: 16 * scaleRatio
+                    fontSize: 16
                 }
             }
 
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: 16 * scaleRatio
+                spacing: 16
 
                 MoneroComponents.LineEditMulti {
                     id: statusText
-                    Layout.minimumWidth: 300 * scaleRatio
+                    Layout.minimumWidth: 300
                     text: qsTr("Not mining") + translationManager.emptyString
                     borderDisabled: true
                     readOnly: true

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -65,18 +65,18 @@ Rectangle {
     /* main layout */
     ColumnLayout {
         id: mainLayout
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
 
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
 
-        spacing: 20 * scaleRatio
-        property int labelWidth: 120 * scaleRatio
-        property int editWidth: 400 * scaleRatio
-        property int lineEditFontSize: 12 * scaleRatio
-        property int qrCodeSize: 220 * scaleRatio
+        spacing: 20
+        property int labelWidth: 120
+        property int editWidth: 400
+        property int lineEditFontSize: 12
+        property int qrCodeSize: 220
 
         ColumnLayout {
             id: addressRow
@@ -90,8 +90,8 @@ Rectangle {
 
             ColumnLayout {
                 id: subaddressListRow
-                property int subaddressListItemHeight: 50 * scaleRatio
-                Layout.topMargin: 6 * scaleRatio
+                property int subaddressListItemHeight: 50
+                Layout.topMargin: 6
                 Layout.fillWidth: true
                 Layout.minimumWidth: 240
                 Layout.preferredHeight: subaddressListItemHeight * subaddressListView.count
@@ -136,8 +136,8 @@ Rectangle {
                                 color: index === appWindow.current_subaddress_table_index ? MoneroComponents.Style.defaultFontColor : "#757575"
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: parent.left
-                                anchors.leftMargin: 6 * scaleRatio
-                                fontSize: 14 * scaleRatio
+                                anchors.leftMargin: 6
+                                fontSize: 14
                                 fontBold: true
                                 text: "#" + index
                                 themeTransition: false
@@ -148,8 +148,8 @@ Rectangle {
                                 color: MoneroComponents.Style.dimmedFontColor
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: idLabel.right
-                                anchors.leftMargin: 6 * scaleRatio
-                                fontSize: 14 * scaleRatio
+                                anchors.leftMargin: 6
+                                fontSize: 14
                                 fontBold: true
                                 text: label
                                 elide: Text.ElideRight
@@ -162,8 +162,8 @@ Rectangle {
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
                                 anchors.left: parent.right
-                                anchors.leftMargin: (mainLayout.width < 510 ? -130 : -190) * scaleRatio
-                                fontSize: 14 * scaleRatio
+                                anchors.leftMargin: (mainLayout.width < 510 ? -130 : -190)
+                                fontSize: 14
                                 fontBold: true
                                 text: TxUtils.addressTruncate(address, mainLayout.width < 510 ? 6 : 10)
                                 themeTransition: false
@@ -186,8 +186,8 @@ Rectangle {
                             opacity: 0.5
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.right: parent.right
-                            anchors.rightMargin: 30 * scaleRatio
-                            anchors.topMargin: 1 * scaleRatio
+                            anchors.rightMargin: 30
+                            anchors.topMargin: 1
                             width: 23
                             height: 21
                             visible: index !== 0
@@ -242,10 +242,10 @@ Rectangle {
                 border: false
                 checkedIcon: "qrc:///images/plus-in-circle-medium-white.png"
                 uncheckedIcon: "qrc:///images/plus-in-circle-medium-white.png"
-                fontSize: 14 * scaleRatio
+                fontSize: 14
                 iconOnTheLeft: true
                 Layout.fillWidth: true
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 text: qsTr("Create new address") + translationManager.emptyString;
                 onClicked: {
                     inputDialog.labelText = qsTr("Set the label of the new address:") + translationManager.emptyString
@@ -262,8 +262,8 @@ Rectangle {
 
         ColumnLayout {
             Layout.alignment: Qt.AlignHCenter
-            spacing: 11 * scaleRatio
-            property int qrSize: 220 * scaleRatio
+            spacing: 11
+            property int qrSize: 220
 
             Rectangle {
                 id: qrContainer
@@ -271,12 +271,12 @@ Rectangle {
                 Layout.fillWidth: true
                 Layout.maximumWidth: parent.qrSize
                 Layout.preferredHeight: width
-                radius: 4 * scaleRatio
+                radius: 4
 
                 Image {
                     id: qrCode
                     anchors.fill: parent
-                    anchors.margins: 1 * scaleRatio
+                    anchors.margins: 1
 
                     smooth: false
                     fillMode: Image.PreserveAspectFit

--- a/pages/SharedRingDB.qml
+++ b/pages/SharedRingDB.qml
@@ -80,14 +80,14 @@ Rectangle {
     ColumnLayout {
         id: mainLayout
         Layout.fillWidth: true
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
   
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
 
-        spacing: 20 * scaleRatio
+        spacing: 20
 
         MessageDialog {
             id: sharedRingDBDialog
@@ -96,7 +96,7 @@ Rectangle {
 
         MoneroComponents.Label {
             id: signTitleLabel
-            fontSize: 24 * scaleRatio
+            fontSize: 24
             text: qsTr("Shared RingDB") + translationManager.emptyString
         }
 
@@ -106,7 +106,7 @@ Rectangle {
             wrapMode: Text.Wrap
             Layout.fillWidth: true
             font.family: MoneroComponents.Style.fontRegular.name
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             color: MoneroComponents.Style.defaultFontColor
         }
 
@@ -137,7 +137,7 @@ Rectangle {
         MoneroComponents.TextPlain {
             textFormat: Text.RichText
             font.family: MoneroComponents.Style.fontRegular.name
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             text: qsTr("This sets which outputs are known to be spent, and thus not to be used as privacy placeholders in ring signatures. ") +
                   qsTr("You should only have to load a file when you want to refresh the list. Manual adding/removing is possible if needed.") + translationManager.emptyString
             wrapMode: Text.Wrap
@@ -163,10 +163,10 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: loadBlackballFileLine
                 Layout.fillWidth: true
-                fontSize: 16 * scaleRatio
-                placeholderFontSize: 16 * scaleRatio
+                fontSize: 16
+                placeholderFontSize: 16
                 placeholderText: qsTr("Path to file") + "..." + translationManager.emptyString
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Filename with outputs to mark as spent") + ":" + translationManager.emptyString
                 copyButton: true
                 readOnly: false
@@ -198,15 +198,15 @@ Rectangle {
 
         GridLayout {
             Layout.fillWidth: true
-            columnSpacing: 20 * scaleRatio
+            columnSpacing: 20
 
             MoneroComponents.LineEdit {
                 id: blackballOutputAmountLine
                 Layout.fillWidth: true
-                fontSize: 16 * scaleRatio
-                labelFontSize: 14 * scaleRatio
+                fontSize: 16
+                labelFontSize: 14
                 labelText: qsTr("Or manually mark a single output as spent/unspent:") + translationManager.emptyString
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Paste output amount") + "..." + translationManager.emptyString
                 readOnly: false
                 validator: IntValidator { bottom: 0 }
@@ -215,10 +215,10 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: blackballOutputOffsetLine
                 Layout.fillWidth: true
-                fontSize: 16 * scaleRatio
-                labelFontSize: 14 * scaleRatio
+                fontSize: 16
+                labelFontSize: 14
                 labelText: " "
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Paste output offset") + "..." + translationManager.emptyString
                 readOnly: false
                 validator: IntValidator { bottom: 0 }
@@ -248,7 +248,7 @@ Rectangle {
 
         MoneroComponents.LabelSubheader {
             Layout.fillWidth: true
-            Layout.topMargin: 24 * scaleRatio
+            Layout.topMargin: 24
             textFormat: Text.RichText
             text: "<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 14px;}</style>" +
                   qsTr("Rings") + " <a href='#'>" + qsTr("Help") + "</a>" + translationManager.emptyString
@@ -275,7 +275,7 @@ Rectangle {
         MoneroComponents.TextPlain {
             textFormat: Text.RichText
             font.family: MoneroComponents.Style.fontRegular.name
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             text: qsTr("This records rings used by outputs spent on Monero on a key reusing chain, so that the same ring may be reused to avoid privacy issues.") + translationManager.emptyString
             wrapMode: Text.Wrap
             Layout.fillWidth: true;
@@ -285,27 +285,27 @@ Rectangle {
         MoneroComponents.LineEdit {
             id: keyImageLine
             Layout.fillWidth: true
-            fontSize: 16 * scaleRatio
-            labelFontSize: 14 * scaleRatio
+            fontSize: 16
+            labelFontSize: 14
             labelText: qsTr("Key image") + ":" + translationManager.emptyString
-            placeholderFontSize: 16 * scaleRatio
+            placeholderFontSize: 16
             placeholderText: qsTr("Paste key image") + "..." + translationManager.emptyString
             readOnly: false
             copyButton: true
         }
 
         GridLayout{
-            Layout.topMargin: 12 * scaleRatio
+            Layout.topMargin: 12
             columns: (isMobile) ?  1 : 2
-            columnSpacing: 32 * scaleRatio
+            columnSpacing: 32
 
             ColumnLayout {
                 RowLayout {
                     MoneroComponents.LineEdit {
                         id: getRingLine
                         Layout.fillWidth: true
-                        fontSize: 16 * scaleRatio
-                        labelFontSize: 14 * scaleRatio
+                        fontSize: 16
+                        labelFontSize: 14
                         labelText: qsTr("Get ring") + ":" + translationManager.emptyString
                         readOnly: true
                         copyButton: true
@@ -339,9 +339,9 @@ Rectangle {
                     MoneroComponents.LineEdit {
                         id: setRingLine
                         Layout.fillWidth: true
-                        fontSize: 16 * scaleRatio
-                        labelFontSize: 14 * scaleRatio
-                        placeholderFontSize: 16 * scaleRatio
+                        fontSize: 16
+                        labelFontSize: 14
+                        placeholderFontSize: 16
                         labelText: qsTr("Set ring") + ":" + translationManager.emptyString
                         readOnly: false
                         copyButton: true
@@ -367,7 +367,7 @@ Rectangle {
         }
 
         GridLayout {
-            columnSpacing: 20 * scaleRatio
+            columnSpacing: 20
             columns: (isMobile) ?  1 : 2
 
             MoneroComponents.CheckBox {
@@ -404,17 +404,17 @@ Rectangle {
         GridLayout {
             id: segregationHeightRow
             Layout.fillWidth: true
-            Layout.topMargin: 17 * scaleRatio
+            Layout.topMargin: 17
             columns: (isMobile) ?  1 : 2
-            columnSpacing: 32 * scaleRatio
+            columnSpacing: 32
 
             MoneroComponents.LineEdit {
                 id: segregationHeightLine
                 property bool edited: false
                 Layout.fillWidth: true
 
-                placeholderFontSize: 16 * scaleRatio
-                labelFontSize: 14 * scaleRatio
+                placeholderFontSize: 16
+                labelFontSize: 14
                 labelText: qsTr("Set segregation height:") + translationManager.emptyString
                 validator: IntValidator { bottom: 0 }
                 readOnly: false

--- a/pages/Sign.qml
+++ b/pages/Sign.qml
@@ -87,17 +87,17 @@ Rectangle {
     ColumnLayout {
         id: mainLayout
         Layout.fillWidth: true
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
 
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
 
-        spacing: 20 * scaleRatio
+        spacing: 20
 
         MoneroComponents.Label {
-            fontSize: 24 * scaleRatio
+            fontSize: 24
             text: qsTr("Sign/verify") + translationManager.emptyString
         }
 
@@ -106,7 +106,7 @@ Rectangle {
             wrapMode: Text.Wrap
             Layout.fillWidth: true
             font.family: MoneroComponents.Style.fontRegular.name
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             color: MoneroComponents.Style.defaultFontColor
         }
 
@@ -117,18 +117,18 @@ Rectangle {
             MoneroComponents.TextPlain {
                 id: modeText
                 Layout.fillWidth: true
-                Layout.topMargin: 12 * scaleRatio
+                Layout.topMargin: 12
                 text: qsTr("Mode") + translationManager.emptyString
                 wrapMode: Text.Wrap
                 font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 20 * scaleRatio
+                font.pixelSize: 20
                 textFormat: Text.RichText
                 color: MoneroComponents.Style.defaultFontColor
             }
 
             RowLayout {
                 id: modeButtonsRow
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
 
                 MoneroComponents.StandardButton {
                     id: handleMessageButton
@@ -154,12 +154,12 @@ Rectangle {
 
         ColumnLayout {
             id: signSection
-            spacing: 10 * scaleRatio
+            spacing: 10
 
             MoneroComponents.LabelSubheader {
                 Layout.fillWidth: true
-                Layout.topMargin: 12 * scaleRatio
-                Layout.bottomMargin: 24 * scaleRatio
+                Layout.topMargin: 12
+                Layout.bottomMargin: 24
                 textFormat: Text.RichText
                 text: fileMode ? qsTr("Sign file") + translationManager.emptyString : qsTr("Sign message") + translationManager.emptyString
             }
@@ -167,15 +167,15 @@ Rectangle {
             ColumnLayout{
                 id: signMessageRow
                 Layout.fillWidth: true
-                spacing: 10 * scaleRatio
+                spacing: 10
                 visible: messageMode
 
                 MoneroComponents.LineEditMulti{
                     id: signMessageLine
                     Layout.fillWidth: true
-                    labelFontSize: 14 * scaleRatio
+                    labelFontSize: 14
                     labelText: qsTr("Message") + translationManager.emptyString;
-                    placeholderFontSize: 16 * scaleRatio
+                    placeholderFontSize: 16
                     placeholderText: qsTr("Enter a message to sign") + translationManager.emptyString;
                     readOnly: false
                     onTextChanged: signSignatureLine.text = ''
@@ -191,9 +191,9 @@ Rectangle {
 
                 MoneroComponents.LineEditMulti {
                     id: signFileLine
-                    labelFontSize: 14 * scaleRatio
+                    labelFontSize: 14
                     labelText: qsTr("File") + translationManager.emptyString
-                    placeholderFontSize: 16 * scaleRatio
+                    placeholderFontSize: 16
                     placeholderText: qsTr("Enter path to file") + translationManager.emptyString;
                     readOnly: false
                     Layout.fillWidth: true
@@ -219,9 +219,9 @@ Rectangle {
 
                 MoneroComponents.LineEditMulti {
                     id: signSignatureLine
-                    labelFontSize: 14 * scaleRatio
+                    labelFontSize: 14
                     labelText: qsTr("Signature") + translationManager.emptyString
-                    placeholderFontSize: 16 * scaleRatio
+                    placeholderFontSize: 16
                     placeholderText: messageMode ? qsTr("Click [Sign Message] to generate signature") + translationManager.emptyString : qsTr("Click [Sign File] to generate signature") + translationManager.emptyString;
                     readOnly: true
                     Layout.fillWidth: true
@@ -275,11 +275,11 @@ Rectangle {
 
         ColumnLayout {
             id: verifySection
-            spacing: 16 * scaleRatio
+            spacing: 16
 
             MoneroComponents.LabelSubheader {
                 Layout.fillWidth: true
-                Layout.bottomMargin: 24 * scaleRatio
+                Layout.bottomMargin: 24
                 textFormat: Text.RichText
                 text: fileMode ? qsTr("Verify file") + translationManager.emptyString : qsTr("Verify message") + translationManager.emptyString
             }
@@ -288,9 +288,9 @@ Rectangle {
                 id: verifyMessageLine
                 visible: messageMode
                 Layout.fillWidth: true
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Message") + translationManager.emptyString
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Enter the message to verify") + translationManager.emptyString
                 readOnly: false
                 wrapMode: Text.WrapAnywhere
@@ -305,9 +305,9 @@ Rectangle {
 
                 MoneroComponents.LineEditMulti {
                     id: verifyFileLine
-                    labelFontSize: 14 * scaleRatio
+                    labelFontSize: 14
                     labelText: qsTr("File") + translationManager.emptyString
-                    placeholderFontSize: 16 * scaleRatio
+                    placeholderFontSize: 16
                     placeholderText: qsTr("Enter path to file") + translationManager.emptyString
                     readOnly: false
                     Layout.fillWidth: true
@@ -330,10 +330,10 @@ Rectangle {
             MoneroComponents.LineEditMulti {
                 id: verifyAddressLine
                 Layout.fillWidth: true
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Address") + translationManager.emptyString
                 addressValidation: true
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Enter the Monero Address (example: 44AFFq5kSiGBoZ...)") + translationManager.emptyString
                 wrapMode: Text.WrapAnywhere
                 text: ''
@@ -342,9 +342,9 @@ Rectangle {
 
             MoneroComponents.LineEditMulti {
                 id: verifySignatureLine
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Signature") + translationManager.emptyString
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Enter the signature to verify") + translationManager.emptyString
                 Layout.fillWidth: true
                 pasteButton: true
@@ -354,7 +354,7 @@ Rectangle {
 
             RowLayout{
                 Layout.fillWidth: true
-                Layout.topMargin: 12 * scaleRatio
+                Layout.topMargin: 12
                 Layout.alignment: Qt.AlignRight
 
                 MoneroComponents.StandardButton {

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -107,14 +107,14 @@ Rectangle {
 
     ColumnLayout {
       id: pageRoot
-      anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-      anchors.topMargin: 40 * scaleRatio
+      anchors.margins: (isMobile)? 17 : 20
+      anchors.topMargin: 40
 
       anchors.left: parent.left
       anchors.top: parent.top
       anchors.right: parent.right
 
-      spacing: 30 * scaleRatio
+      spacing: 30
 
       RowLayout {
           visible: root.warningContent !== ""
@@ -134,7 +134,7 @@ Rectangle {
 
           ColumnLayout {
               Layout.fillWidth: true
-              Layout.minimumWidth: 200 * scaleRatio
+              Layout.minimumWidth: 200
 
               // Amount input
               LineEdit {
@@ -149,7 +149,7 @@ Rectangle {
                       appWindow.showPageRequest("Account")
                   }
                   placeholderText: "0.00"
-                  width: 100 * scaleRatio
+                  width: 100
                   fontBold: true
                   inlineButtonText: qsTr("All") + translationManager.emptyString
                   inlineButton.onClicked: amountLine.text = "(all)"
@@ -169,10 +169,10 @@ Rectangle {
               Layout.fillWidth: true
               Label {
                   id: transactionPriority
-                  Layout.topMargin: 12 * scaleRatio
+                  Layout.topMargin: 12
                   text: qsTr("Transaction priority") + translationManager.emptyString
                   fontBold: false
-                  fontSize: 16 * scaleRatio
+                  fontSize: 16
               }
               // Note: workaround for translations in listElements
               // ListElement: cannot use script for property value, so
@@ -195,7 +195,7 @@ Rectangle {
               StandardDropdown {
                   Layout.fillWidth: true
                   id: priorityDropdown
-                  Layout.topMargin: 5 * scaleRatio
+                  Layout.topMargin: 5
                   currentIndex: 0
               }
           }
@@ -259,7 +259,7 @@ Rectangle {
 
       StandardButton {
           id: resolveButton
-          width: 80 * scaleRatio
+          width: 80
           text: qsTr("Resolve") + translationManager.emptyString
           visible: TxUtils.isValidOpenAliasAddress(addressLine.text)
           enabled : visible
@@ -311,8 +311,8 @@ Rectangle {
               border: false
               checkedIcon: "qrc:///images/minus-white.png"
               uncheckedIcon: "qrc:///images/plus-white.png"
-              imgWidth: 12 * scaleRatio
-              imgHeight: 12 * scaleRatio
+              imgWidth: 12
+              imgHeight: 12
               fontSize: paymentIdLine.labelFontSize
               iconOnTheLeft: false
               Layout.fillWidth: true
@@ -342,8 +342,8 @@ Rectangle {
               border: false
               checkedIcon: "qrc:///images/minus-white.png"
               uncheckedIcon: "qrc:///images/plus-white.png"
-              imgWidth: 12 * scaleRatio
-              imgHeight: 12 * scaleRatio
+              imgWidth: 12
+              imgHeight: 12
               fontSize: descriptionLine.labelFontSize
               iconOnTheLeft: false
               Layout.fillWidth: true
@@ -384,7 +384,7 @@ Rectangle {
               id: sendButton
               rightIcon: "qrc:///images/rightArrow.png"
               rightIconInactive: "qrc:///images/rightArrowInactive.png"
-              Layout.topMargin: 4 * scaleRatio
+              Layout.topMargin: 4
               text: qsTr("Send") + translationManager.emptyString
               enabled: {
                 updateSendButton()
@@ -433,9 +433,9 @@ Rectangle {
         anchors.top: pageRoot.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 32 * scaleRatio
-        spacing: 26 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 32
+        spacing: 26
         enabled: !viewOnly || pageRoot.enabled
 
         RowLayout {

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -45,21 +45,21 @@ Rectangle {
     /* main layout */
     ColumnLayout {
         id: mainLayout
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
-        anchors.topMargin: 40 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
+        anchors.topMargin: 40
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
-        spacing: 20 * scaleRatio
+        spacing: 20
 
         // solo
         ColumnLayout {
             id: soloBox
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             MoneroComponents.Label {
                 id: soloTitleLabel
-                fontSize: 24 * scaleRatio
+                fontSize: 24
                 text: qsTr("Prove Transaction") + translationManager.emptyString
             }
 
@@ -69,17 +69,17 @@ Rectangle {
                            "For the case of outgoing payments, you can get a 'Spend Proof' that proves the authorship of a transaction. In this case, you don't need to specify the recipient address.") + translationManager.emptyString
                 wrapMode: Text.Wrap
                 font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 color: MoneroComponents.Style.defaultFontColor
             }
 
             MoneroComponents.LineEdit {
                 id: getProofTxIdLine
                 Layout.fillWidth: true
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Transaction ID") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
-                placeholderFontSize: 16 * scaleRatio
+                fontSize: 16
+                placeholderFontSize: 16
                 placeholderText: qsTr("Paste tx ID") + translationManager.emptyString
                 readOnly: false
                 copyButton: true
@@ -88,10 +88,10 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: getProofAddressLine
                 Layout.fillWidth: true
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Address") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
-                placeholderFontSize: 16 * scaleRatio
+                fontSize: 16
+                placeholderFontSize: 16
                 placeholderText: qsTr("Recipient's wallet address") + translationManager.emptyString;
                 readOnly: false
                 copyButton: true
@@ -100,17 +100,17 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: getProofMessageLine
                 Layout.fillWidth: true
-                fontSize: 16 * scaleRatio
-                labelFontSize: 14 * scaleRatio
+                fontSize: 16
+                labelFontSize: 14
                 labelText: qsTr("Message") + translationManager.emptyString
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Optional message against which the signature is signed") + translationManager.emptyString;
                 readOnly: false
                 copyButton: true
             }
 
             MoneroComponents.StandardButton {
-                Layout.topMargin: 16 * scaleRatio
+                Layout.topMargin: 16
                 small: true
                 text: qsTr("Generate") + translationManager.emptyString
                 enabled: TxUtils.checkTxID(getProofTxIdLine.text) && (getProofAddressLine.text.length == 0 || TxUtils.checkAddress(getProofAddressLine.text, appWindow.persistentSettings.nettype))
@@ -127,12 +127,12 @@ Rectangle {
                 opacity: MoneroComponents.Style.dividerOpacity
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignHCenter
-                anchors.bottomMargin: 3 * scaleRatio
+                anchors.bottomMargin: 3
             }
 
             MoneroComponents.Label {
                 id: soloTitleLabel2
-                fontSize: 24 * scaleRatio
+                fontSize: 24
                 text: qsTr("Check Transaction") + translationManager.emptyString
             }
 
@@ -142,17 +142,17 @@ Rectangle {
                 wrapMode: Text.Wrap
                 Layout.fillWidth: true
                 font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 color: MoneroComponents.Style.defaultFontColor
             }
 
             MoneroComponents.LineEdit {
                 id: checkProofTxIdLine
                 Layout.fillWidth: true
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Transaction ID") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
-                placeholderFontSize: 16 * scaleRatio
+                fontSize: 16
+                placeholderFontSize: 16
                 placeholderText: qsTr("Paste tx ID") + translationManager.emptyString
                 readOnly: false
                 copyButton: true
@@ -161,10 +161,10 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: checkProofAddressLine
                 Layout.fillWidth: true
-                labelFontSize: 14 * scaleRatio
+                labelFontSize: 14
                 labelText: qsTr("Address") + translationManager.emptyString
-                fontSize: 16 * scaleRatio
-                placeholderFontSize: 16 * scaleRatio
+                fontSize: 16
+                placeholderFontSize: 16
                 placeholderText: qsTr("Recipient's wallet address") + translationManager.emptyString;
                 readOnly: false
                 copyButton: true
@@ -173,10 +173,10 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: checkProofMessageLine
                 Layout.fillWidth: true
-                fontSize: 16 * scaleRatio
-                labelFontSize: 14 * scaleRatio
+                fontSize: 16
+                labelFontSize: 14
                 labelText: qsTr("Message") + translationManager.emptyString
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Optional message against which the signature is signed") + translationManager.emptyString;
                 readOnly: false
                 copyButton: true
@@ -185,17 +185,17 @@ Rectangle {
             MoneroComponents.LineEdit {
                 id: checkProofSignatureLine
                 Layout.fillWidth: true
-                fontSize: 16 * scaleRatio
-                labelFontSize: 14 * scaleRatio
+                fontSize: 16
+                labelFontSize: 14
                 labelText: qsTr("Signature") + translationManager.emptyString
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Paste tx proof") + translationManager.emptyString;
                 readOnly: false
                 copyButton: true
             }
 
             MoneroComponents.StandardButton {
-                Layout.topMargin: 16 * scaleRatio
+                Layout.topMargin: 16
                 small: true
                 text: qsTr("Check") + translationManager.emptyString
                 enabled: TxUtils.checkTxID(checkProofTxIdLine.text) && TxUtils.checkSignature(checkProofSignatureLine.text) && ((checkProofSignatureLine.text.indexOf("SpendProofV") === 0 && checkProofAddressLine.text.length == 0) || (checkProofSignatureLine.text.indexOf("SpendProofV") !== 0 && TxUtils.checkAddress(checkProofAddressLine.text, appWindow.persistentSettings.nettype)))
@@ -212,7 +212,7 @@ Rectangle {
                 opacity: MoneroComponents.Style.dividerOpacity
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignHCenter
-                anchors.bottomMargin: 3 * scaleRatio
+                anchors.bottomMargin: 3
             }
 
             MoneroComponents.TextPlain {
@@ -220,7 +220,7 @@ Rectangle {
                 wrapMode: Text.Wrap
                 Layout.fillWidth: true
                 font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 color: MoneroComponents.Style.defaultFontColor
             }
         }

--- a/pages/merchant/Merchant.qml
+++ b/pages/merchant/Merchant.qml
@@ -24,8 +24,8 @@ Item {
     id: root
     anchors.margins: 0
 
-    property int    minWidth: 900 * scaleRatio
-    property int    qrCodeSize: 220 * scaleRatio
+    property int    minWidth: 900
+    property int    qrCodeSize: 220
     property bool   enableTracking: false
     property string trackingError: ""  // setting this will show a message @ tracking table
     property alias  merchantHeight: mainLayout.height
@@ -64,7 +64,7 @@ Item {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        height: 300 * scaleRatio
+        height: 300
         source: "qrc:///images/merchant/bg.png"
         smooth: false
     }
@@ -75,8 +75,8 @@ Item {
         spacing: 0
 
         // emulates max-width + center for container
-        property int maxWidth: 1200 * scaleRatio
-        property int defaultMargin: 50 * scaleRatio
+        property int maxWidth: 1200
+        property int defaultMargin: 50
         property int horizontalMargin: {
             if(appWindow.width >= maxWidth){
                 return ((appWindow.width - maxWidth) / 2) + defaultMargin;
@@ -93,7 +93,7 @@ Item {
         anchors.right: parent.right
 
         Item {
-            height: 220 * scaleRatio
+            height: 220
             anchors.left: parent.left
             anchors.right: parent.right
 
@@ -101,8 +101,8 @@ Item {
                 id: tracker
                 anchors.left: parent.left
                 anchors.top: parent.top
-                height: 220 * scaleRatio
-                width: (parent.width - qrImg.width) - 50 * scaleRatio
+                height: 220
+                width: (parent.width - qrImg.width) - 50
                 radius: 5
 
                 ColumnLayout {
@@ -113,21 +113,21 @@ Item {
 
                     RowLayout {
                         spacing: 0
-                        height: 56 * scaleRatio
+                        height: 56
 
                         RowLayout {
                             Layout.alignment: Qt.AlignLeft
-                            Layout.preferredWidth: 260 * scaleRatio
+                            Layout.preferredWidth: 260
                             Layout.preferredHeight: parent.height
                             Layout.fillHeight: true
-                            spacing: 8 * scaleRatio
+                            spacing: 8
 
                             Item {
-                                Layout.preferredWidth: 10 * scaleRatio
+                                Layout.preferredWidth: 10
                             }
 
                             MoneroComponents.TextPlain {
-                                font.pixelSize: 16 * scaleRatio
+                                font.pixelSize: 16
                                 font.bold: true
                                 color: "#767676"
                                 text: qsTr("Sales") + translationManager.emptyString
@@ -146,13 +146,13 @@ Item {
 
                     Rectangle {
                         Layout.fillWidth: true
-                        Layout.preferredHeight: 1 * scaleRatio
+                        Layout.preferredHeight: 1
                         color: "#d9d9d9"
                     }
 
                     MerchantTrackingList {
                         Layout.fillWidth: true
-                        Layout.preferredHeight: 400 * scaleRatio
+                        Layout.preferredHeight: 400
                         model: trackingModel
                         message: {
                             if(!root.enableTracking){
@@ -212,7 +212,7 @@ Item {
                 Image {
                     id: qrCode
                     anchors.fill: parent
-                    anchors.margins: 1 * scaleRatio
+                    anchors.margins: 1
 
                     smooth: false
                     fillMode: Image.PreserveAspectFit
@@ -257,18 +257,18 @@ Item {
         }
 
         Item {
-            Layout.preferredHeight: 40 * scaleRatio
+            Layout.preferredHeight: 40
             anchors.left: parent.left
             anchors.right: parent.right
 
             Item {
-                width: (parent.width - qrImg.width) - (50 * scaleRatio)
-                height: 32 * scaleRatio
+                width: (parent.width - qrImg.width) - (50)
+                height: 32
 
                 MoneroComponents.TextPlain {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter
-                    font.pixelSize: 12 * scaleRatio
+                    font.pixelSize: 12
                     font.bold: false
                     color: "white"
                     text: "<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 12px;}</style>Currently selected address: " + addressLabel + " <a href='#'>(Change)</a>"
@@ -287,13 +287,13 @@ Item {
             Item {
                 anchors.right: parent.right
                 anchors.top: parent.top
-                width: 220 * scaleRatio
-                height: 32 * scaleRatio
+                width: 220
+                height: 32
 
                 MoneroComponents.TextPlain {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter
-                    font.pixelSize: 12 * scaleRatio
+                    font.pixelSize: 12
                     font.bold: false
                     color: "white"
                     text: qsTr("(right-click, save as)") + translationManager.emptyString
@@ -303,16 +303,16 @@ Item {
         }
 
         Item {
-            Layout.preferredHeight: 120 * scaleRatio
-            Layout.topMargin: 20 * scaleRatio
+            Layout.preferredHeight: 120
+            Layout.topMargin: 20
             Layout.fillWidth: true
 
             Rectangle {
                 id: payment_url_container
                 anchors.left: parent.left
                 anchors.top: parent.top
-                implicitHeight: 120 * scaleRatio
-                width: (parent.width - qrImg.width) - (50 * scaleRatio)
+                implicitHeight: 120
+                width: (parent.width - qrImg.width) - (50)
                 radius: 5
 
                 ColumnLayout {
@@ -323,21 +323,21 @@ Item {
 
                     RowLayout {
                         spacing: 0
-                        height: 56 * scaleRatio
+                        height: 56
 
                         RowLayout {
                             Layout.alignment: Qt.AlignLeft
-                            Layout.preferredWidth: 260 * scaleRatio
+                            Layout.preferredWidth: 260
                             Layout.preferredHeight: parent.height
                             Layout.fillHeight: true
                             spacing: 8
 
                             Item {
-                                Layout.preferredWidth: 10 * scaleRatio
+                                Layout.preferredWidth: 10
                             }
 
                             MoneroComponents.TextPlain {
-                                font.pixelSize: 14 * scaleRatio
+                                font.pixelSize: 14
                                 font.bold: true
                                 color: "#767676"
                                 text: qsTr("Payment URL") + translationManager.emptyString
@@ -353,15 +353,15 @@ Item {
 //                        Rectangle {
 //                            // help box
 //                            Layout.alignment: Qt.AlignLeft
-//                            Layout.preferredWidth: 40 * scaleRatio
+//                            Layout.preferredWidth: 40
 //                            Layout.fillHeight: true
 //                            color: "transparent"
 
 //                            MoneroComponents.TextPlain {
 //                                anchors.verticalCenter: parent.verticalCenter
 //                                anchors.right: parent.right
-//                                anchors.rightMargin: 20 * scaleRatio
-//                                font.pixelSize: 16 * scaleRatio
+//                                anchors.rightMargin: 20
+//                                font.pixelSize: 16
 //                                font.bold: true
 //                                color: "#767676"
 //                                text:"?"
@@ -394,13 +394,13 @@ Item {
                     MoneroComponents.TextPlain {
                         property string _color: "#767676"
                         Layout.fillWidth: true
-                        Layout.margins: 20 * scaleRatio
-                        Layout.topMargin: 10 * scaleRatio
+                        Layout.margins: 20
+                        Layout.topMargin: 10
 
                         wrapMode: Text.WrapAnywhere
                         elide: Text.ElideRight
 
-                        font.pixelSize: 12 * scaleRatio
+                        font.pixelSize: 12
                         font.bold: true
                         color: _color
                         text: TxUtils.makeQRCodeString(appWindow.current_address, amountToReceive.text)
@@ -441,15 +441,15 @@ Item {
             Item {
                 anchors.right: parent.right
                 anchors.top: parent.top
-                width: 220 * scaleRatio
-                height: 32 * scaleRatio
+                width: 220
+                height: 32
 
                 ColumnLayout {
                     anchors.left: parent.left
                     anchors.right: parent.right
 
                     MoneroComponents.TextPlain {
-                        font.pixelSize: 14 * scaleRatio
+                        font.pixelSize: 14
                         font.bold: false
                         color: "white"
                         text: qsTr("Amount to receive") + " (XMR)"
@@ -457,20 +457,20 @@ Item {
                     }
 
                     Image {
-                        height: 28 * scaleRatio
-                        width: 220 * scaleRatio
+                        height: 28
+                        width: 220
                         source: "qrc:///images/merchant/input_box.png"
 
                         TextField {
                             id: amountToReceive
                             topPadding: 0
-                            leftPadding: 10 * scaleRatio
+                            leftPadding: 10
 
                             anchors.left: parent.left
                             anchors.right: parent.right
                             anchors.top: parent.top
-                            anchors.topMargin: 3 * scaleRatio
-                            font.pixelSize: 16 * scaleRatio
+                            anchors.topMargin: 3
+                            font.pixelSize: 16
                             font.bold: true
                             horizontalAlignment: TextInput.AlignLeft
                             verticalAlignment: TextInput.AlignVCenter
@@ -495,14 +495,14 @@ Item {
                     }
 
                     Item {
-                        height: 2 * scaleRatio
-                        width: 220 * scaleRatio
+                        height: 2
+                        width: 220
                     }
 
                     MoneroComponents.TextPlain {
                         // @TODO: When we have XMR/USD rate avi. in the future.
                         visible: false
-                        font.pixelSize: 14 * scaleRatio
+                        font.pixelSize: 14
                         font.bold: false
                         color: "white"
                         text: qsTr("Amount to receive") + " (USD)"
@@ -512,8 +512,8 @@ Item {
 
                     Image {
                         visible: false
-                        height: 28 * scaleRatio
-                        width: 220 * scaleRatio
+                        height: 28
+                        width: 220
                         source: "qrc:///images/merchant/input_box.png"
                         opacity: 0.2
                     }
@@ -522,13 +522,13 @@ Item {
         }
 
         Item {
-            Layout.topMargin: 32 * scaleRatio
-            Layout.preferredHeight: 40 * scaleRatio
+            Layout.topMargin: 32
+            Layout.preferredHeight: 40
             anchors.left: parent.left
             anchors.right: parent.right
 
             ColumnLayout {
-                spacing: 16 * scaleRatio
+                spacing: 16
 
                 MerchantCheckbox {
                     id: trackingCheckbox
@@ -542,7 +542,7 @@ Item {
 
                 MoneroComponents.TextPlain {
                     id: content
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                     font.bold: false
                     color: "white"
                     text: qsTr("Leave this page") + translationManager.emptyString
@@ -563,16 +563,16 @@ Item {
         // Shows when the window is too small
         visible: parent.width < root.minWidth
         anchors.top: parent.top
-        anchors.topMargin: 100 * scaleRatio;
+        anchors.topMargin: 100;
         anchors.horizontalCenter: parent.horizontalCenter
-        height: 120 * scaleRatio
-        width: 400 * scaleRatio
+        height: 120
+        width: 400
         radius: 5
 
         MoneroComponents.TextPlain {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             font.bold: true
             color: MoneroComponents.Style.moneroGrey
             text: qsTr("The merchant page requires a larger window") + translationManager.emptyString

--- a/pages/merchant/MerchantCheckbox.qml
+++ b/pages/merchant/MerchantCheckbox.qml
@@ -6,7 +6,7 @@ import "../../components" as MoneroComponents
 
 RowLayout {
     id: root
-    spacing: 10 * scaleRatio
+    spacing: 10
     property bool checked: false;
     property alias text: content.text
     signal changed;
@@ -15,8 +15,8 @@ RowLayout {
         id: checkbox
         anchors.left: parent.left
         anchors.top: parent.top
-        implicitHeight: 22 * scaleRatio
-        width: 22 * scaleRatio
+        implicitHeight: 22
+        width: 22
         radius: 5
 
         Image {
@@ -29,7 +29,7 @@ RowLayout {
 
     MoneroComponents.TextPlain {
         id: content
-        font.pixelSize: 14 * scaleRatio
+        font.pixelSize: 14
         font.bold: false
         color: "white"
         text: ""

--- a/pages/merchant/MerchantTitlebar.qml
+++ b/pages/merchant/MerchantTitlebar.qml
@@ -45,7 +45,7 @@ Rectangle {
 
     height: {
         if(!persistentSettings.customDecorations || isMobile) return 0;
-        return 50 * scaleRatio;
+        return 50;
     }
 
     z: 1

--- a/pages/merchant/MerchantTrackingList.qml
+++ b/pages/merchant/MerchantTrackingList.qml
@@ -28,11 +28,11 @@ ListView {
         // message box
         visible: parent.message !== ""
         anchors.fill: parent
-        anchors.margins: 20 * scaleRatio
-        anchors.topMargin: 10 * scaleRatio
+        anchors.margins: 20
+        anchors.topMargin: 10
         wrapMode: Text.Wrap
 
-        font.pixelSize: 14 * scaleRatio
+        font.pixelSize: 14
         font.bold: false
         color: "#767676"
         textFormat: Text.RichText
@@ -46,7 +46,7 @@ ListView {
     delegate: Item {
         id: trackingTableItem
         visible: trackingListView.message === ""
-        height: 53 * scaleRatio
+        height: 53
         width: parent.width
         Layout.fillWidth: true
 
@@ -58,22 +58,22 @@ ListView {
 
             Item {
                 Layout.preferredHeight: parent.height
-                Layout.preferredWidth: 20 * scaleRatio
+                Layout.preferredWidth: 20
             }
 
             ColumnLayout {
                 spacing: 0
-                Layout.preferredHeight: 40 * scaleRatio
-                Layout.preferredWidth: 240 * scaleRatio
+                Layout.preferredHeight: 40
+                Layout.preferredWidth: 240
 
                 Item {
                     Layout.preferredWidth: parent.width
-                    Layout.preferredHeight: 18 * scaleRatio
+                    Layout.preferredHeight: 18
 
                     TextEdit {
                         id: dateString
                         anchors.verticalCenter: parent.verticalCenter
-                        font.pixelSize: 13 * scaleRatio
+                        font.pixelSize: 13
                         font.bold: false
                         color: "#707070"
                         text: time_date + " (" + Utils.ago(time_epoch) + ") "
@@ -93,11 +93,11 @@ ListView {
                         TextEdit {
                             id: hideAmount
                             anchors.top: parent.top
-                            anchors.topMargin: 1 * scaleRatio
+                            anchors.topMargin: 1
                             anchors.left: parent.left
                             anchors.verticalCenter: parent.verticalCenter
                             readOnly: true
-                            font.pixelSize: 12 * scaleRatio
+                            font.pixelSize: 12
                             font.bold: false
                             color: "#707070"
                             text: (hide_amount ? "(" + qsTr("show") + ")" : "(" + qsTr("hide") + ")") + translationManager.emptyString
@@ -117,12 +117,12 @@ ListView {
 
                 Item {
                     Layout.preferredWidth: parent.width
-                    Layout.preferredHeight: 18 * scaleRatio
+                    Layout.preferredHeight: 18
 
                     TextEdit {
                         id: amountText
                         anchors.verticalCenter: parent.verticalCenter
-                        font.pixelSize: 14 * scaleRatio
+                        font.pixelSize: 14
                         font.bold: true
                         color: hide_amount ? "#707070" : "#009F1E"
                         text: hide_amount ? '-' : '+' + amount
@@ -141,7 +141,7 @@ ListView {
             RowLayout {
                 spacing: 0
                 Layout.preferredHeight: parent.height
-                Layout.preferredWidth: 240 * scaleRatio
+                Layout.preferredWidth: 240
 
                 Item {
                     Layout.fillWidth: true
@@ -149,13 +149,13 @@ ListView {
                 }
 
                 Item {
-                    Layout.preferredWidth: 150 * scaleRatio
+                    Layout.preferredWidth: 150
                     Layout.preferredHeight: parent.height
 
                     TextEdit {
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.verticalCenter: parent.verticalCenter
-                        font.pixelSize: 12 * scaleRatio
+                        font.pixelSize: 12
                         font.bold: false
                         color: "#a8a8a8"
                         text: {
@@ -191,14 +191,14 @@ ListView {
                 }
 
                 Item {
-                    Layout.preferredWidth: 30 * scaleRatio
+                    Layout.preferredWidth: 30
                     Layout.preferredHeight: parent.height
 
                     Image {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
-                        Layout.preferredWidth: 12 * scaleRatio
-                        Layout.preferredHeight: 21 * scaleRatio
+                        Layout.preferredWidth: 12
+                        Layout.preferredHeight: 21
                         source: "qrc:///images/merchant/arrow_right.png"
                     }
 
@@ -214,7 +214,7 @@ ListView {
                 }
 
                 Item {
-                    Layout.preferredWidth: 10 * scaleRatio
+                    Layout.preferredWidth: 10
                     Layout.preferredHeight: parent.height
                 }
             }

--- a/pages/settings/Navbar.qml
+++ b/pages/settings/Navbar.qml
@@ -55,7 +55,7 @@ Rectangle {
             columnSpacing: 0
             property string fontColorActive: MoneroComponents.Style.blackTheme ? "white" : "white"
             property string fontColorInActive: MoneroComponents.Style.blackTheme ? "white" : MoneroComponents.Style.dimmedFontColor
-            property int fontSize: 15 * scaleRatio
+            property int fontSize: 15
             property bool fontBold: true
             property var fontFamily: MoneroComponents.Style.fontRegular.name
             property string borderColor: MoneroComponents.Style.blackTheme ? "#808080" : "#B9B9B9"
@@ -118,7 +118,7 @@ Rectangle {
                 id: navWallet
                 property bool isActive: settingsStateView.state === "Wallet"
                 Layout.preferredWidth: navWalletText.width + grid.textMargin
-                Layout.minimumWidth: 72 * scaleRatio
+                Layout.minimumWidth: 72
                 Layout.preferredHeight: 32
                 spacing: 0
 
@@ -130,7 +130,7 @@ Rectangle {
 
                 Rectangle {
                     color: parent.isActive ? grid.borderColor : "transparent"
-                    height: 30 * scaleRatio
+                    height: 30
                     Layout.fillWidth: true
 
                     MoneroComponents.TextPlain {
@@ -171,7 +171,7 @@ Rectangle {
                 property bool isActive: settingsStateView.state === "UI"
                 Layout.preferredWidth: navUIText.width + grid.textMargin
                 Layout.preferredHeight: 32
-                Layout.minimumWidth: 72 * scaleRatio
+                Layout.minimumWidth: 72
                 spacing: 0
 
                 Rectangle { 
@@ -182,7 +182,7 @@ Rectangle {
 
                 Rectangle {
                     color: parent.isActive ? grid.borderColor : "transparent"
-                    height: 30 * scaleRatio
+                    height: 30
                     Layout.fillWidth: true
 
                     MoneroComponents.TextPlain {
@@ -224,7 +224,7 @@ Rectangle {
                 visible: appWindow.walletMode >= 2
                 Layout.preferredWidth: navNodeText.width + grid.textMargin
                 Layout.preferredHeight: 32
-                Layout.minimumWidth: 72 * scaleRatio
+                Layout.minimumWidth: 72
                 spacing: 0
 
                 Rectangle { 
@@ -235,7 +235,7 @@ Rectangle {
 
                 Rectangle {
                     color: parent.isActive ? grid.borderColor : "transparent"
-                    height: 30 * scaleRatio
+                    height: 30
                     Layout.fillWidth: true
 
                     MoneroComponents.TextPlain {
@@ -278,7 +278,7 @@ Rectangle {
                 visible: appWindow.walletMode >= 2
                 Layout.preferredWidth: navLogText.width + grid.textMargin
                 Layout.preferredHeight: 32
-                Layout.minimumWidth: 72 * scaleRatio
+                Layout.minimumWidth: 72
                 spacing: 0
 
                 Rectangle { 
@@ -289,7 +289,7 @@ Rectangle {
 
                 Rectangle {
                     color: parent.isActive ? grid.borderColor : "transparent"
-                    height: 30 * scaleRatio
+                    height: 30
                     Layout.fillWidth: true
 
                     MoneroComponents.TextPlain {
@@ -331,7 +331,7 @@ Rectangle {
                 property bool isActive: settingsStateView.state === "Info"
                 Layout.preferredWidth: navInfoText.width + grid.textMargin
                 Layout.preferredHeight: 32
-                Layout.minimumWidth: 72 * scaleRatio
+                Layout.minimumWidth: 72
                 spacing: 0
 
                 Rectangle { 
@@ -342,7 +342,7 @@ Rectangle {
 
                 Rectangle {
                     color: parent.isActive ? grid.borderColor : "transparent"
-                    height: 30 * scaleRatio
+                    height: 30
                     Layout.fillWidth: true
 
                     MoneroComponents.TextPlain {

--- a/pages/settings/SettingsInfo.qml
+++ b/pages/settings/SettingsInfo.qml
@@ -38,7 +38,7 @@ import "../../components" as MoneroComponents
 
 Rectangle {
     color: "transparent"
-    height: 1400 * scaleRatio
+    height: 1400
     Layout.fillWidth: true
     property string walletModeString: {
         if(appWindow.walletMode === 0){
@@ -56,29 +56,29 @@ Rectangle {
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
         anchors.topMargin: 0
-        spacing: 30 * scaleRatio
+        spacing: 30
 
         GridLayout {
             columns: 2
             columnSpacing: 0
 
             MoneroComponents.TextBlock {
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: qsTr("GUI version: ") + translationManager.emptyString
             }
 
             MoneroComponents.TextBlock {
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 color: MoneroComponents.Style.dimmedFontColor
                 text: Version.GUI_VERSION + " (Qt " + qtRuntimeVersion + ")" + translationManager.emptyString
             }
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -86,8 +86,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -95,20 +95,20 @@ Rectangle {
 
             MoneroComponents.TextBlock {
                 id: guiMoneroVersion
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: qsTr("Embedded Monero version: ") + translationManager.emptyString
             }
 
             MoneroComponents.TextBlock {
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 color: MoneroComponents.Style.dimmedFontColor
                 text: Version.GUI_MONERO_VERSION + translationManager.emptyString
             }
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -116,8 +116,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -125,15 +125,15 @@ Rectangle {
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: qsTr("Wallet path: ") + translationManager.emptyString
             }
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
-                Layout.maximumWidth: 360 * scaleRatio
+                Layout.maximumWidth: 360
                 color: MoneroComponents.Style.dimmedFontColor
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: {
                     var wallet_path = walletPath();
                     if(isIOS)
@@ -144,8 +144,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -153,8 +153,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -162,7 +162,7 @@ Rectangle {
 
             MoneroComponents.TextBlock {
                 id: restoreHeight
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 textFormat: Text.RichText
                 text: (typeof currentWallet == "undefined") ? "" : qsTr("Wallet creation height: ") + translationManager.emptyString
             }
@@ -172,7 +172,7 @@ Rectangle {
                 Layout.fillWidth: true
                 textFormat: Text.RichText
                 color: MoneroComponents.Style.dimmedFontColor
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 property var style: "<style type='text/css'>a {cursor:pointer;text-decoration: none; color: #FF6C3C}</style>"
                 text: (currentWallet ? currentWallet.walletCreationHeight : "") + style + qsTr(" <a href='#'> (Click to change)</a>") + translationManager.emptyString
                 onLinkActivated: {
@@ -234,8 +234,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -243,8 +243,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -252,21 +252,21 @@ Rectangle {
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: qsTr("Wallet log path: ") + translationManager.emptyString
             }
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dimmedFontColor
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: walletLogPath
             }
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -274,8 +274,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -283,21 +283,21 @@ Rectangle {
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: qsTr("Wallet mode: ") + translationManager.emptyString
             }
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dimmedFontColor
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: walletModeString
             }
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -305,8 +305,8 @@ Rectangle {
 
             Rectangle {
                 height: 1
-                Layout.topMargin: 2 * scaleRatio
-                Layout.bottomMargin: 2 * scaleRatio
+                Layout.topMargin: 2
+                Layout.bottomMargin: 2
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -314,14 +314,14 @@ Rectangle {
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: qsTr("Graphics mode: ") + translationManager.emptyString
             }
 
             MoneroComponents.TextBlock {
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dimmedFontColor
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 text: isOpenGL ? "OpenGL" : "Low graphics mode"
             }
         }

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -50,14 +50,14 @@ Rectangle {
 
     ColumnLayout {
         id: settingsUI
-        property int itemHeight: 60 * scaleRatio
+        property int itemHeight: 60
         Layout.fillWidth: true
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
         anchors.topMargin: 0
-        spacing: 6 * scaleRatio
+        spacing: 6
 
         MoneroComponents.CheckBox {
             visible: !isMobile
@@ -109,12 +109,12 @@ Rectangle {
         ColumnLayout {
             visible: userInActivityCheckbox.checked
             Layout.fillWidth: true
-            Layout.topMargin: 6 * scaleRatio
-            Layout.leftMargin: 42 * scaleRatio
+            Layout.topMargin: 6
+            Layout.leftMargin: 42
             spacing: 0
 
             MoneroComponents.TextBlock {
-                font.pixelSize: 14 * scaleRatio
+                font.pixelSize: 14
                 Layout.fillWidth: true
                 text: {
                     var val = userInactivitySlider.value;
@@ -136,8 +136,8 @@ Rectangle {
                 background: Rectangle {
                     x: parent.leftPadding
                     y: parent.topPadding + parent.availableHeight / 2 - height / 2
-                    implicitWidth: 200 * scaleRatio
-                    implicitHeight: 4 * scaleRatio
+                    implicitWidth: 200
+                    implicitHeight: 4
                     width: parent.availableWidth
                     height: implicitHeight
                     radius: 2
@@ -154,8 +154,8 @@ Rectangle {
                 handle: Rectangle {
                     x: parent.leftPadding + parent.visualPosition * (parent.availableWidth - width)
                     y: parent.topPadding + parent.availableHeight / 2 - height / 2
-                    implicitWidth: 18 * scaleRatio
-                    implicitHeight: 18 * scaleRatio
+                    implicitWidth: 18
+                    implicitHeight: 18
                     radius: 8
                     color: parent.pressed ? "#f0f0f0" : "#f6f6f6"
                     border.color: MoneroComponents.Style.grey
@@ -176,7 +176,7 @@ Rectangle {
 
         MoneroComponents.StandardButton {
             visible: !persistentSettings.customDecorations
-            Layout.topMargin: 10 * scaleRatio
+            Layout.topMargin: 10
             small: true
             text: qsTr("Change language") + translationManager.emptyString
 

--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -42,34 +42,34 @@ Rectangle {
 
     ColumnLayout {
         id: settingsLog
-        property int itemHeight: 60 * scaleRatio
+        property int itemHeight: 60
         Layout.fillWidth: true
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
         anchors.topMargin: 0
         spacing: 10
 
 //        Rectangle {
 //            // divider
-//            Layout.preferredHeight: 1 * scaleRatio
+//            Layout.preferredHeight: 1
 //            Layout.fillWidth: true
-//            Layout.bottomMargin: 8 * scaleRatio
+//            Layout.bottomMargin: 8
 //            color: MoneroComponents.Style.dividerColor
 //            opacity: MoneroComponents.Style.dividerOpacity
 //        }
 
         MoneroComponents.TextPlain {
-            Layout.bottomMargin: 2 * scaleRatio
+            Layout.bottomMargin: 2
             color: MoneroComponents.Style.defaultFontColor
-            font.pixelSize: 18 * scaleRatio
+            font.pixelSize: 18
             font.family: MoneroComponents.Style.fontRegular.name
             text: qsTr("Log level") + translationManager.emptyString
         }
 
         ColumnLayout {
-            spacing: 10 * scaleRatio
+            spacing: 10
             Layout.fillWidth: true
             id: logColumn
             z: parent.z + 1
@@ -87,7 +87,7 @@ Rectangle {
             MoneroComponents.StandardDropdown {
                 id: logLevelDropdown
                 dataModel: logLevel
-                itemTopMargin: 2 * scaleRatio
+                itemTopMargin: 2
                 currentIndex: appWindow.persistentSettings.logLevel;
                 onChanged: {
                     if (currentIndex == 5) {
@@ -112,8 +112,8 @@ Rectangle {
                 Layout.preferredWidth: logColumn.width
                 text: appWindow.persistentSettings.logCategories
                 placeholderText: "(e.g. *:WARNING,net.p2p:DEBUG)"
-                placeholderFontSize: 14 * scaleRatio
-                fontSize: 14 * scaleRatio
+                placeholderFontSize: 14
+                fontSize: 14
                 enabled: logLevelDropdown.currentIndex === 5
                 onEditingFinished: {
                     if(enabled) {
@@ -126,10 +126,10 @@ Rectangle {
         }
 
         MoneroComponents.TextPlain {
-            Layout.topMargin: 10 * scaleRatio
-            Layout.bottomMargin: 2 * scaleRatio
+            Layout.topMargin: 10
+            Layout.bottomMargin: 2
             color: MoneroComponents.Style.defaultFontColor
-            font.pixelSize: 18 * scaleRatio
+            font.pixelSize: 18
             font.family: MoneroComponents.Style.fontRegular.name
             text: qsTr("Daemon log") + translationManager.emptyString
         }
@@ -137,7 +137,7 @@ Rectangle {
         Item {
             Layout.fillHeight: true
             Layout.fillWidth: true
-            Layout.preferredHeight: 240 * scaleRatio
+            Layout.preferredHeight: 240
 
             Rectangle {
                 anchors.fill: parent
@@ -159,7 +159,7 @@ Rectangle {
                     selectByMouse: true
                     selectByKeyboard: true
                     font.family: MoneroComponents.Style.defaultFontColor
-                    font.pixelSize: 14 * scaleRatio
+                    font.pixelSize: 14
                     wrapMode: TextEdit.Wrap
                     readOnly: true
                     function logCommand(msg){
@@ -212,7 +212,7 @@ Rectangle {
             Layout.fillWidth: true
             fontBold: false
             placeholderText: qsTr("command + enter (e.g 'help' or 'status')") + translationManager.emptyString
-            placeholderFontSize: 16 * scaleRatio
+            placeholderFontSize: 16
             onAccepted: {
                 if(text.length > 0) {
                     consoleArea.logCommand(">>> " + text)

--- a/pages/settings/SettingsNode.qml
+++ b/pages/settings/SettingsNode.qml
@@ -42,17 +42,17 @@ Rectangle{
     /* main layout */
     ColumnLayout {
         id: root
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
         anchors.topMargin: 0
 
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
 
-        spacing: 0 * scaleRatio
+        spacing: 0
         property int labelWidth: 120
         property int editWidth: 400
-        property int lineEditFontSize: 14 * scaleRatio
+        property int lineEditFontSize: 14
         property int buttonWidth: 110
 
         Rectangle {
@@ -63,7 +63,7 @@ Rectangle{
             Rectangle {
                 id: localNodeDivider
                 Layout.fillWidth: true
-                anchors.topMargin: 0 * scaleRatio
+                anchors.topMargin: 0
                 anchors.left: parent.left
                 anchors.right: parent.right
                 height: 1
@@ -93,7 +93,7 @@ Rectangle{
                     height: 32
                     width: 32
                     anchors.left: parent.left
-                    anchors.leftMargin: 16 * scaleRatio
+                    anchors.leftMargin: 16
                     anchors.verticalCenter: parent.verticalCenter
 
                     MoneroEffects.ImageMask {
@@ -113,25 +113,25 @@ Rectangle{
                 MoneroComponents.TextPlain {
                     id: localNodeHeader
                     anchors.left: localNodeIcon.right
-                    anchors.leftMargin: 14 * scaleRatio
+                    anchors.leftMargin: 14
                     anchors.top: parent.top
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
                     font.bold: true
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: qsTr("Local node") + translationManager.emptyString
                 }
 
                 TextArea {
                     id: localNodeArea
                     anchors.top: localNodeHeader.bottom
-                    anchors.topMargin: 4 * scaleRatio
+                    anchors.topMargin: 4
                     anchors.left: localNodeIcon.right
-                    anchors.leftMargin: 14 * scaleRatio
+                    anchors.leftMargin: 14
                     color: MoneroComponents.Style.dimmedFontColor
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 15 * scaleRatio
+                    font.pixelSize: 15
                     horizontalAlignment: TextInput.AlignLeft
                     selectByMouse: false
                     wrapMode: Text.WordWrap;
@@ -169,7 +169,7 @@ Rectangle{
             Rectangle {
                 id: remoteNodeDivider
                 Layout.fillWidth: true
-                anchors.topMargin: 0 * scaleRatio
+                anchors.topMargin: 0
                 anchors.left: parent.left
                 anchors.right: parent.right
                 height: 1
@@ -199,7 +199,7 @@ Rectangle{
                     height: 32
                     width: 32
                     anchors.left: parent.left
-                    anchors.leftMargin: 16 * scaleRatio
+                    anchors.leftMargin: 16
                     anchors.verticalCenter: parent.verticalCenter
 
                     MoneroEffects.ImageMask {
@@ -218,25 +218,25 @@ Rectangle{
                 MoneroComponents.TextPlain {
                     id: remoteNodeHeader
                     anchors.left: remoteNodeIcon.right
-                    anchors.leftMargin: 14 * scaleRatio
+                    anchors.leftMargin: 14
                     anchors.top: parent.top
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
                     font.bold: true
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: qsTr("Remote node") + translationManager.emptyString
                 }
 
                 TextArea {
                     id: remoteNodeArea
                     anchors.top: remoteNodeHeader.bottom
-                    anchors.topMargin: 4 * scaleRatio
+                    anchors.topMargin: 4
                     anchors.left: remoteNodeIcon.right
-                    anchors.leftMargin: 14 * scaleRatio
+                    anchors.leftMargin: 14
                     color: MoneroComponents.Style.dimmedFontColor
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 15 * scaleRatio
+                    font.pixelSize: 15
                     activeFocusOnPress: false
                     horizontalAlignment: TextInput.AlignLeft
                     selectByMouse: false
@@ -269,7 +269,7 @@ Rectangle{
             Rectangle {
                 id: localNodeBottomDivider
                 Layout.fillWidth: true
-                anchors.topMargin: 0 * scaleRatio
+                anchors.topMargin: 0
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
@@ -282,21 +282,21 @@ Rectangle{
         ColumnLayout {
             id: remoteNodeLayout
             anchors.margins: 0
-            spacing: 20 * scaleRatio
+            spacing: 20
             Layout.fillWidth: true
             Layout.topMargin: 20
             visible: !isMobile && persistentSettings.useRemoteNode
 
             MoneroComponents.WarningBox {
-                Layout.topMargin: 26 * scaleRatio
-                Layout.bottomMargin: 6 * scaleRatio
+                Layout.topMargin: 26
+                Layout.bottomMargin: 6
                 text: qsTr("To find a remote node, type 'Monero remote node' into your favorite search engine. Please ensure the node is run by a trusted third-party.") + translationManager.emptyString
             }
 
             MoneroComponents.RemoteNodeEdit {
                 id: remoteNodeEdit
-                Layout.minimumWidth: 100 * scaleRatio
-                placeholderFontSize: 15 * scaleRatio
+                Layout.minimumWidth: 100
+                placeholderFontSize: 15
 
                 daemonAddrLabelText: qsTr("Address")
                 daemonPortLabelText: qsTr("Port")
@@ -326,9 +326,9 @@ Rectangle{
                     labelText: "Daemon username"
                     text: persistentSettings.daemonUsername
                     placeholderText: qsTr("(optional)") + translationManager.emptyString
-                    placeholderFontSize: 15 * scaleRatio
-                    labelFontSize: 14 * scaleRatio
-                    fontSize: 15 * scaleRatio
+                    placeholderFontSize: 15
+                    labelFontSize: 14
+                    fontSize: 15
                 }
 
                 MoneroComponents.LineEdit {
@@ -338,9 +338,9 @@ Rectangle{
                     text: persistentSettings.daemonPassword
                     placeholderText: qsTr("Password") + translationManager.emptyString
                     echoMode: TextInput.Password
-                    placeholderFontSize: 15 * scaleRatio
-                    labelFontSize: 14 * scaleRatio
-                    fontSize: 15 * scaleRatio
+                    placeholderFontSize: 15
+                    labelFontSize: 14
+                    fontSize: 15
                 }
             }
 
@@ -375,7 +375,7 @@ Rectangle{
 
         ColumnLayout {
             id: localNodeLayout
-            spacing: 20 * scaleRatio
+            spacing: 20
             Layout.topMargin: 40
             visible: !isMobile && !persistentSettings.useRemoteNode
 
@@ -397,12 +397,12 @@ Rectangle{
                     id: blockchainFolder
                     Layout.preferredWidth: 200
                     Layout.fillWidth: true
-                    fontSize: 15 * scaleRatio
-                    labelFontSize: 14 * scaleRatio
+                    fontSize: 15
+                    labelFontSize: 14
                     property string style: "<style type='text/css'>a {cursor:pointer;text-decoration: none; color: #FF6C3C}</style>"
                     labelText: qsTr("Blockchain location") + style + qsTr(" <a href='#'> (change)</a>") + translationManager.emptyString
                     placeholderText: qsTr("(default)") + translationManager.emptyString
-                    placeholderFontSize: 15 * scaleRatio
+                    placeholderFontSize: 15
                     text: {
                         if(persistentSettings.blockchainDataDir.length > 0){
                             return persistentSettings.blockchainDataDir;
@@ -423,12 +423,12 @@ Rectangle{
             MoneroComponents.LineEditMulti {
                 id: daemonFlags
                 Layout.fillWidth: true
-                labelFontSize: 14 * scaleRatio
-                fontSize: 15 * scaleRatio
+                labelFontSize: 14
+                fontSize: 15
                 wrapMode: Text.WrapAnywhere
                 labelText: qsTr("Daemon startup flags") + translationManager.emptyString
                 placeholderText: qsTr("(optional)") + translationManager.emptyString
-                placeholderFontSize: 15 * scaleRatio
+                placeholderFontSize: 15
                 text: persistentSettings.daemonFlags
                 addressValidation: false
                 onEditingFinished: persistentSettings.daemonFlags = daemonFlags.text;
@@ -442,8 +442,8 @@ Rectangle{
 
                     MoneroComponents.RemoteNodeEdit {
                         id: bootstrapNodeEdit
-                        Layout.minimumWidth: 100 * scaleRatio
-                        Layout.bottomMargin: 20 * scaleRatio
+                        Layout.minimumWidth: 100
+                        Layout.bottomMargin: 20
 
                         daemonAddrLabelText: qsTr("Bootstrap Address")
                         daemonPortLabelText: qsTr("Bootstrap Port")

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -41,20 +41,20 @@ Rectangle {
 
     ColumnLayout {
         id: settingsWallet
-        property int itemHeight: 60 * scaleRatio
+        property int itemHeight: 60
         Layout.fillWidth: true
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.margins: (isMobile)? 17 * scaleRatio : 20 * scaleRatio
+        anchors.margins: (isMobile)? 17 : 20
         anchors.topMargin: 0
         spacing: 0
 
         Rectangle {
             // divider
-            Layout.preferredHeight: 1 * scaleRatio
+            Layout.preferredHeight: 1
             Layout.fillWidth: true
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.bottomMargin: 8
             color: MoneroComponents.Style.dividerColor
             opacity: MoneroComponents.Style.dividerOpacity
         }
@@ -71,13 +71,13 @@ Rectangle {
 
                 MoneroComponents.TextPlain {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 20 * scaleRatio
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.preferredHeight: 20
+                    Layout.topMargin: 8
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
                     font.bold: true
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: qsTr("Close this wallet") + translationManager.emptyString
                 }
 
@@ -101,16 +101,16 @@ Rectangle {
                     middlePanel.receiveView.clearFields();
                     appWindow.showWizard();
                 }
-                width: 135 * scaleRatio
+                width: 135
             }
         }
 
         Rectangle {
             // divider
-            Layout.preferredHeight: 1 * scaleRatio
+            Layout.preferredHeight: 1
             Layout.fillWidth: true
-            Layout.topMargin: 8 * scaleRatio
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.topMargin: 8
+            Layout.bottomMargin: 8
             color: MoneroComponents.Style.dividerColor
             opacity: MoneroComponents.Style.dividerOpacity
         }
@@ -128,13 +128,13 @@ Rectangle {
 
                 MoneroComponents.TextPlain {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 20 * scaleRatio
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.preferredHeight: 20
+                    Layout.topMargin: 8
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
                     font.bold: true
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: qsTr("Create a view-only wallet") + translationManager.emptyString
                 }
 
@@ -166,17 +166,17 @@ Rectangle {
                         informationPopup.open()
                     }
                 }
-                width: 135 * scaleRatio
+                width: 135
             }
         }
 
         Rectangle {
             // divider
             visible: !appWindow.viewOnly
-            Layout.preferredHeight: 1 * scaleRatio
+            Layout.preferredHeight: 1
             Layout.fillWidth: true
-            Layout.topMargin: 8 * scaleRatio
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.topMargin: 8
+            Layout.bottomMargin: 8
             color: MoneroComponents.Style.dividerColor
             opacity: MoneroComponents.Style.dividerOpacity
         }
@@ -193,13 +193,13 @@ Rectangle {
 
                 MoneroComponents.TextPlain {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 20 * scaleRatio
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.preferredHeight: 20
+                    Layout.topMargin: 8
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
                     font.bold: true
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: qsTr("Show seed & keys") + translationManager.emptyString
                 }
 
@@ -220,16 +220,16 @@ Rectangle {
                 onClicked: {
                     Utils.showSeedPage();
                 }
-                width: 135 * scaleRatio
+                width: 135
             }
         }
 
         Rectangle {
             // divider
-            Layout.preferredHeight: 1 * scaleRatio
+            Layout.preferredHeight: 1
             Layout.fillWidth: true
-            Layout.topMargin: 8 * scaleRatio
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.topMargin: 8
+            Layout.bottomMargin: 8
             color: MoneroComponents.Style.dividerColor
             opacity: MoneroComponents.Style.dividerOpacity
         }
@@ -247,13 +247,13 @@ Rectangle {
 
                 MoneroComponents.TextPlain {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 20 * scaleRatio
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.preferredHeight: 20
+                    Layout.topMargin: 8
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
                     font.bold: true
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: qsTr("Rescan wallet balance") + translationManager.emptyString
                 }
 
@@ -287,16 +287,16 @@ Rectangle {
                         informationPopup.open();
                     }
                 }
-                width: 135 * scaleRatio
+                width: 135
             }
         }
         Rectangle {
             // divider
             visible: appWindow.walletMode >= 2
-            Layout.preferredHeight: 1 * scaleRatio
+            Layout.preferredHeight: 1
             Layout.fillWidth: true
-            Layout.topMargin: 8 * scaleRatio
-            Layout.bottomMargin: 8 * scaleRatio
+            Layout.topMargin: 8
+            Layout.bottomMargin: 8
             color: MoneroComponents.Style.dividerColor
             opacity: MoneroComponents.Style.dividerOpacity
         }
@@ -313,13 +313,13 @@ Rectangle {
 
                 MoneroComponents.TextPlain {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 20 * scaleRatio
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.preferredHeight: 20
+                    Layout.topMargin: 8
                     color: MoneroComponents.Style.defaultFontColor
                     opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
                     font.bold: true
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     text: qsTr("Change wallet password") + translationManager.emptyString
                 }
 
@@ -353,7 +353,7 @@ Rectangle {
                     passwordDialog.onRejectedCallback = null;
                     passwordDialog.open()
                 }
-                width: 135 * scaleRatio
+                width: 135
             }
         }
     }

--- a/wizard/WizardAskPassword.qml
+++ b/wizard/WizardAskPassword.qml
@@ -79,7 +79,7 @@ ColumnLayout {
         progressText.text = passwordStrengthText + strengthString + translationManager.emptyString;
     }
 
-    spacing: 20 * scaleRatio
+    spacing: 20
 
     WizardHeader{
         title: qsTr("Give your wallet a password") + translationManager.emptyString
@@ -100,21 +100,21 @@ ColumnLayout {
             anchors.top: parent.top
             anchors.topMargin: 6
             font.family: MoneroComponents.Style.fontMedium.name
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             font.bold: false
             color: MoneroComponents.Style.defaultFontColor
             text: root.passwordStrengthText + '-'
-            height: 18 * scaleRatio
+            height: 18
             passwordCharacter: "*"
         }
 
         TextInput {
             id: progressTextValue
             font.family: MoneroComponents.Style.fontMedium.name
-            font.pixelSize: 13 * scaleRatio
+            font.pixelSize: 13
             font.bold: true
             color: MoneroComponents.Style.defaultFontColor
-            height: 18 * scaleRatio
+            height: 18
             passwordCharacter: "*"
         }
 
@@ -123,7 +123,7 @@ ColumnLayout {
             Layout.fillWidth: true
             Layout.preferredHeight: 8
 
-            radius: 8 * scaleRatio
+            radius: 8
             color: MoneroComponents.Style.progressBarBackgroundColor
 
             Rectangle {
@@ -132,7 +132,7 @@ ColumnLayout {
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
                 height: bar.height
-                property int maxWidth: bar.width * scaleRatio
+                property int maxWidth: bar.width
                 width: (maxWidth * root.passwordFill) / 100
                 radius: 8
                 color: MoneroComponents.Style.orange
@@ -142,20 +142,20 @@ ColumnLayout {
                 color: MoneroComponents.Style.defaultFontColor
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
-                anchors.leftMargin: 8 * scaleRatio
+                anchors.leftMargin: 8
             }
         }
     }
 
     ColumnLayout {
-        spacing: 4 * scaleRatio
+        spacing: 4
         Layout.fillWidth: true
 
         Label {
             text: qsTr("Password") + translationManager.emptyString
             Layout.fillWidth: true
 
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             font.family: MoneroComponents.Style.fontLight.name
 
             color: MoneroComponents.Style.defaultFontColor
@@ -164,12 +164,12 @@ ColumnLayout {
         TextField {
             id: passwordInput
 
-            Layout.topMargin: 6 * scaleRatio
+            Layout.topMargin: 6
             Layout.fillWidth: true
 
-            bottomPadding: 10 * scaleRatio
-            leftPadding: 10 * scaleRatio
-            topPadding: 10 * scaleRatio
+            bottomPadding: 10
+            leftPadding: 10
+            topPadding: 10
 
             horizontalAlignment: TextInput.AlignLeft
             verticalAlignment: TextInput.AlignVCenter
@@ -177,7 +177,7 @@ ColumnLayout {
             KeyNavigation.tab: passwordInputConfirm
 
             font.family: MoneroComponents.Style.fontLight.name
-            font.pixelSize: 15 * scaleRatio
+            font.pixelSize: 15
             color: MoneroComponents.Style.defaultFontColor
             selectionColor: MoneroComponents.Style.textSelectionColor
             selectedTextColor: MoneroComponents.Style.textSelectedColor
@@ -212,7 +212,7 @@ ColumnLayout {
             text: qsTr("Password (confirm)") + translationManager.emptyString
             Layout.fillWidth: true
 
-            font.pixelSize: 14 * scaleRatio
+            font.pixelSize: 14
             font.family: MoneroComponents.Style.fontLight.name
 
             color: MoneroComponents.Style.defaultFontColor
@@ -221,12 +221,12 @@ ColumnLayout {
         TextField {
             id : passwordInputConfirm
             
-            Layout.topMargin: 6 * scaleRatio
+            Layout.topMargin: 6
             Layout.fillWidth: true
 
-            bottomPadding: 10 * scaleRatio
-            leftPadding: 10 * scaleRatio
-            topPadding: 10 * scaleRatio
+            bottomPadding: 10
+            leftPadding: 10
+            topPadding: 10
 
             horizontalAlignment: TextInput.AlignLeft
             verticalAlignment: TextInput.AlignVCenter
@@ -234,7 +234,7 @@ ColumnLayout {
             KeyNavigation.tab: passwordInputConfirm
 
             font.family: MoneroComponents.Style.fontLight.name
-            font.pixelSize: 15 * scaleRatio
+            font.pixelSize: 15
             color: MoneroComponents.Style.defaultFontColor
             selectionColor: MoneroComponents.Style.textSelectionColor
             selectedTextColor: MoneroComponents.Style.textSelectedColor

--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -76,8 +76,8 @@ Rectangle {
     property var m_wallet;
     property alias wizardState: wizardStateView.state
     property alias wizardStatePrevious: wizardStateView.previousView
-    property int wizardSubViewWidth: 780 * scaleRatio
-    property int wizardSubViewTopMargin: persistentSettings.customDecorations ? 90 * scaleRatio : 32 * scaleRatio
+    property int wizardSubViewWidth: 780
+    property int wizardSubViewTopMargin: persistentSettings.customDecorations ? 90 : 32
     property bool skipModeSelection: false
 
     // wallet variables

--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -68,7 +68,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("Create a new wallet") + translationManager.emptyString
@@ -82,13 +82,13 @@ Rectangle {
             ColumnLayout {
                 spacing: 0
 
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
 
                 MoneroComponents.RadioButton {
                     id: newDeviceWallet
                     text: qsTr("Create a new wallet from device.") + translationManager.emptyString
-                    fontSize: 16 * scaleRatio
+                    fontSize: 16
                     checked: true
                     onClicked: {
                         checked = true;
@@ -99,9 +99,9 @@ Rectangle {
 
                 MoneroComponents.RadioButton {
                     id: restoreDeviceWallet
-                    Layout.topMargin: 10 * scaleRatio
+                    Layout.topMargin: 10
                     text: qsTr("Restore a wallet from device. Use this if you used your hardware wallet before.") + translationManager.emptyString
-                    fontSize: 16 * scaleRatio
+                    fontSize: 16
                     checked: false
                     onClicked: {
                         checked = true;
@@ -112,18 +112,18 @@ Rectangle {
             }
 
             ColumnLayout {
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
 
-                spacing: 20 * scaleRatio
+                spacing: 20
 
                 MoneroComponents.LineEdit {
                     id: restoreHeight
                     visible: !newDeviceWallet.checked
                     Layout.fillWidth: true
                     labelText: qsTr("Wallet creation date as `YYYY-MM-DD` or restore height") + translationManager.emptyString
-                    labelFontSize: 14 * scaleRatio
-                    placeholderFontSize: 16 * scaleRatio
+                    labelFontSize: 14
+                    placeholderFontSize: 16
                     placeholderText: qsTr("Restore height") + translationManager.emptyString
                     validator: RegExpValidator {
                         regExp: /^(\d+|\d{4}-\d{2}-\d{2})$/
@@ -136,9 +136,9 @@ Rectangle {
                     Layout.fillWidth: true
 
                     labelText: qsTr("Subaddress lookahead (optional)") + translationManager.emptyString
-                    labelFontSize: 14 * scaleRatio
+                    labelFontSize: 14
                     placeholderText: "<major>:<minor>"
-                    placeholderFontSize: 16 * scaleRatio
+                    placeholderFontSize: 16
                     validator: RegExpValidator { regExp: /(\d+):(\d+)?$/ }
                 }
             }
@@ -146,7 +146,7 @@ Rectangle {
             ColumnLayout {
                 spacing: 0
 
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
                 z: 3
 
@@ -155,7 +155,7 @@ Rectangle {
                         id: deviceNameDropdown
                         dataModel: deviceNameModel
                         Layout.fillWidth: true
-                        Layout.topMargin: 6 * scaleRatio
+                        Layout.topMargin: 6
                     }
                 }
             }
@@ -167,7 +167,7 @@ Rectangle {
                 Layout.fillWidth: true
                 font.family: MoneroComponents.Style.fontRegular.name
                 color: MoneroComponents.Style.errorColor
-                font.pixelSize: 16 * scaleRatio
+                font.pixelSize: 16
 
                 selectionColor: MoneroComponents.Style.textSelectionColor
                 selectedTextColor: MoneroComponents.Style.textSelectedColor

--- a/wizard/WizardCreateWallet1.qml
+++ b/wizard/WizardCreateWallet1.qml
@@ -54,7 +54,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("Create a new wallet") + translationManager.emptyString
@@ -68,26 +68,26 @@ Rectangle {
             ColumnLayout {
                 spacing: 0
 
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
 
                 MoneroComponents.LineEditMulti {
                     id: seed
 
                     spacing: 0
-                    inputPaddingLeft: 16 * scaleRatio
-                    inputPaddingRight: 16 * scaleRatio
-                    inputPaddingTop: 20 * scaleRatio
-                    inputPaddingBottom: 20 * scaleRatio
+                    inputPaddingLeft: 16
+                    inputPaddingRight: 16
+                    inputPaddingTop: 20
+                    inputPaddingBottom: 20
                     inputRadius: 0
 
-                    fontSize: 18 * scaleRatio
+                    fontSize: 18
                     fontBold: true
                     wrapMode: Text.WordWrap
                     backgroundColor: "red"
                     addressValidation: false
                     labelText: qsTr("Mnemonic seed") + translationManager.emptyString
-                    labelFontSize: 14 * scaleRatio
+                    labelFontSize: 14
                     copyButton: false
                     readOnly: true
 

--- a/wizard/WizardCreateWallet2.qml
+++ b/wizard/WizardCreateWallet2.qml
@@ -51,7 +51,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 0 * scaleRatio
+            spacing: 0
 
             WizardAskPassword {
                 id: passwordFields

--- a/wizard/WizardCreateWallet3.qml
+++ b/wizard/WizardCreateWallet3.qml
@@ -51,7 +51,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("Daemon settings") + translationManager.emptyString

--- a/wizard/WizardCreateWallet4.qml
+++ b/wizard/WizardCreateWallet4.qml
@@ -52,7 +52,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("You're all set up!") + translationManager.emptyString
@@ -62,7 +62,7 @@ Rectangle {
             WizardSummary {}
 
             WizardNav {
-                Layout.topMargin: 24 * scaleRatio
+                Layout.topMargin: 24
                 btnNextText: qsTr("Open wallet") + translationManager.emptyString
                 progressSteps: 4
                 progress: 4

--- a/wizard/WizardDaemonSettings.qml
+++ b/wizard/WizardDaemonSettings.qml
@@ -38,7 +38,7 @@ ColumnLayout {
     Layout.fillWidth: true
     Layout.maximumWidth: wizardController.wizardSubViewWidth
     Layout.alignment: Qt.AlignHCenter
-    spacing: 10 * scaleRatio
+    spacing: 10
 
     function save(){
         persistentSettings.useRemoteNode = remoteNode.checked
@@ -50,7 +50,7 @@ ColumnLayout {
         id: localNode
         Layout.fillWidth: true
         text: qsTr("Start a node automatically in background (recommended)") + translationManager.emptyString
-        fontSize: 16 * scaleRatio
+        fontSize: 16
         checked: !appWindow.persistentSettings.useRemoteNode && !isAndroid && !isIOS
         visible: !isAndroid && !isIOS
         onClicked: {
@@ -62,9 +62,9 @@ ColumnLayout {
     ColumnLayout {
         id: blockchainFolderRow
         visible: localNode.checked
-        spacing: 20 * scaleRatio
+        spacing: 20
 
-        Layout.topMargin: 8 * scaleRatio
+        Layout.topMargin: 8
         Layout.fillWidth: true
 
         MoneroComponents.LineEdit {
@@ -73,9 +73,9 @@ ColumnLayout {
 
             readOnly: true
             labelText: qsTr("Blockchain location (optional)") + translationManager.emptyString
-            labelFontSize: 14 * scaleRatio
+            labelFontSize: 14
             placeholderText: qsTr("Default") + translationManager.emptyString
-            placeholderFontSize: 15 * scaleRatio
+            placeholderFontSize: 15
             text: persistentSettings.blockchainDataDir
             inlineButton.small: true
             inlineButtonText: qsTr("Browse") + translationManager.emptyString
@@ -88,20 +88,20 @@ ColumnLayout {
         }
 
         ColumnLayout{
-            Layout.topMargin: 6 * scaleRatio
+            Layout.topMargin: 6
             spacing: 0
 
             TextArea {
                 text: qsTr("Bootstrap node") + translationManager.emptyString
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
                 font.family: MoneroComponents.Style.fontRegular.name
                 color: MoneroComponents.Style.defaultFontColor
                 font.pixelSize: {
                     if(wizardController.layoutScale === 2 ){
-                        return 22 * scaleRatio;
+                        return 22;
                     } else {
-                        return 16 * scaleRatio;
+                        return 16;
                     }
                 }
 
@@ -119,7 +119,7 @@ ColumnLayout {
 
             TextArea {
                 text: qsTr("Additionally, you may specify a bootstrap node to use Monero immediately.") + translationManager.emptyString
-                Layout.topMargin: 4 * scaleRatio
+                Layout.topMargin: 4
                 Layout.fillWidth: true
 
                 font.family: MoneroComponents.Style.fontRegular.name
@@ -127,9 +127,9 @@ ColumnLayout {
 
                 font.pixelSize: {
                     if(wizardController.layoutScale === 2 ){
-                        return 16 * scaleRatio;
+                        return 16;
                     } else {
-                        return 14 * scaleRatio;
+                        return 14;
                     }
                 }
 
@@ -152,7 +152,7 @@ ColumnLayout {
 
             MoneroComponents.RemoteNodeEdit {
                 id: bootstrapNodeEdit
-                Layout.minimumWidth: 300 * scaleRatio
+                Layout.minimumWidth: 300
                 //labelText: qsTr("Bootstrap node (leave blank if not wanted)") + translationManager.emptyString
 
                 daemonAddrText: persistentSettings.bootstrapNodeAddress.split(":")[0].trim()
@@ -171,9 +171,9 @@ ColumnLayout {
     MoneroComponents.RadioButton {
         id: remoteNode
         Layout.fillWidth: true
-        Layout.topMargin: 8 * scaleRatio
+        Layout.topMargin: 8
         text: qsTr("Connect to a remote node") + translationManager.emptyString
-        fontSize: 16 * scaleRatio
+        fontSize: 16
         checked: appWindow.persistentSettings.useRemoteNode
         onClicked: {
             checked = true
@@ -183,9 +183,9 @@ ColumnLayout {
 
     ColumnLayout {
         visible: remoteNode.checked
-        spacing: 0 * scaleRatio
+        spacing: 0
 
-        Layout.topMargin: 8 * scaleRatio
+        Layout.topMargin: 8
         Layout.fillWidth: true
 
         MoneroComponents.RemoteNodeEdit {

--- a/wizard/WizardHeader.qml
+++ b/wizard/WizardHeader.qml
@@ -38,7 +38,7 @@ import QtQuick.Controls 2.0
 ColumnLayout {
     property string title: ""
     property string subtitle: ""
-    spacing: 4 * scaleRatio
+    spacing: 4
     Layout.maximumWidth: wizardController.wizardSubViewWidth
 
     TextArea {
@@ -49,9 +49,9 @@ ColumnLayout {
         opacity: MoneroComponents.Style.blackTheme ? 1.0 : 0.8
         font.pixelSize: {
             if(wizardController.layoutScale === 2 ){
-                return 34 * scaleRatio;
+                return 34;
             } else {
-                return 28 * scaleRatio;
+                return 28;
             }
         }
 
@@ -78,9 +78,9 @@ ColumnLayout {
         font.family: MoneroComponents.Style.fontRegular.name
         font.pixelSize: {
             if(wizardController.layoutScale === 2 ){
-                return 16 * scaleRatio;
+                return 16;
             } else {
-                return 14 * scaleRatio;
+                return 14;
             }
         }
 

--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -46,17 +46,17 @@ Rectangle {
         Layout.fillWidth: true
         anchors.horizontalCenter: parent.horizontalCenter;
 
-        spacing: 10 * scaleRatio
+        spacing: 10
 
         ColumnLayout {
             Layout.fillWidth: true
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 0 * scaleRatio
+            spacing: 0
 
             WizardHeader {
-                Layout.bottomMargin: 20 * scaleRatio
+                Layout.bottomMargin: 20
                 title: qsTr("Welcome to Monero.") + translationManager.emptyString
                 subtitle: ""
             }
@@ -75,8 +75,8 @@ Rectangle {
 
             Rectangle {
                 Layout.preferredHeight: 1
-                Layout.topMargin: 3 * scaleRatio
-                Layout.bottomMargin: 3 * scaleRatio
+                Layout.topMargin: 3
+                Layout.bottomMargin: 3
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -95,8 +95,8 @@ Rectangle {
 
             Rectangle {
                 Layout.preferredHeight: 1
-                Layout.topMargin: 3 * scaleRatio
-                Layout.bottomMargin: 3 * scaleRatio
+                Layout.topMargin: 3
+                Layout.bottomMargin: 3
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -114,8 +114,8 @@ Rectangle {
 
             Rectangle {
                 Layout.preferredHeight: 1
-                Layout.topMargin: 3 * scaleRatio
-                Layout.bottomMargin: 3 * scaleRatio
+                Layout.topMargin: 3
+                Layout.bottomMargin: 3
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -134,8 +134,8 @@ Rectangle {
 
             RowLayout {
                 Layout.fillWidth: true
-                Layout.topMargin: 16 * scaleRatio
-                spacing: 20 * scaleRatio
+                Layout.topMargin: 16
+                spacing: 20
 
                 MoneroComponents.StandardButton {
                     small: true
@@ -159,9 +159,9 @@ Rectangle {
 
             MoneroComponents.CheckBox2 {
                 id: showAdvancedCheckbox
-                Layout.topMargin: 30 * scaleRatio
+                Layout.topMargin: 30
                 Layout.fillWidth: true
-                fontSize: 15 * scaleRatio
+                fontSize: 15
                 checked: false
                 text: qsTr("Advanced options") + translationManager.emptyString
                 visible: appWindow.walletMode >= 2
@@ -203,8 +203,8 @@ Rectangle {
                     Layout.fillWidth: true
 
                     labelText: qsTr("Number of KDF rounds:") + translationManager.emptyString
-                    labelFontSize: 14 * scaleRatio
-                    placeholderFontSize: 16 * scaleRatio
+                    labelFontSize: 14
+                    placeholderFontSize: 16
                     placeholderText: "0"
                     validator: IntValidator { bottom: 1 }
                     text: persistentSettings.kdfRounds ? persistentSettings.kdfRounds : "1"

--- a/wizard/WizardLang.qml
+++ b/wizard/WizardLang.qml
@@ -65,8 +65,8 @@ Rectangle {
 
     ColumnLayout {
         anchors.top: parent.top
-        anchors.topMargin: persistentSettings.customDecorations ? 90 * scaleRatio : 32 * scaleRatio
-        width: parent.width - 100 * scaleRatio
+        anchors.topMargin: persistentSettings.customDecorations ? 90 : 32
+        width: parent.width - 100
         anchors.horizontalCenter: parent.horizontalCenter;
 
         TextArea {
@@ -76,9 +76,9 @@ Rectangle {
             color: MoneroComponents.Style.defaultFontColor
             font.pixelSize: {
                 if(langScreen.layoutScale === 2 ){
-                    return 34 * scaleRatio;
+                    return 34;
                 } else {
-                    return 28 * scaleRatio;
+                    return 28;
                 }
             }
 
@@ -104,9 +104,9 @@ Rectangle {
             font.family: MoneroComponents.Style.fontRegular.name
             font.pixelSize: {
                 if(langScreen.layoutScale === 2 ){
-                    return 16 * scaleRatio;
+                    return 16;
                 } else {
-                    return 14 * scaleRatio;
+                    return 14;
                 }
             }
 
@@ -123,11 +123,11 @@ Rectangle {
 
         Flow {
             id: flow
-            height: 800 * scaleRatio
+            height: 800
             Layout.fillWidth: true
-            Layout.topMargin: 20 * scaleRatio
+            Layout.topMargin: 20
 
-            spacing: 5 * scaleRatio
+            spacing: 5
 
             Repeater {
                 model: langModel
@@ -136,25 +136,25 @@ Rectangle {
                     color: "transparent"
                     width: {
                         var minimumWidth = img.width + langRect.width;
-                        if(minimumWidth < 200 * scaleRatio) return 200 * scaleRatio;
+                        if(minimumWidth < 200) return 200;
                         return minimumWidth;
                     }
 
-                    height: 48 * scaleRatio
+                    height: 48
 
                     Rectangle {
                         id: img
                         anchors.top: parent.top
                         color: "transparent"
-                        width: 32 * scaleRatio
+                        width: 32
                         height: parent.height
 
                         Image {
                             source: flag
                             mipmap: true
                             smooth: true
-                            width: 32 * scaleRatio
-                            height: 32 * scaleRatio
+                            width: 32
+                            height: 32
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.horizontalCenter: parent.horizontalCenter
                         }
@@ -166,12 +166,12 @@ Rectangle {
                         anchors.left: img.right
                         color: "transparent"
                         height: parent.height
-                        width: langText.width + 22 * scaleRatio
+                        width: langText.width + 22
 
                         MoneroComponents.TextPlain {
                             id: langText
                             font.bold: true
-                            font.pixelSize: 14 * scaleRatio
+                            font.pixelSize: 14
                             color: MoneroComponents.Style.defaultFontColor
                             text: display_name
                             anchors.verticalCenter: parent.verticalCenter
@@ -211,8 +211,8 @@ Rectangle {
 
         RowLayout {
             Layout.fillWidth: true
-            Layout.topMargin: 32 * scaleRatio
-            spacing: 20 * scaleRatio
+            Layout.topMargin: 32
+            spacing: 20
 
             MoneroComponents.StandardButton {
                 small: true

--- a/wizard/WizardLanguage.qml
+++ b/wizard/WizardLanguage.qml
@@ -46,7 +46,7 @@ Rectangle {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        spacing: 30 * scaleRatio
+        spacing: 30
 
         Rectangle {
             // some margins for the titlebar
@@ -66,7 +66,7 @@ Rectangle {
 
             font.family: MoneroComponents.Style.fontRegular.name
             font.bold: true
-            font.pixelSize: 18 * scaleRatio
+            font.pixelSize: 18
             horizontalAlignment: TextInput.AlignHCenter
             selectByMouse: false
             wrapMode: Text.WordWrap
@@ -110,10 +110,10 @@ Rectangle {
                 visible: !globe.small
                 anchors.left: parent.left
                 anchors.top: parent.top
-                anchors.leftMargin: 117 * scaleRatio
-                anchors.topMargin: 71 * scaleRatio
-                width: 36 * scaleRatio
-                height: 40 * scaleRatio
+                anchors.leftMargin: 117
+                anchors.topMargin: 71
+                width: 36
+                height: 40
                 color: "transparent"
 
                 MouseArea {
@@ -150,13 +150,13 @@ Rectangle {
             opacity: 0
             columns: isMobile ? 1 : 2
             anchors.horizontalCenter: parent.horizontalCenter
-            Layout.topMargin: 20 * scaleRatio
+            Layout.topMargin: 20
             Layout.fillWidth: true
-            columnSpacing: 20 * scaleRatio
+            columnSpacing: 20
 
             MoneroComponents.StandardButton {
                 id: idChangeLang
-                Layout.minimumWidth: 150 * scaleRatio
+                Layout.minimumWidth: 150
                 text: "Language"
 
                 onClicked: {
@@ -166,7 +166,7 @@ Rectangle {
 
             MoneroComponents.StandardButton {
                 id: btnContinue
-                Layout.minimumWidth: 150 * scaleRatio
+                Layout.minimumWidth: 150
                 text: "Continue"
 
                 onClicked: {
@@ -191,7 +191,7 @@ Rectangle {
             opacity: 0
             anchors.horizontalCenter: parent.horizontalCenter
             font.bold: true
-            font.pixelSize: 12 * scaleRatio
+            font.pixelSize: 12
             font.family: MoneroComponents.Style.fontRegular.name
             color: MoneroComponents.Style.defaultFontColor
             text: Version.GUI_VERSION + " (Qt " + qtRuntimeVersion + ")"

--- a/wizard/WizardMenuItem.qml
+++ b/wizard/WizardMenuItem.qml
@@ -37,16 +37,16 @@ import "../components" as MoneroComponents
 RowLayout {
     id: rowlayout
     Layout.fillWidth: true
-    Layout.bottomMargin: 10 * scaleRatio
+    Layout.bottomMargin: 10
     property alias imageIcon: icon.source
     property alias headerText: header.text
     property alias bodyText: body.text
     signal menuClicked();
-    spacing: 10 * scaleRatio
+    spacing: 10
 
     Item {
-        Layout.preferredWidth: 70 * scaleRatio
-        Layout.preferredHeight: 70 * scaleRatio
+        Layout.preferredWidth: 70
+        Layout.preferredHeight: 70
 
         Image {
             id: icon
@@ -93,9 +93,9 @@ RowLayout {
             font.family: MoneroComponents.Style.fontRegular.name
             font.pixelSize: {
                 if(wizardController.layoutScale === 2 ){
-                    return 22 * scaleRatio;
+                    return 22;
                 } else {
-                    return 16 * scaleRatio;
+                    return 16;
                 }
             }
 
@@ -115,12 +115,12 @@ RowLayout {
             font.family: MoneroComponents.Style.fontRegular.name
             font.pixelSize: {
                 if(wizardController.layoutScale === 2 ){
-                    return 16 * scaleRatio;
+                    return 16;
                 } else {
-                    return 14 * scaleRatio;
+                    return 14;
                 }
             }
-            topPadding: 4 * scaleRatio
+            topPadding: 4
             wrapMode: Text.WordWrap
             themeTransition: false
 

--- a/wizard/WizardModeBootstrap.qml
+++ b/wizard/WizardModeBootstrap.qml
@@ -46,14 +46,14 @@ Rectangle {
         Layout.fillWidth: true
         anchors.horizontalCenter: parent.horizontalCenter;
 
-        spacing: 10 * scaleRatio
+        spacing: 10
 
         ColumnLayout {
             Layout.fillWidth: true
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.alignment: Qt.AlignHCenter
-            spacing: 0 * scaleRatio
+            spacing: 0
 
             WizardHeader {
                 title: qsTr("About the bootstrap mode") + translationManager.emptyString
@@ -61,47 +61,47 @@ Rectangle {
             }
 
             ColumnLayout {
-                spacing: 20 * scaleRatio
+                spacing: 20
 
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
 
                 MoneroComponents.TextPlain {
                     text: qsTr("This mode will use a remote node whilst also syncing the blockchain. This is different from the first menu option (Simple mode), since it will only use the remote node until the blockchain is fully synced locally. It is a reasonable tradeoff for most people who care about privacy but also want the convenience of an automatic fallback option.") + translationManager.emptyString
                     wrapMode: Text.Wrap
-                    Layout.topMargin: 14 * scaleRatio
+                    Layout.topMargin: 14
                     Layout.fillWidth: true
 
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     color: MoneroComponents.Style.lightGreyFontColor
                 }
 
                 MoneroComponents.TextPlain {
                     text: qsTr("Temporary use of remote nodes is useful in order to use Monero immediately (hence the name <i>bootstrap</i>), however be aware that when using remote nodes (including with the bootstrap setting), nodes could track your IP address, track your \"restore height\" and associated block request data, and send you inaccurate information to learn more about transactions you make.") + translationManager.emptyString
                     wrapMode: Text.Wrap
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.topMargin: 8
                     Layout.fillWidth: true
 
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     color: MoneroComponents.Style.lightGreyFontColor
                 }
 
                 MoneroComponents.WarningBox{
-                    Layout.topMargin: 14 * scaleRatio
-                    Layout.bottomMargin: 6 * scaleRatio
+                    Layout.topMargin: 14
+                    Layout.bottomMargin: 6
                     text: qsTr("Remain aware of these limitations. <b>Users who prioritize privacy and decentralization must use a full node instead</b>.") + translationManager.emptyString
                 }
 
                 MoneroComponents.TextPlain {
                     text: qsTr("For enhanced node performance you may specify your region:") + translationManager.emptyString
                     wrapMode: Text.Wrap
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.topMargin: 8
                     Layout.fillWidth: true
 
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     color: MoneroComponents.Style.defaultFontColor
                 }
 
@@ -139,8 +139,8 @@ Rectangle {
 
                 MoneroComponents.CheckBox {
                     id: understoodCheckbox
-                    Layout.topMargin: 20 * scaleRatio
-                    fontSize: 16 * scaleRatio
+                    Layout.topMargin: 20
+                    fontSize: 16
                     text: qsTr("I understand the privacy implications of using a third-party server.") + translationManager.emptyString
                     onClicked: {
                         wizardModeBootstrapWarning.understood = !wizardModeBootstrapWarning.understood
@@ -148,7 +148,7 @@ Rectangle {
                 }
 
                 WizardNav {
-                    Layout.topMargin: 4 * scaleRatio
+                    Layout.topMargin: 4
                     btnNext.enabled: wizardModeBootstrapWarning.understood
                     progressSteps: 0
 

--- a/wizard/WizardModeRemoteNodeWarning.qml
+++ b/wizard/WizardModeRemoteNodeWarning.qml
@@ -46,14 +46,14 @@ Rectangle {
         Layout.fillWidth: true
         anchors.horizontalCenter: parent.horizontalCenter;
 
-        spacing: 10 * scaleRatio
+        spacing: 10
 
         ColumnLayout {
             Layout.fillWidth: true
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.alignment: Qt.AlignHCenter
-            spacing: 0 * scaleRatio
+            spacing: 0
 
             WizardHeader {
                 title: qsTr("About the simple mode") + translationManager.emptyString
@@ -61,9 +61,9 @@ Rectangle {
             }
 
             ColumnLayout {
-                spacing: 20 * scaleRatio
+                spacing: 20
 
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
 
                 MoneroComponents.TextPlain {
@@ -71,11 +71,11 @@ Rectangle {
                     themeTransitionBlackColor: MoneroComponents.Style._b_lightGreyFontColor
                     themeTransitionWhiteColor: MoneroComponents.Style._w_lightGreyFontColor
                     wrapMode: Text.Wrap
-                    Layout.topMargin: 14 * scaleRatio
+                    Layout.topMargin: 14
                     Layout.fillWidth: true
 
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     color: MoneroComponents.Style.lightGreyFontColor
                 }
 
@@ -84,28 +84,28 @@ Rectangle {
                     themeTransitionBlackColor: MoneroComponents.Style._b_lightGreyFontColor
                     themeTransitionWhiteColor: MoneroComponents.Style._w_lightGreyFontColor
                     wrapMode: Text.Wrap
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.topMargin: 8
                     Layout.fillWidth: true
 
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     color: MoneroComponents.Style.lightGreyFontColor
                 }
 
                 MoneroComponents.WarningBox {
-                    Layout.topMargin: 14 * scaleRatio
-                    Layout.bottomMargin: 6 * scaleRatio
+                    Layout.topMargin: 14
+                    Layout.bottomMargin: 6
                     text: qsTr("Remain aware of these limitations. <b>Users who prioritize privacy and decentralization must use a full node instead</b>.") + translationManager.emptyString
                 }
 
                 MoneroComponents.TextPlain {
                     text: qsTr("For enhanced node performance you may specify your region:") + translationManager.emptyString
                     wrapMode: Text.Wrap
-                    Layout.topMargin: 8 * scaleRatio
+                    Layout.topMargin: 8
                     Layout.fillWidth: true
 
                     font.family: MoneroComponents.Style.fontRegular.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     color: MoneroComponents.Style.defaultFontColor
                 }
 
@@ -143,8 +143,8 @@ Rectangle {
 
                 MoneroComponents.CheckBox {
                     id: understoodCheckbox
-                    Layout.topMargin: 20 * scaleRatio
-                    fontSize: 16 * scaleRatio
+                    Layout.topMargin: 20
+                    fontSize: 16
                     text: qsTr("I understand the privacy implications of using a third-party server.") + translationManager.emptyString
                     onClicked: {
                         wizardModeRemoteNodeWarning.understood = !wizardModeRemoteNodeWarning.understood
@@ -152,7 +152,7 @@ Rectangle {
                 }
 
                 WizardNav {
-                    Layout.topMargin: 4 * scaleRatio
+                    Layout.topMargin: 4
                     btnNext.enabled: wizardModeRemoteNodeWarning.understood
                     progressSteps: 0
 

--- a/wizard/WizardModeSelection.qml
+++ b/wizard/WizardModeSelection.qml
@@ -46,14 +46,14 @@ Rectangle {
         Layout.fillWidth: true
         anchors.horizontalCenter: parent.horizontalCenter;
 
-        spacing: 10 * scaleRatio
+        spacing: 10
 
         ColumnLayout {
             Layout.fillWidth: true
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.alignment: Qt.AlignHCenter
-            spacing: 0 * scaleRatio
+            spacing: 0
 
             WizardHeader {
                 title: qsTr("Mode selection.") + translationManager.emptyString
@@ -62,7 +62,7 @@ Rectangle {
 
             WizardMenuItem {
                 opacity: appWindow.persistentSettings.nettype == 0 ? 1.0 : 0.5
-                Layout.topMargin: 20 * scaleRatio
+                Layout.topMargin: 20
                 headerText: qsTr("Simple mode") + translationManager.emptyString
                 bodyText: {
                     if(appWindow.persistentSettings.nettype == 0){
@@ -84,8 +84,8 @@ Rectangle {
 
             Rectangle {
                 Layout.preferredHeight: 1
-                Layout.topMargin: 5 * scaleRatio
-                Layout.bottomMargin: 10 * scaleRatio
+                Layout.topMargin: 5
+                Layout.bottomMargin: 10
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -113,8 +113,8 @@ Rectangle {
 
             Rectangle {
                 Layout.preferredHeight: 1
-                Layout.topMargin: 5 * scaleRatio
-                Layout.bottomMargin: 10 * scaleRatio
+                Layout.topMargin: 5
+                Layout.bottomMargin: 10
                 Layout.fillWidth: true
                 color: MoneroComponents.Style.dividerColor
                 opacity: MoneroComponents.Style.dividerOpacity
@@ -132,7 +132,7 @@ Rectangle {
             }
 
             WizardNav {
-                Layout.topMargin: 5 * scaleRatio
+                Layout.topMargin: 5
                 btnPrevText: qsTr("Change language") + translationManager.emptyString
                 btnNext.visible: false
                 progressSteps: 0

--- a/wizard/WizardNav.qml
+++ b/wizard/WizardNav.qml
@@ -42,8 +42,8 @@ GridLayout {
     property alias btnNext: btnNext
     property string btnPrevText: qsTr("Previous") + translationManager.emptyString
     property string btnNextText: qsTr("Next") + translationManager.emptyString
-    Layout.topMargin: 20 * scaleRatio
-    Layout.preferredHeight: 70 * scaleRatio
+    Layout.topMargin: 20
+    Layout.preferredHeight: 70
     Layout.preferredWidth: parent.width
     columns: 3
 

--- a/wizard/WizardNavProgressDot.qml
+++ b/wizard/WizardNavProgressDot.qml
@@ -34,7 +34,7 @@ import "../components" as MoneroComponents
 
 Rectangle {
     property bool active: false
-    Layout.preferredWidth: 30 * scaleRatio
+    Layout.preferredWidth: 30
     Layout.fillHeight: true
     property string activeColor: MoneroComponents.Style.defaultFontColor
     property string inactiveColor: MoneroComponents.Style.progressBarBackgroundColor
@@ -43,9 +43,9 @@ Rectangle {
     Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
-        width: 10 * scaleRatio
-        height: 10 * scaleRatio
-        radius: 10 * scaleRatio
+        width: 10
+        height: 10
+        radius: 10
         color: parent.active ? parent.activeColor : parent.inactiveColor
     }
 }

--- a/wizard/WizardOpenWallet1.qml
+++ b/wizard/WizardOpenWallet1.qml
@@ -67,7 +67,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("Open a wallet from file") + translationManager.emptyString
@@ -75,7 +75,7 @@ Rectangle {
             }
 
             MoneroComponents.StandardButton {
-                Layout.topMargin: 20 * scaleRatio
+                Layout.topMargin: 20
                 id: btnNext
                 small: true
                 text: qsTr("Browse filesystem") + translationManager.emptyString
@@ -87,15 +87,15 @@ Rectangle {
 
             GridLayout {
                 visible: folderModel.count > 0
-                Layout.topMargin: 30 * scaleRatio
+                Layout.topMargin: 30
                 Layout.fillWidth: true
-                columnSpacing: 20 * scaleRatio
+                columnSpacing: 20
                 columns: 2
 
                 MoneroComponents.TextPlain {
                     text: qsTr("Most recent wallets") + translationManager.emptyString
                     font.family: MoneroComponents.Style.fontLight.name
-                    font.pixelSize: 16 * scaleRatio
+                    font.pixelSize: 16
                     color: MoneroComponents.Style.defaultFontColor
                     Layout.fillWidth: true
                 }
@@ -107,14 +107,14 @@ Rectangle {
 
             GridLayout {
                 visible: folderModel.count > 0
-                Layout.topMargin: 10 * scaleRatio
+                Layout.topMargin: 10
                 Layout.fillWidth: true
-                columnSpacing: 20 * scaleRatio
+                columnSpacing: 20
                 columns: 2
 
                 ListView {
                     id: recentList
-                    property int itemHeight: 42 * scaleRatio
+                    property int itemHeight: 42
                     property int maxItems: 7
 
                     clip: true
@@ -125,14 +125,14 @@ Rectangle {
 
                     delegate: Rectangle {
                         height: recentList.itemHeight
-                        width: 200 * scaleRatio
+                        width: 200
                         property string activeColor: "#26FFFFFF"
                         color: "transparent"
 
                         RowLayout {
                             height: recentList.itemHeight
                             width: parent.width
-                            spacing: 10 * scaleRatio
+                            spacing: 10
 
                             Rectangle {
                                 Layout.preferredWidth: recentList.itemHeight
@@ -159,7 +159,7 @@ Rectangle {
                                     anchors.verticalCenter: parent.verticalCenter
                                     font.family: MoneroComponents.Style.fontRegular.name
                                     color: MoneroComponents.Style.defaultFontColor
-                                    font.pixelSize: 18 * scaleRatio
+                                    font.pixelSize: 18
 
                                     selectionColor: MoneroComponents.Style.textSelectionColor
                                     selectedTextColor: MoneroComponents.Style.textSelectedColor
@@ -219,9 +219,9 @@ Rectangle {
             WizardNav {
                 Layout.topMargin: {
                     if(folderModel.count > 0){
-                        return 40 * scaleRatio;
+                        return 40;
                     } else {
-                        return 20 * scaleRatio;
+                        return 20;
                     }
                 }
                 progressEnabled: false

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -99,7 +99,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("Restore wallet") + translationManager.emptyString
@@ -150,14 +150,14 @@ Rectangle {
             ColumnLayout {
                 // seed textarea
                 visible: wizardController.walletRestoreMode === 'seed'
-                Layout.preferredHeight: 100 * scaleRatio
+                Layout.preferredHeight: 100
                 Layout.fillWidth: true
 
                 Rectangle {
                     color: "transparent"
                     radius: 4
 
-                    Layout.preferredHeight: 100 * scaleRatio
+                    Layout.preferredHeight: 100
                     Layout.fillWidth: true
 
                     border.width: 1
@@ -175,14 +175,14 @@ Rectangle {
                         id: seedInput
                         property bool error: false
                         width: parent.width
-                        height: 100 * scaleRatio
+                        height: 100
 
                         color: MoneroComponents.Style.defaultFontColor
-                        textMargin: 2 * scaleRatio
+                        textMargin: 2
                         text: ""
 
                         font.family: MoneroComponents.Style.fontRegular.name
-                        font.pixelSize: 16 * scaleRatio
+                        font.pixelSize: 16
                         selectionColor: MoneroComponents.Style.textSelectionColor
                         selectedTextColor: MoneroComponents.Style.textSelectedColor
                         wrapMode: TextInput.Wrap
@@ -193,9 +193,9 @@ Rectangle {
                             id: memoTextPlaceholder
                             opacity: 0.35
                             anchors.fill:parent
-                            font.pixelSize: 16 * scaleRatio
-                            anchors.margins: 8 * scaleRatio
-                            anchors.leftMargin: 10 * scaleRatio
+                            font.pixelSize: 16
+                            anchors.margins: 8
+                            anchors.leftMargin: 10
                             font.family: MoneroComponents.Style.fontRegular.name
                             text: qsTr("Enter your 25 (or 24) word mnemonic seed") + translationManager.emptyString
                             color: MoneroComponents.Style.defaultFontColor
@@ -209,7 +209,7 @@ Rectangle {
                 id: addressLine
                 visible: wizardController.walletRestoreMode === 'keys'
                 Layout.fillWidth: true
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Account address (public)") + translationManager.emptyString
 
                 onTextUpdated: {
@@ -221,7 +221,7 @@ Rectangle {
                 id: viewKeyLine
                 visible: wizardController.walletRestoreMode === 'keys'
                 Layout.fillWidth: true
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("View key (private)") + translationManager.emptyString
 
                 onTextUpdated: {
@@ -233,7 +233,7 @@ Rectangle {
                 id: spendKeyLine
                 visible: wizardController.walletRestoreMode === 'keys'
                 Layout.fillWidth: true
-                placeholderFontSize: 16 * scaleRatio
+                placeholderFontSize: 16
                 placeholderText: qsTr("Spend key (private)") + translationManager.emptyString
 
                 onTextUpdated: {
@@ -246,8 +246,8 @@ Rectangle {
                     id: restoreHeight
                     Layout.fillWidth: true
                     labelText: qsTr("Wallet creation date as `YYYY-MM-DD` or restore height") + translationManager.emptyString
-                    labelFontSize: 14 * scaleRatio
-                    placeholderFontSize: 16 * scaleRatio
+                    labelFontSize: 14
+                    placeholderFontSize: 16
                     placeholderText: qsTr("Restore height") + translationManager.emptyString
                     validator: RegExpValidator {
                         regExp: /^(\d+|\d{4}-\d{2}-\d{2})$/

--- a/wizard/WizardRestoreWallet2.qml
+++ b/wizard/WizardRestoreWallet2.qml
@@ -54,7 +54,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 0 * scaleRatio
+            spacing: 0
 
             WizardAskPassword {
                 id: passwordFields

--- a/wizard/WizardRestoreWallet3.qml
+++ b/wizard/WizardRestoreWallet3.qml
@@ -59,7 +59,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("Daemon settings") + translationManager.emptyString

--- a/wizard/WizardRestoreWallet4.qml
+++ b/wizard/WizardRestoreWallet4.qml
@@ -52,7 +52,7 @@ Rectangle {
             Layout.topMargin: wizardController.wizardSubViewTopMargin
             Layout.maximumWidth: wizardController.wizardSubViewWidth
             Layout.alignment: Qt.AlignHCenter
-            spacing: 20 * scaleRatio
+            spacing: 20
 
             WizardHeader {
                 title: qsTr("You're all set up!") + translationManager.emptyString
@@ -62,7 +62,7 @@ Rectangle {
             WizardSummary {}
 
             WizardNav {
-                Layout.topMargin: 24 * scaleRatio
+                Layout.topMargin: 24
                 btnNextText: "Open wallet"
                 progressSteps: 4
                 progress: 4

--- a/wizard/WizardSummaryItem.qml
+++ b/wizard/WizardSummaryItem.qml
@@ -47,7 +47,7 @@ ColumnLayout {
 
         Rectangle {
             Layout.fillWidth: true
-            Layout.preferredHeight: 20 * scaleRatio
+            Layout.preferredHeight: 20
             color: "transparent"
 
             MoneroComponents.TextBlock {
@@ -61,7 +61,7 @@ ColumnLayout {
 
         Rectangle {
             Layout.fillWidth: true
-            Layout.preferredHeight: 20 * scaleRatio
+            Layout.preferredHeight: 20
             color: "transparent"
 
             MoneroComponents.TextBlock {
@@ -75,9 +75,9 @@ ColumnLayout {
     }
 
     Rectangle {
-        Layout.preferredHeight: 1 * scaleRatio
-        Layout.topMargin: 2 * scaleRatio
-        Layout.bottomMargin: 2 * scaleRatio
+        Layout.preferredHeight: 1
+        Layout.topMargin: 2
+        Layout.bottomMargin: 2
         Layout.fillWidth: true
         color: MoneroComponents.Style.dividerColor
         opacity: MoneroComponents.Style.dividerOpacity

--- a/wizard/WizardWalletInput.qml
+++ b/wizard/WizardWalletInput.qml
@@ -40,7 +40,7 @@ GridLayout {
     property alias walletName: walletName
     property alias walletLocation: walletLocation
 
-    columnSpacing: 20 * scaleRatio
+    columnSpacing: 20
     columns: 3
 
     function verify() {
@@ -71,8 +71,8 @@ GridLayout {
         }
 
         labelText: qsTr("Wallet name") + translationManager.emptyString
-        labelFontSize: 14 * scaleRatio
-        placeholderFontSize: 16 * scaleRatio
+        labelFontSize: 14
+        placeholderFontSize: 16
         placeholderText: "-"
         text: defaultAccountName
 
@@ -85,9 +85,9 @@ GridLayout {
         Layout.fillWidth: true
 
         labelText: qsTr("Wallet location") + translationManager.emptyString
-        labelFontSize: 14 * scaleRatio
+        labelFontSize: 14
         placeholderText: "..."
-        placeholderFontSize: 16 * scaleRatio
+        placeholderFontSize: 16
         text: moneroAccountsDir + "/"
         inlineButton.small: true
         inlineButtonText: qsTr("Browse") + translationManager.emptyString


### PR DESCRIPTION
Removing `scaleRatio`, it is not needed. To scale the GUI; use environment variable `QT_SCALE_FACTOR`. There is commented code in [main.cpp](https://github.com/monero-project/monero-gui/blob/master/main.cpp#L99) that deals with DPI. And for mobile #2026 is a better idea.

Requires white-theme https://github.com/monero-project/monero-gui/pull/2060