### PR TITLE
ContextMenu: implement 'paste' context menu for all text fields

### DIFF
--- a/components/ContextMenu.qml
+++ b/components/ContextMenu.qml
@@ -1,0 +1,43 @@
+import QtQuick.Controls 2.2
+import QtQuick 2.9
+
+import "../components" as MoneroComponents
+
+MouseArea {
+    signal paste()
+
+    id: root
+    acceptedButtons: Qt.RightButton
+    anchors.fill: parent
+    onClicked: {
+        if (mouse.button === Qt.RightButton)
+            contextMenu.open()
+    }
+
+    Menu {
+        id: contextMenu
+
+        background: Rectangle {
+            radius: 2
+            color: MoneroComponents.Style.buttonInlineBackgroundColor
+        }
+
+        font.family: MoneroComponents.Style.fontRegular.name
+        font.pixelSize: 14
+        width: 50
+        x: root.mouseX
+        y: root.mouseY
+
+        MenuItem {
+            id: pasteItem
+            background: Rectangle {
+                radius: 2
+                color: MoneroComponents.Style.buttonBackgroundColorDisabledHover
+                opacity: pasteItem.down ? 1 : 0
+            }
+            enabled: root.parent.canPaste
+            onTriggered: root.paste()
+            text: qsTr("Paste") + translationManager.emptyString
+        }
+    }
+}

--- a/components/Input.qml
+++ b/components/Input.qml
@@ -32,6 +32,7 @@ import QtQuick 2.9
 import "../components" as MoneroComponents
 
 TextField {
+    id: textField
     font.family: MoneroComponents.Style.fontRegular.name
     font.pixelSize: 18
     font.bold: true
@@ -43,5 +44,12 @@ TextField {
 
     background: Rectangle {
         color: "transparent"
+    }
+
+    MoneroComponents.ContextMenu {
+        onPaste: {
+            textField.clear();
+            textField.paste();
+        }
     }
 }

--- a/components/InputDialog.qml
+++ b/components/InputDialog.qml
@@ -86,7 +86,7 @@ Item {
                 color: MoneroComponents.Style.defaultFontColor
             }
 
-            TextField {
+            MoneroComponents.Input {
                 id : input
                 focus: true
                 Layout.topMargin: 6

--- a/components/InputMulti.qml
+++ b/components/InputMulti.qml
@@ -57,11 +57,22 @@ TextArea {
     onTextChanged: {
         if(addressValidation){
             // js replacement for `RegExpValidator { regExp: /[0-9A-Fa-f]{95}/g }`
+            if (textArea.text.startsWith("monero:")) {
+                error = false;
+                return;
+            }
             textArea.text = textArea.text.replace(/[^a-z0-9.@\-]/gi,'');
             var address_ok = TxUtils.checkAddress(textArea.text, appWindow.persistentSettings.nettype) || TxUtils.isValidOpenAliasAddress(textArea.text);
             if(!address_ok) error = true;
             else error = false;
             TextArea.cursorPosition = textArea.text.length;
+        }
+    }
+
+    MoneroComponents.ContextMenu {
+        onPaste: {
+            textArea.clear();
+            textArea.paste();
         }
     }
 }

--- a/components/LineEditMulti.qml
+++ b/components/LineEditMulti.qml
@@ -80,9 +80,6 @@ ColumnLayout {
     property alias readOnly: input.readOnly
     property bool copyButton: false
     property bool pasteButton: false
-    property var onPaste: function(clipboardText) {
-        item.text = clipboardText;
-    }
     property bool showingHeader: labelText != "" || copyButton || pasteButton
     property var wrapMode: Text.NoWrap
     property alias addressValidation: input.addressValidation
@@ -146,7 +143,10 @@ ColumnLayout {
 
             MoneroComponents.LabelButton {
                 id: pasteButtonId
-                onClicked: item.onPaste(clipboard.text())
+                onClicked: {
+                    input.clear();
+                    input.paste();
+                }
                 text: qsTr("Paste") + translationManager.emptyString
                 visible: pasteButton
             }

--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -187,7 +187,7 @@ Item {
                 text: qsTr("CAPSLOCKS IS ON.") + translationManager.emptyString;
             }
 
-            TextField {
+            MoneroComponents.Input {
                 id: passwordInput1
                 Layout.topMargin: 6
                 Layout.fillWidth: true
@@ -296,7 +296,7 @@ Item {
                 color: MoneroComponents.Style.defaultFontColor
             }
 
-            TextField {
+            MoneroComponents.Input {
                 id: passwordInput2
                 visible: !passwordDialogMode
                 Layout.topMargin: 6

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -325,8 +325,8 @@ Rectangle {
                 wrapMode: Text.WrapAnywhere
                 addressValidation: true
                 pasteButton: true
-                onPaste: function(clipboardText) {
-                    const parsed = walletManager.parse_uri_to_object(clipboardText);
+                onTextChanged: {
+                    const parsed = walletManager.parse_uri_to_object(addressLine.text);
                     if (!parsed.error) {
                         addressLine.text = parsed.address;
                         descriptionLine.text = parsed.tx_description;

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -257,18 +257,14 @@ Rectangle {
                   appWindow.showPageRequest("AddressBook");
               }
               pasteButton: true
-              onPaste: function(clipboardText) {
-                  const parsed = walletManager.parse_uri_to_object(clipboardText);
+              onTextChanged: {
+                  const parsed = walletManager.parse_uri_to_object(text);
                   if (!parsed.error) {
                     addressLine.text = parsed.address;
                     setPaymentId(parsed.payment_id);
                     amountLine.text = parsed.amount;
                     setDescription(parsed.tx_description);
-                  } else {
-                     addressLine.text = clipboardText; 
                   }
-              }
-              onTextChanged: {
                   warningLongPidTransfer = isLongPidService(text);
               }
               inlineButton.text: FontAwesome.qrcode

--- a/pages/merchant/Merchant.qml
+++ b/pages/merchant/Merchant.qml
@@ -455,7 +455,7 @@ Item {
                         width: 220
                         source: "qrc:///images/merchant/input_box.png"
 
-                        TextField {
+                        MoneroComponents.Input {
                             id: amountToReceive
                             topPadding: 0
                             leftPadding: 10

--- a/qml.qrc
+++ b/qml.qrc
@@ -21,6 +21,7 @@
         <file>pages/History.qml</file>
         <file>pages/AddressBook.qml</file>
         <file>pages/Mining.qml</file>
+        <file>components/ContextMenu.qml</file>
         <file>components/NetworkStatusItem.qml</file>
         <file>components/Input.qml</file>
         <file>components/StandardButton.qml</file>

--- a/wizard/WizardAskPassword.qml
+++ b/wizard/WizardAskPassword.qml
@@ -150,7 +150,7 @@ ColumnLayout {
             color: MoneroComponents.Style.defaultFontColor
         }
 
-        TextField {
+        MoneroComponents.Input {
             id: passwordInput
 
             Layout.topMargin: 6
@@ -207,7 +207,7 @@ ColumnLayout {
             color: MoneroComponents.Style.defaultFontColor
         }
 
-        TextField {
+        MoneroComponents.Input {
             id : passwordInputConfirm
             
             Layout.topMargin: 6

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -185,7 +185,7 @@ Rectangle {
                         }
                     }
 
-                    TextArea {
+                    MoneroComponents.InputMulti {
                         id: seedInput
                         property bool error: false
                         width: parent.width


### PR DESCRIPTION
Fixes #2359
Partially addresses #2405

![context-menu-paste](https://user-images.githubusercontent.com/26060097/68445409-c8fc6c00-01d1-11ea-896d-58649707ee8a.gif)
