### PR TITLE
get_tx_key fixes for Trezor

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1003,11 +1003,21 @@ ApplicationWindow {
                     ", address: ", address,
                     ", message: ", message);
 
-        var result;
+        function spendProofFallback(txid, result){
+            if (!result || result.indexOf("error|") === 0) {
+                currentWallet.getSpendProofAsync(txid, message, txProofComputed);
+            } else {
+                txProofComputed(txid, result);
+            }
+        }
+
         if (address.length > 0)
-            result = currentWallet.getTxProof(txid, address, message);
-        if (!result || result.indexOf("error|") === 0)
-            result = currentWallet.getSpendProof(txid, message);
+            currentWallet.getTxProofAsync(txid, address, message, spendProofFallback);
+        else
+            spendProofFallback(txid, null);
+    }
+
+    function txProofComputed(txid, result){
         informationPopup.title  = qsTr("Payment proof") + translationManager.emptyString;
         if (result.indexOf("error|") === 0) {
             var errorString = result.split("|")[1];

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1576,16 +1576,16 @@ Rectangle {
 
     function getTxKey(hash, elem){
         if (elem.parent.state != 'ready'){
-            var txKey = currentWallet.getTxKey(hash)
-            elem.parent.text = txKey ? txKey : '-';
-            elem.parent.state = 'ready';
+            currentWallet.getTxKeyAsync(hash, function(hash, txKey) {
+                elem.parent.text = txKey ? txKey : '-';
+                elem.parent.state = 'ready';
+            });
         }
 
         toClipboard(elem.parent.text);
     }
 
     function showTxDetails(hash, paymentId, destinations, subaddrAccount, subaddrIndex){
-        var tx_key = currentWallet.getTxKey(hash)
         var tx_note = currentWallet.getUserNote(hash)
         var rings = currentWallet.getRings(hash)
         var address_label = subaddrIndex == 0 ? (qsTr("Primary address") + translationManager.emptyString) : currentWallet.getSubaddressLabel(subaddrAccount, subaddrIndex)
@@ -1593,10 +1593,12 @@ Rectangle {
         if (rings)
             rings = rings.replace(/\|/g, '\n')
 
-        informationPopup.title = qsTr("Transaction details") + translationManager.emptyString;
-        informationPopup.content = buildTxDetailsString(hash, paymentId, tx_key, tx_note, destinations, rings, address, address_label);
-        informationPopup.onCloseCallback = null
-        informationPopup.open();
+        currentWallet.getTxKeyAsync(hash, function(hash, tx_key) {
+            informationPopup.title = qsTr("Transaction details") + translationManager.emptyString;
+            informationPopup.content = buildTxDetailsString(hash, paymentId, tx_key, tx_note, destinations, rings, address, address_label);
+            informationPopup.onCloseCallback = null
+            informationPopup.open();
+        });
     }
 
     function showTxProof(hash, paymentId, destinations, subaddrAccount, subaddrIndex){

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1099,17 +1099,13 @@ Rectangle {
                             MoneroComponents.TextPlain {
                                 font.family: MoneroComponents.Style.fontRegular.name
                                 font.pixelSize: 15
-                                text: {
-                                    var txKey = currentWallet.getTxKey(hash)
-                                    if(txKey) return txKey;
-                                    else return "-"
-                                }
-
+                                text: qsTr("Click to reveal")
                                 color: MoneroComponents.Style.defaultFontColor
                                 anchors.verticalCenter: parent.verticalCenter
+                                state: "txkey_hidden"
 
                                 MouseArea {
-                                    state: "copyable"
+                                    state: "copyable_txkey"
                                     anchors.fill: parent
                                     hoverEnabled: true
                                     onEntered: parent.color = MoneroComponents.Style.orange
@@ -1200,6 +1196,7 @@ Rectangle {
                             if(res[i].containsMouse === true){
                                 if(res[i].state === 'copyable' && res[i].parent.hasOwnProperty('text')) toClipboard(res[i].parent.text);
                                 if(res[i].state === 'copyable_address') root.toClipboard(address);
+                                if(res[i].state === 'copyable_txkey') root.getTxKey(hash, res[i]);
                                 if(res[i].state === 'set_tx_note') root.editDescription(hash);
                                 if(res[i].state === 'details') root.showTxDetails(hash, paymentId, destinations, subaddrAccount, subaddrIndex);
                                 if(res[i].state === 'proof') root.showTxProof(hash, paymentId, destinations, subaddrAccount, subaddrIndex);
@@ -1575,6 +1572,16 @@ Rectangle {
         } else {
             root.historyStatusMessage = qsTr("%1 transactions total, showing %2.").arg(root.txData.length).arg(txListViewModel.count) + translationManager.emptyString;
         }
+    }
+
+    function getTxKey(hash, elem){
+        if (elem.parent.state != 'ready'){
+            var txKey = currentWallet.getTxKey(hash)
+            elem.parent.text = txKey ? txKey : '-';
+            elem.parent.state = 'ready';
+        }
+
+        toClipboard(elem.parent.text);
     }
 
     function showTxDetails(hash, paymentId, destinations, subaddrAccount, subaddrIndex){

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -33,6 +33,7 @@
 #include <QTime>
 #include <QMutex>
 #include <QList>
+#include <QJSValue>
 #include <QtConcurrent/QtConcurrent>
 
 #include "wallet/api/wallet2_api.h" // we need to have an access to the Monero::Wallet::Status enum here;
@@ -289,10 +290,13 @@ public:
     Q_INVOKABLE bool setUserNote(const QString &txid, const QString &note);
     Q_INVOKABLE QString getUserNote(const QString &txid) const;
     Q_INVOKABLE QString getTxKey(const QString &txid) const;
+    Q_INVOKABLE void getTxKeyAsync(const QString &txid, const QJSValue &ref);
     Q_INVOKABLE QString checkTxKey(const QString &txid, const QString &tx_key, const QString &address);
     Q_INVOKABLE QString getTxProof(const QString &txid, const QString &address, const QString &message) const;
+    Q_INVOKABLE void getTxProofAsync(const QString &txid, const QString &address, const QString &message, const QJSValue &ref);
     Q_INVOKABLE QString checkTxProof(const QString &txid, const QString &address, const QString &message, const QString &signature);
     Q_INVOKABLE QString getSpendProof(const QString &txid, const QString &message) const;
+    Q_INVOKABLE void getSpendProofAsync(const QString &txid, const QString &message, const QJSValue &ref);
     Q_INVOKABLE QString checkSpendProof(const QString &txid, const QString &message, const QString &signature) const;
     // Rescan spent outputs
     Q_INVOKABLE bool rescanSpent();


### PR DESCRIPTION
- do not display tx key for Trezor-based wallets in the Transaction history by default. It required device roundtrip with confirmation which made browsing the history unusable.  
- async behavior: getTxKey, get tx info, get tx proof
- fixes issue https://github.com/monero-project/monero-gui/issues/2183
- fixes the deadlock issues
- requires https://github.com/monero-project/monero/pull/5662 to work correctly (otherwise, zeros are returned, async nature cannot be tested, proofs don't work, etc...). However, it compiles without it and this PR can be merged before the monero-core PR is merged and submodule updated.

<img width="680" alt="Screenshot 2019-06-17 at 16 05 09" src="https://user-images.githubusercontent.com/1052761/59610523-e133f780-9119-11e9-8af9-890ebb010991.png">
