### PR TITLE
Expose get/set attrs for wallet cache in libwalletqt

### DIFF
--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -634,6 +634,15 @@ void Wallet::setPaymentId(const QString &paymentId)
     m_paymentId = paymentId;
 }
 
+QString Wallet::getCacheAttribute(const QString &key) const {
+    return QString::fromStdString(m_walletImpl->getCacheAttribute(key.toStdString()));
+}
+
+bool Wallet::setCacheAttribute(const QString &key, const QString &val)
+{
+    return m_walletImpl->setCacheAttribute(key.toStdString(), val.toStdString());
+}
+
 bool Wallet::setUserNote(const QString &txid, const QString &note)
 {
   return m_walletImpl->setUserNote(txid.toStdString(), note.toStdString());

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -294,6 +294,10 @@ public:
 
     void setPaymentId(const QString &paymentId);
 
+    //! Namespace your cacheAttribute keys to avoid collisions
+    Q_INVOKABLE bool setCacheAttribute(const QString &key, const QString &val);
+    Q_INVOKABLE QString getCacheAttribute(const QString &key) const;
+
     Q_INVOKABLE bool setUserNote(const QString &txid, const QString &note);
     Q_INVOKABLE QString getUserNote(const QString &txid) const;
     Q_INVOKABLE QString getTxKey(const QString &txid) const;


### PR DESCRIPTION
```C++
#include "WalletManager.h"
#include "Wallet.h"

WalletManager *wallet_manager = WalletManager::instance();
Wallet *wallet = wallet_manager->openWallet("/home/foobar/Monero/wallets/foobar/foobar.keys", "passwd", NetworkType::MAINNET);
    
wallet->setCacheAttribute("foo_key", "bar_value");
qDebug() << wallet->getCacheAttribute("foo_key");
```

Requires https://github.com/monero-project/monero/pull/5534