### PR TITLE
wizard: reset remote node when switching network type

### DIFF
--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -195,6 +195,7 @@ Rectangle {
                         } else if(item === "testnet"){
                             persistentSettings.nettype = NetworkType.TESTNET
                         }
+                        appWindow.disconnectRemoteNode()
                     }
                 }
 


### PR DESCRIPTION
Should fix one case of #2017.