### PR TITLE
macOS: enable fullscreen support

### DIFF
--- a/components/InputDialog.qml
+++ b/components/InputDialog.qml
@@ -50,7 +50,6 @@ Item {
         leftPanel.enabled = false
         middlePanel.enabled = false
         titleBar.state = "essentials"
-        show()
         root.visible = true;
         input.focus = true;
         input.text = "";

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -86,7 +86,6 @@ Rectangle {
             root.x = parent.width/2 - root.width/2
             root.y = 100
         }
-        show()
         root.z = 11
         root.visible = true;
     }

--- a/js/Windows.js
+++ b/js/Windows.js
@@ -1,5 +1,5 @@
 var flagsCustomDecorations = (Qt.FramelessWindowHint | Qt.CustomizeWindowHint | Qt.WindowSystemMenuHint | Qt.Window);
-var flags = (Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint);
+var flags = (Qt.WindowSystemMenuHint | Qt.Window | Qt.WindowMinimizeButtonHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMaximizeButtonHint | Qt.WindowFullscreenButtonHint);
 
 /**
  * Toggles window decorations


### PR DESCRIPTION
Requires custom decorations turned off.

![Screenshot 2019-04-26 at 01 32 43](https://user-images.githubusercontent.com/7697454/56774505-44ad4300-67c3-11e9-9527-776b9c37e341.png)
