### PR TITLE
SettingsWallet: set trusted daemon before rescan

### DIFF
--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -271,6 +271,7 @@ Rectangle {
                 small: true
                 text: qsTr("Rescan") + translationManager.emptyString
                 onClicked: {
+                    currentWallet.setTrustedDaemon(persistentSettings.is_trusted_daemon)
                     if (!currentWallet.rescanSpent()) {
                         console.error("Error: ", currentWallet.errorString);
                         informationPopup.title = qsTr("Error") + translationManager.emptyString;


### PR DESCRIPTION
When opening the GUI, the trusted daemon flag doesn’t get set properly. Easy fix: set it manually before rescanning.

Reported here: https://monero.stackexchange.com/questions/11512/rescan-ledger-wallet-from-0-in-the-gui