### PR TITLE
TitleBar: change Light Theme icon from 'light bulb' to 'moon'

### DIFF
--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -156,8 +156,8 @@ Rectangle {
             Layout.preferredHeight: parent.height
 
             Text {
-                text: MoneroComponents.Style.blackTheme ? FontAwesome.lightbulbO : FontAwesome.moonO
-                font.family: FontAwesome.fontFamily
+                text: FontAwesome.moonO
+                font.family: MoneroComponents.Style.blackTheme ? FontAwesome.fontFamilySolid : FontAwesome.fontFamily
                 font.pixelSize: 16
                 color: MoneroComponents.Style.defaultFontColor
                 anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
Requires and to be merged after #2372

![light-theme-icon](https://user-images.githubusercontent.com/26060097/64200197-7faf3980-ce7b-11e9-8ed7-fbc6a1f33ede.gif)