### PR TITLE
InlineButton: fix warning and set font

### DIFF
--- a/components/InlineButton.qml
+++ b/components/InlineButton.qml
@@ -49,7 +49,7 @@ Item {
     property int rectHMargin: small ? 16 * scaleRatio : 22 * scaleRatio
     property alias text: inlineText.text
     property alias fontPixelSize: inlineText.font.pixelSize
-    property alias fontFamily: inlineText.font
+    property alias fontFamily: inlineText.font.family
     property alias buttonColor: rect.color
     signal clicked()
 

--- a/components/LineEditMulti.qml
+++ b/components/LineEditMulti.qml
@@ -201,7 +201,6 @@ ColumnLayout {
             visible: (inlineButtonId.text || inlineButtonId.icon) && inlineButtonVisible ? true : false
             anchors.right: parent.right
             anchors.rightMargin: 8 * scaleRatio
-            anchors.verticalCenter: parent.verticalCenter
         }
     }
 }


### PR DESCRIPTION
```
2019-04-23 22:03:49.972	W qrc:/components/LineEditMulti.qml:199:9: QML InlineButton: Cannot specify top, bottom, and verticalCenter anchors at the same time.
```