### PR TITLE
Fix wizardcontroller

### DIFF
--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -291,6 +291,8 @@ Rectangle {
                 anchors.fill: parent
                 clip: true
 
+                property bool backTransition: false
+
                 delegate: StackViewDelegate {
                     pushTransition: StackViewTransition {
                          PropertyAnimation {


### PR DESCRIPTION
Current master broken;

`qrc:///wizard/WizardHome.qml:145: Error: Cannot assign to non-existent property "backTransition"`