### PR TITLE
TitleBar: show wallet name

### DIFF
--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -43,6 +43,7 @@ Rectangle {
     property bool showMinimizeButton: true
     property bool showMaximizeButton: true
     property bool showCloseButton: true
+    property string walletName: ""
 
     height: {
         if(!persistentSettings.customDecorations || isMobile) return 0;
@@ -189,6 +190,7 @@ Rectangle {
 
         // monero logo
         Item {
+            visible: walletName.length === 0
             Layout.fillWidth: true
             Layout.preferredHeight: parent.height
 
@@ -213,6 +215,22 @@ Rectangle {
                 anchors.fill: imgLogo
                 source: imgLogo
                 saturation: 0.0
+            }
+        }
+
+        Item {
+            visible: walletName.length > 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: parent.height
+
+            MoneroComponents.TextPlain {
+                font.pixelSize: 20
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                width: parent.width
+                height: parent.height
+                elide: Text.ElideRight
+                text: walletName
             }
         }
 

--- a/main.qml
+++ b/main.qml
@@ -309,6 +309,7 @@ ApplicationWindow {
         middlePanel.getProofClicked.disconnect(handleGetProof);
         middlePanel.checkProofClicked.disconnect(handleCheckProof);
 
+        appWindow.walletName = "";
         currentWallet = undefined;
 
         appWindow.showProcessingSplash(qsTr("Closing wallet..."));
@@ -1925,6 +1926,7 @@ ApplicationWindow {
         TitleBar {
             id: titleBar
             visible: persistentSettings.customDecorations && middlePanel.state !== "Merchant"
+            walletName: appWindow.walletName
             anchors.left: parent.left
             anchors.right: parent.right
             onCloseClicked: appWindow.close();


### PR DESCRIPTION
Shows the wallet name if a wallet is open, else it will show the current logo + MONERO.
<img width="1026" alt="Screenshot 2019-09-05 at 01 30 48" src="https://user-images.githubusercontent.com/7697454/64300437-03048400-cf7d-11e9-970d-2d1ef3b6f459.png">

Resolves #2325 