### PR TITLE
wizard: fix non-existent property backTransition

### DIFF
--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -287,6 +287,7 @@ Rectangle {
 
             StackView {
                 id: stackView
+                property bool backTransition: false
                 initialItem: wizardStateView.wizardLanguageView
                 anchors.fill: parent
                 clip: true


### PR DESCRIPTION
Error: Cannot assign to non-existent property "backTransition"