### PR TITLE
History: don't hide 'Export all history' if there ain't any txes

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1315,7 +1315,7 @@ Rectangle {
             }
 
             MoneroComponents.StandardButton {
-                visible: !isIOS && root.txCount > 0
+                visible: !isIOS
                 small: true
                 text: qsTr("Export all history") + translationManager.emptyString
                 onClicked: {


### PR DESCRIPTION
To be merged after #2614

Shouldn't hide any functionality from a user that just set up a wallet.

A newbie observing Monero GUI wallet for the first time should learn that such a functionality exists and could be used in the future.