### PR TITLE
WalletManager: async setDaemonAddress

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -256,7 +256,7 @@ ApplicationWindow {
         }
 
         // Local daemon settings
-        walletManager.setDaemonAddress(localDaemonAddress)
+        walletManager.setDaemonAddressAsync(localDaemonAddress);
 
         // enable timers
         userInActivityTimer.running = true;
@@ -608,7 +608,7 @@ ApplicationWindow {
         persistentSettings.useRemoteNode = true;
         currentDaemonAddress = persistentSettings.remoteNodeAddress;
         currentWallet.initAsync(currentDaemonAddress);
-        walletManager.setDaemonAddress(currentDaemonAddress);
+        walletManager.setDaemonAddressAsync(currentDaemonAddress);
         remoteNodeConnected = true;
     }
 
@@ -620,7 +620,7 @@ ApplicationWindow {
         persistentSettings.useRemoteNode = false;
         currentDaemonAddress = localDaemonAddress
         currentWallet.initAsync(currentDaemonAddress);
-        walletManager.setDaemonAddress(currentDaemonAddress);
+        walletManager.setDaemonAddressAsync(currentDaemonAddress);
         remoteNodeConnected = false;
     }
 

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -344,9 +344,11 @@ QString WalletManager::paymentIdFromAddress(const QString &address, NetworkType:
     return QString::fromStdString(Monero::Wallet::paymentIdFromAddress(address.toStdString(), static_cast<Monero::NetworkType>(nettype)));
 }
 
-void WalletManager::setDaemonAddress(const QString &address)
+void WalletManager::setDaemonAddressAsync(const QString &address)
 {
-    m_pimpl->setDaemonAddress(address.toStdString());
+    QtConcurrent::run([this, address] {
+        m_pimpl->setDaemonAddress(address.toStdString());
+    });
 }
 
 bool WalletManager::connected() const

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -150,7 +150,7 @@ public:
 
     Q_INVOKABLE QString paymentIdFromAddress(const QString &address, NetworkType::Type nettype) const;
 
-    Q_INVOKABLE void setDaemonAddress(const QString &address);
+    Q_INVOKABLE void setDaemonAddressAsync(const QString &address);
     Q_INVOKABLE bool connected() const;
     Q_INVOKABLE quint64 networkDifficulty() const;
     Q_INVOKABLE quint64 blockchainHeight() const;


### PR DESCRIPTION
Getting rid of the following lag during wallet initialization:

![monero-gui-lag-setdaemonaddress](https://user-images.githubusercontent.com/26060097/58475684-2cbc3c80-813e-11e9-848e-5987628da141.gif)
