### PR TITLE
[Qt 5.14] main: enable high DPI scaling

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -170,11 +170,8 @@ int main(int argc, char *argv[])
     if (isDesktop) putenv((char*)"QT_QPA_PLATFORM=xcb");
 #endif
 
-//    // Enable high DPI scaling on windows & linux
-//#if !defined(Q_OS_ANDROID) && QT_VERSION >= 0x050600
-//    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-//    qDebug() << "High DPI auto scaling - enabled";
-//#endif
+    // enable High DPI scaling
+    qputenv("QT_ENABLE_HIGHDPI_SCALING", "1");
 
     // Turn off colors in monerod log output.
     qputenv("TERM", "goaway");


### PR DESCRIPTION
Tested on Ubuntu, someone has to test it on Windows. Requires Qt 5.14.