### PR TITLE
use XDG_CACHE_DIR for the log file

### DIFF
--- a/Logger.cpp
+++ b/Logger.cpp
@@ -56,8 +56,8 @@ static const QString defaultLogName = "monero-wallet-gui.log";
     static const QString appFolder = "Library/Logs";
 #else // linux + bsd
     //HomeLocation = "~"
-    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
-    static const QString appFolder = ".bitmonero";
+    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::CacheLocation).at(0);
+    static const QString appFolder = "bitmonero";
 #endif
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -152,7 +152,9 @@ int main(int argc, char *argv[])
     QCommandLineOption logPathOption(QStringList() << "l" << "log-file",
         QCoreApplication::translate("main", "Log to specified file"),
         QCoreApplication::translate("main", "file"));
-
+    logPathOption.setDefaultValue(
+        QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+        + "/monero-wallet-gui.log");
     parser.addOption(logPathOption);
     parser.addHelpOption();
     parser.process(app);


### PR DESCRIPTION
I maintain the monero and monero-gui packages in NixOS: this is a patch I have been using and wanted to upstream for quite some time.
I'm not sure about now, but the log defaulted to being written in the same directory of the binary (monero-wallet-gui), which is read-only in NixOS and probably other distribution.
This patch moves the log to the XDG cache directory.