### PR TITLE
Windows installer: Bump version from 0.15.0.0 to 0.15.0.1

### DIFF
--- a/installers/windows/Monero.iss
+++ b/installers/windows/Monero.iss
@@ -8,7 +8,7 @@ AppName=Monero GUI Wallet
 ; Thus it's important to keep this stable over releases
 ; With a different "AppName" InnoSetup would treat a mere update as a completely new application and thus mess up
 
-AppVersion=0.15.0.0
+AppVersion=0.15.0.1
 DefaultDirName={pf}\Monero GUI Wallet
 DefaultGroupName=Monero GUI Wallet
 UninstallDisplayIcon={app}\monero-wallet-gui.exe
@@ -58,7 +58,7 @@ Name: "en"; MessagesFile: "compiler:Default.isl"
 ; .exe/.dll file possibly with version info).
 ;
 ; This is far more robust than relying on version info or on file dates (flag "comparetimestamp").
-; As of version 0.15.0.0, the Monero .exe files do not carry version info anyway in their .exe headers.
+; As of version 0.15.0.1, the Monero .exe files do not carry version info anyway in their .exe headers.
 ; The only small drawback seems to be somewhat longer update times because each and every file is
 ; copied again, even if already present with correct file date and identical content.
 ;

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -40,7 +40,7 @@ The build steps in detail:
 
 1. Install *Inno Setup*. You can get it from [here](http://www.jrsoftware.org/isdl.php)
 2. Get the Inno Setup script plus related files by cloning the whole [monero-gui GitHub repository](https://github.com/monero-project/monero-gui); you will only need the files in the installer directory `installers\windows` however. Depending on development state, additionally instead of simply using `master` you may have to checkout a specific branch, like `release-v0.15`.
-3. The setup script is written to take the GUI wallet files from a subdirectory named `bin`; so create `installers\windows\bin`, get the zip file of the GUI wallet from [here](https://getmonero.org/downloads/), unpack it somewhere, and copy all the files and subdirectories in the single subdirectory there (currently named `monero-gui-0.15.0.0`) to this `bin` subdirectory
+3. The setup script is written to take the GUI wallet files from a subdirectory named `bin`; so create `installers\windows\bin`, get the zip file of the GUI wallet from [here](https://getmonero.org/downloads/), unpack it somewhere, and copy all the files and subdirectories in the single subdirectory there (currently named `monero-gui-0.15.0.1`) to this `bin` subdirectory
 4. Start Inno Setup, load `Monero.iss` and compile it
 5. The result i.e. the finished installer will be the file `mysetup.exe` in the `installers\windows\Output` subdirectory 
 

--- a/installers/windows/ReadMe.htm
+++ b/installers/windows/ReadMe.htm
@@ -7,7 +7,7 @@
 <h1>Monero Carbon Chamaeleon GUI Wallet</h1>
 
   <p>Copyright (c) 2014-2019, The Monero Project<br>
-  Date: November 1, 2019</p>
+  Date: November 11, 2019</p>
 
 <h2>Preface</h2>
 
@@ -23,7 +23,7 @@
 
 <h2>Content of the Package</h2>
 
-  <p>You just installed the <i>Monero GUI wallet</i> for Windows, release Carbon Chamaeleon, version 0.15.0.0.
+  <p>You just installed the <i>Monero GUI wallet</i> for Windows, release Carbon Chamaeleon, version 0.15.0.1.
   The wallet enables you to send and receive Moneroj in a secure and very private way.
   </p>
 


### PR DESCRIPTION
I still have no good idea how incorporating the current version number into installer files could be automated with reasonable effort.