### PR TITLE
NetworkStatusItem: correctly display remote node status

### DIFF
--- a/components/NetworkStatusItem.qml
+++ b/components/NetworkStatusItem.qml
@@ -41,7 +41,7 @@ Rectangle {
         if (status == Wallet.ConnectionStatus_Connected) {
             if(!appWindow.daemonSynced)
                 return qsTr("Synchronizing")
-            if(appWindow.remoteNodeConnected)
+            if(persistentSettings.useRemoteNode)
                 return qsTr("Remote node")
             return appWindow.isMining ? qsTr("Connected") + " + " + qsTr("Mining"): qsTr("Connected")
         }

--- a/main.qml
+++ b/main.qml
@@ -76,7 +76,6 @@ ApplicationWindow {
     property bool isMining: false
     property int walletMode: persistentSettings.walletMode
     property var cameraUi
-    property bool remoteNodeConnected: false
     property bool androidCloseTapped: false;
     property int userLastActive;  // epoch
     // Default daemon addresses
@@ -608,7 +607,6 @@ ApplicationWindow {
         currentDaemonAddress = persistentSettings.remoteNodeAddress;
         currentWallet.initAsync(currentDaemonAddress);
         walletManager.setDaemonAddressAsync(currentDaemonAddress);
-        remoteNodeConnected = true;
     }
 
     function disconnectRemoteNode() {
@@ -620,7 +618,6 @@ ApplicationWindow {
         currentDaemonAddress = localDaemonAddress
         currentWallet.initAsync(currentDaemonAddress);
         walletManager.setDaemonAddressAsync(currentDaemonAddress);
-        remoteNodeConnected = false;
     }
 
     function onHeightRefreshed(bcHeight, dCurrentBlock, dTargetBlock) {


### PR DESCRIPTION
Fixes a bug where it would display “Connected” instead of “Remote node”.

To reproduce:

- Connect to remote node.
- Exit GUI.
- Start GUI again, it now displays “Connected” instead of “Remote node”.