### PR TITLE
SettingsLayout: userInactivitySliderTimer is not defined

### DIFF
--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -40,14 +40,6 @@ Rectangle {
     height: 1400
     Layout.fillWidth: true
 
-    function onPageCompleted() {
-        userInactivitySliderTimer.running = true;
-    }
-
-    function onPageClosed() {
-        userInactivitySliderTimer.running = false;
-    }
-
     ColumnLayout {
         id: settingsUI
         property int itemHeight: 60


### PR DESCRIPTION
```
2019-04-25 21:40:51.062 W qrc:/pages/settings/SettingsLayout.qml:48: ReferenceError: userInactivitySliderTimer is not defined 
```