### PR TITLE
fix dropdown closure behavior

### DIFF
--- a/components/DatePicker.qml
+++ b/components/DatePicker.qml
@@ -251,6 +251,7 @@ Item {
     QtQuickControls2.Popup {
         id: popup
         padding: 0
+        closePolicy: QtQuickControls2.Popup.CloseOnEscape | QtQuickControls2.Popup.CloseOnPressOutsideParent
 
         Rectangle {
             id: calendarRect

--- a/components/StandardDropdown.qml
+++ b/components/StandardDropdown.qml
@@ -126,6 +126,7 @@ Item {
     Popup {
         id: popup
         padding: 0
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
         Rectangle {
             id: droplist


### PR DESCRIPTION
Clicking on parent will now properly close dropdown.