### PR TITLE
[Qt 5.9] Back transitions for the wizards

### DIFF
--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -76,6 +76,7 @@ Rectangle {
     property var m_wallet;
     property alias wizardState: wizardStateView.state
     property alias wizardStatePrevious: wizardStateView.previousView
+    property alias wizardStackView: stackView
     property int wizardSubViewWidth: 780
     property int wizardSubViewTopMargin: persistentSettings.customDecorations ? 90 : 32
     property bool skipModeSelection: false
@@ -161,9 +162,6 @@ Rectangle {
                if (typeof previousView.onPageClosed === "function") {
                    previousView.onPageClosed();
                }
-
-               // Combined with NumberAnimation to fade out views
-               previousView.opacity = 0;
             }
 
             if (currentView) {
@@ -172,12 +170,13 @@ Rectangle {
                 if (typeof currentView.onPageCompleted === "function") {
                     currentView.onPageCompleted(previousView);
                 }
-
-                // Combined with NumberAnimation to fade in views
-                currentView.opacity = 1;
             }
 
             previousView = currentView;
+
+            // reset push direction
+            if(wizardController.wizardState == "wizardHome")
+                wizardController.wizardStackView.backTransition = false;
         }
 
         states: [
@@ -286,7 +285,7 @@ Rectangle {
                          PropertyAnimation {
                              target: enterItem
                              property: "x"
-                             from: target.width
+                             from: stackView.backTransition ? -target.width : target.width
                              to: 0
                              duration: 300
                              easing.type: Easing.OutCubic
@@ -295,7 +294,7 @@ Rectangle {
                              target: exitItem
                              property: "x"
                              from: 0
-                             to: 0 - target.width
+                             to: stackView.backTransition ? target.width : -target.width
                              duration: 300
                              easing.type: Easing.OutCubic
                          }

--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -142,6 +142,7 @@ Rectangle {
                     text: qsTr("Change wallet mode") + translationManager.emptyString
 
                     onClicked: {
+                        wizardController.wizardStackView.backTransition = true;
                         wizardController.wizardState = 'wizardModeSelection';
                     }                    
                 }
@@ -152,6 +153,7 @@ Rectangle {
                     text: qsTr("Change language") + translationManager.emptyString
 
                     onClicked: {
+                        wizardController.wizardStackView.backTransition = false;
                         appWindow.toggleLanguageView();
                     }
                 }
@@ -169,7 +171,6 @@ Rectangle {
 
             ListModel {
                 id: networkTypeModel
-                // @TODO: try real enums
                 ListElement {column1: "Mainnet"; column2: ""; nettype: "mainnet"}
                 ListElement {column1: "Testnet"; column2: ""; nettype: "testnet"}
                 ListElement {column1: "Stagenet"; column2: ""; nettype: "stagenet"}

--- a/wizard/WizardLanguage.qml
+++ b/wizard/WizardLanguage.qml
@@ -170,6 +170,7 @@ Rectangle {
                 text: "Continue"
 
                 onClicked: {
+                    wizardController.wizardStackView.backTransition = false;
                     if(wizardController.skipModeSelection){
                         wizardStateView.state = "wizardHome"
                     } else {

--- a/wizard/WizardModeSelection.qml
+++ b/wizard/WizardModeSelection.qml
@@ -126,6 +126,7 @@ Rectangle {
                 imageIcon: "qrc:///images/local-node-full.png"
 
                 onMenuClicked: {
+                    wizardController.wizardStackView.backTransition = false;
                     appWindow.changeWalletMode(2);
                     wizardController.wizardState = 'wizardHome';
                 }
@@ -138,6 +139,7 @@ Rectangle {
                 progressSteps: 0
 
                 onPrevClicked: {
+                    wizardController.wizardStackView.backTransition = true;
                     wizardController.wizardState = 'wizardLanguage';
                 }
             }

--- a/wizard/WizardNav.qml
+++ b/wizard/WizardNav.qml
@@ -50,6 +50,18 @@ GridLayout {
     signal nextClicked;
     signal prevClicked;
 
+    // internal signals
+    signal m_nextClicked;
+    signal m_prevClicked;
+
+    onM_prevClicked: {
+        wizardController.wizardStackView.backTransition = true;
+    }
+
+    onM_nextClicked: {
+        wizardController.wizardStackView.backTransition = false;
+    }
+
     Rectangle {
         Layout.preferredHeight: parent.height
         Layout.fillWidth: true
@@ -64,6 +76,7 @@ GridLayout {
             anchors.verticalCenter: parent.verticalCenter
 
             onClicked: {
+                menuNav.m_prevClicked();
                 menuNav.prevClicked();
             }
         }
@@ -99,6 +112,7 @@ GridLayout {
             anchors.right: parent.right
 
             onClicked: {
+                menuNav.m_nextClicked();
                 menuNav.nextClicked();
             }
         }


### PR DESCRIPTION
Quote from IRC:

> Disco: The fact that *all* screen transitions are swipes from the left is very confusing. Users tend to create a mental map of an apps pages.

This PR changes the transition direction depending on Back/Next in the wizards.

Requires #2060 
Requires #2070 