### PR TITLE
wizard: remove wizard specific languages variables

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -212,12 +212,6 @@ ApplicationWindow {
         else
           walletManager.setLogLevel(persistentSettings.logLevel)
 
-        // setup language
-        var locale = persistentSettings.locale
-        if (locale !== "") {
-            translationManager.setLanguage(locale.split("_")[0]);
-        }
-
         // Reload transfer page with translations enabled
         middlePanel.transferView.onPageCompleted();
 
@@ -1363,8 +1357,9 @@ ApplicationWindow {
             return "";
         }
 
-        property string language
-        property string locale
+        property string language: 'English (US)'
+        property string locale: 'en_US'
+        property string language_wallet: 'English'
         property string account_name
         property string wallet_path
         property bool   auto_donations_enabled : false
@@ -1817,11 +1812,6 @@ ApplicationWindow {
         middlePanel.visible = !middlePanel.visible;
         languageView.visible = !languageView.visible
         resetLanguageFields()
-        // update after changing language from settings page
-        if (persistentSettings.language != wizard.language_language) {
-            persistentSettings.language = wizard.language_language
-            persistentSettings.locale   = wizard.language_locale
-        }
     }
 
     // TODO: Make the callback dynamic

--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -107,11 +107,6 @@ Rectangle {
     property bool   walletOptionsDeviceIsRestore: false
     property string tmpWalletFilename: ''
 
-    // language settings, updated via sidebar
-    property string language_locale: 'en_US'
-    property string language_wallet: 'English'
-    property string language_language: 'English (US)'
-
     // recovery made (restore wallet)
     property string walletRestoreMode: 'seed'  // seed, keys, qr
 
@@ -343,7 +338,7 @@ Rectangle {
         console.log("Creating temporary wallet", tmp_wallet_filename)
         var nettype = appWindow.persistentSettings.nettype;
         var kdfRounds = appWindow.persistentSettings.kdfRounds;
-        var wallet = walletManager.createWallet(tmp_wallet_filename, "", wizardController.language_wallet, nettype, kdfRounds)
+        var wallet = walletManager.createWallet(tmp_wallet_filename, "", appWindow.persistentSettings.language_wallet, nettype, kdfRounds)
 
         wizardController.walletOptionsSeed = wallet.seed
 
@@ -378,10 +373,6 @@ Rectangle {
         // Store password in session to be able to use password protected functions (e.g show seed)
         appWindow.walletPassword = walletOptionsPassword
 
-        // save to persistent settings
-        persistentSettings.language = wizardController.language_language
-        persistentSettings.locale   = wizardController.language_locale
-
         persistentSettings.account_name = wizardController.walletOptionsName
         persistentSettings.wallet_path = new_wallet_filename
         persistentSettings.restore_height = (isNaN(walletOptionsRestoreHeight))? 0 : walletOptionsRestoreHeight
@@ -408,7 +399,7 @@ Rectangle {
         if(wizardController.walletRestoreMode === 'seed')
             wallet = walletManager.recoveryWallet(tmp_wallet_filename, wizardController.walletOptionsSeed, nettype, restoreHeight, kdfRounds)
         else
-            wallet = walletManager.createWalletFromKeys(tmp_wallet_filename, wizardController.language_wallet, nettype,
+            wallet = walletManager.createWalletFromKeys(tmp_wallet_filename, appWindow.persistentSettings.language_wallet, nettype,
                                                             wizardController.walletOptionsRecoverAddress, wizardController.walletOptionsRecoverViewkey,
                                                             wizardController.walletOptionsRecoverSpendkey, restoreHeight, kdfRounds)
 
@@ -557,6 +548,9 @@ Rectangle {
     }
 
     Component.onCompleted: {
-        //
+        var locale = appWindow.persistentSettings.locale
+        if (locale !== "") {
+            translationManager.setLanguage(locale.split("_")[0]);
+        }
     }
 }

--- a/wizard/WizardLang.qml
+++ b/wizard/WizardLang.qml
@@ -188,9 +188,9 @@ Rectangle {
                             translationManager.setLanguage(locale_spl[0]);
 
                             // set wizard language settings
-                            wizard.language_locale = locale;
-                            wizard.language_wallet = wallet_language;
-                            wizard.language_language = display_name + " (" + locale_spl[1] + ") ";
+                            appWindow.persistentSettings.locale = locale;
+                            appWindow.persistentSettings.language_wallet = wallet_language;
+                            appWindow.persistentSettings.language = display_name + " (" + locale_spl[1] + ") ";
 
                             appWindow.showStatusMessage(qsTr("Language changed."), 3);
                             appWindow.toggleLanguageView();

--- a/wizard/WizardSummary.qml
+++ b/wizard/WizardSummary.qml
@@ -54,7 +54,7 @@ ColumnLayout {
     WizardSummaryItem {
         Layout.fillWidth: true
         header: qsTr("Language") + translationManager.emptyString
-        value: wizardController.language_language
+        value: appWindow.persistentSettings.language
     }
 
     WizardSummaryItem {


### PR DESCRIPTION
Fixes #2478

The first time I ran this patch my persistent storage got wiped so it’s most likely not correct.