### PR TITLE
Bootstrap warning text should be richtext

### DIFF
--- a/wizard/WizardModeBootstrap.qml
+++ b/wizard/WizardModeBootstrap.qml
@@ -71,6 +71,7 @@ Rectangle {
                     wrapMode: Text.Wrap
                     Layout.topMargin: 14
                     Layout.fillWidth: true
+                    textFormat: Text.RichText
 
                     font.family: MoneroComponents.Style.fontRegular.name
                     font.pixelSize: 16


### PR DESCRIPTION
Wizard modes -> Bootstrap warning text shows html tag.

![https://i.imgur.com/lgVspKF.png](https://i.imgur.com/lgVspKF.png)