### PR TITLE
Tails: Launcher

### DIFF
--- a/linuxdeploy_helper.sh
+++ b/linuxdeploy_helper.sh
@@ -51,4 +51,12 @@ SCRIPT_DIR="\$(dirname "\$(test -L "\${BASH_SOURCE[0]}" && readlink "\${BASH_SOU
 "\$SCRIPT_DIR"/$GUI_EXEC "\$@"
 EOL
 
+# Create start script
+cat > $TARGET/start-tails.AppImage <<EOL
+#!/bin/bash
+# Silly hack to provide a launcher that is double clickable
+bash ./start-gui.sh
+EOL
+
 chmod +x $TARGET/start-gui.sh
+chmod +x $TARGET/start-tails.AppImage


### PR DESCRIPTION
Tails users are required to start a terminal and issue `./start-gui.sh` manually. Terminals are scary. People like to double click on applications and they open.

Tails is weird; We can `chmod +x` our `start-gui.sh` (bash) or `monero-wallet-gui` (ELF) all we want, they won't be double-clickable.

I've found that filenames that start with `.AppImage` *are* double clickable. We abuse this to create a `start-tails.AppImage` that internally calls `start-gui.sh`.

Improves UX a ton.