### PR TITLE
WalletManager: non-blocking mining status updates

### DIFF
--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -258,12 +258,16 @@ Rectangle {
         }
     }
 
-    function update() {
+    function onMiningStatus(isMining) {
         var daemonReady = walletManager.isDaemonLocal(appWindow.currentDaemonAddress) && appWindow.daemonSynced
-        appWindow.isMining = walletManager.isMining()
+        appWindow.isMining = isMining;
         updateStatusText()
         startSoloMinerButton.enabled = !appWindow.isMining && daemonReady
         stopSoloMinerButton.enabled = !startSoloMinerButton.enabled && daemonReady
+    }
+
+    function update() {
+        walletManager.miningStatusAsync();
     }
 
     MoneroComponents.StandardDialog {
@@ -285,5 +289,9 @@ Rectangle {
 
     function onPageClosed() {
         timer.running = false
+    }
+
+    Component.onCompleted: {
+        walletManager.miningStatus.connect(onMiningStatus);
     }
 }

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -381,6 +381,13 @@ bool WalletManager::isMining() const
     return m_pimpl->isMining();
 }
 
+void WalletManager::miningStatusAsync() const
+{
+    QtConcurrent::run([this] {
+        emit miningStatus(isMining());
+    });
+}
+
 bool WalletManager::startMining(const QString &address, quint32 threads, bool backgroundMining, bool ignoreBattery)
 {
     if(threads == 0)

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -159,7 +159,7 @@ public:
     Q_INVOKABLE bool localDaemonSynced() const;
     Q_INVOKABLE bool isDaemonLocal(const QString &daemon_address) const;
 
-    Q_INVOKABLE bool isMining() const;
+    Q_INVOKABLE void miningStatusAsync() const;
     Q_INVOKABLE bool startMining(const QString &address, quint32 threads, bool backgroundMining, bool ignoreBattery);
     Q_INVOKABLE bool stopMining();
 
@@ -201,12 +201,16 @@ signals:
     void deviceButtonPressed();
     void walletClosed(const QString &walletAddress);
     void checkUpdatesComplete(const QString &result) const;
+    void miningStatus(bool isMining) const;
 
 public slots:
 private:
     friend class WalletPassphraseListenerImpl;
 
     explicit WalletManager(QObject *parent = 0);
+
+    bool isMining() const;
+
     static WalletManager * m_instance;
     Monero::WalletManager * m_pimpl;
     QMutex m_mutex;


### PR DESCRIPTION
Another blocking call during startup. Also affects Mining tab:

![mining-status-lag](https://user-images.githubusercontent.com/26060097/58630560-55277080-82cf-11e9-83d0-fbebe41b53c5.gif)
