### PR TITLE
[Qt 5.9] Debug QML animations

### DIFF
--- a/filter.cpp
+++ b/filter.cpp
@@ -27,8 +27,13 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "filter.h"
+#include <QtGlobal>
 #include <QKeyEvent>
 #include <QDebug>
+
+#ifdef QT_DEBUG
+    #include "private/qabstractanimation_p.h"
+#endif
 
 filter::filter(QObject *parent) :
     QObject(parent)
@@ -78,6 +83,21 @@ bool filter::eventFilter(QObject *obj, QEvent *ev) {
     } break;
     case QEvent::KeyRelease: {
         QKeyEvent *ke = static_cast<QKeyEvent*>(ev);
+
+#ifdef QT_DEBUG
+        if(ke->key() == Qt::Key_F9){
+            QUnifiedTimer::instance()->setSlowModeEnabled(true);
+            QUnifiedTimer::instance()->setSlowdownFactor(10);
+            qDebug() << "Slow animations enabled";
+        }
+
+        if(ke->key() == Qt::Key_F10){
+            QUnifiedTimer::instance()->setSlowModeEnabled(false);
+            QUnifiedTimer::instance()->setSlowdownFactor(1);
+
+            qDebug() << "Slow animations disabled";
+        }
+#endif
 
         if(ke->key() == Qt::Key_Backtab)
             m_backtabPressed = false;

--- a/monero-wallet-gui.pro
+++ b/monero-wallet-gui.pro
@@ -5,7 +5,7 @@ lessThan (QT_MAJOR_VERSION, 5) | lessThan (QT_MINOR_VERSION, 7) {
 
 TEMPLATE = app
 
-QT += qml quick widgets
+QT += qml gui-private quick widgets
 
 WALLET_ROOT=$$PWD/monero
 


### PR DESCRIPTION
Slow down QML animations by a factor of 10 on `F9`/`F10` for debugging purposes.

Requires white-theme https://github.com/monero-project/monero-gui/pull/2060