### PR TITLE
LeftPanel: don't change font size if balance is hidden

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -226,6 +226,9 @@ Rectangle {
                     text: "N/A"
                     // dynamically adjust text size
                     font.pixelSize: {
+                        if (persistentSettings.hideBalance) {
+                            return 20;
+                        }
                         var digits = text.split('.')[0].length
                         var defaultSize = 22;
                         if(digits > 2) {
@@ -265,6 +268,9 @@ Rectangle {
                     text: "N/A"
                     // dynamically adjust text size
                     font.pixelSize: {
+                        if (persistentSettings.hideBalance) {
+                            return 20;
+                        }
                         var digits = text.split('.')[0].length
                         var defaultSize = 20;
                         if(digits > 3) {


### PR DESCRIPTION
Before:
<img width="289" alt="Screenshot 2019-04-30 at 02 49 12" src="https://user-images.githubusercontent.com/7697454/56935631-a4bd2580-6af2-11e9-8514-af1f5cce7055.png">
After:
<img width="284" alt="Screenshot 2019-04-30 at 02 48 12" src="https://user-images.githubusercontent.com/7697454/56935634-a8e94300-6af2-11e9-9249-ea66aa06969e.png">
