### PR TITLE
View only wallet -> warning that balance reflects only incoming transactions

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -756,7 +756,8 @@ Rectangle {
 
         // Currently opened wallet is not view-only
         if(appWindow.viewOnly){
-            root.sendButtonWarning = qsTr("Wallet is view-only and sends are not possible.") + translationManager.emptyString;
+            root.sendButtonWarning = qsTr("Wallet is view-only and sends are not possible. Unless key images are imported, " + 
+                                    "the balance reflects only incoming but not outgoing transactions.") + translationManager.emptyString;
             return false;
         }
 


### PR DESCRIPTION
See discussion here:   #2410 

For view-only wallets change warning from:
`Wallet is view-only and sends are not possible.`
to:
`Wallet is view-only and sends are not possible. Unless key images are imported,
the balance reflects only incoming but not outgoing  transactions.`  

![Updated Warning](https://user-images.githubusercontent.com/55572025/67009540-29751d80-f0ec-11e9-87d9-b27f5ad66d51.png)

