### PR TITLE
Scrollbar: don't autohide if enabled (except on Mac)

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -196,6 +196,7 @@ Rectangle {
                 anchors.topMargin: persistentSettings.customDecorations ? 60 : 10
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: persistentSettings.customDecorations ? 15 : 10
+                onActiveChanged: if (!active && !isMac) active = true
             }
 
             onFlickingChanged: {

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -124,7 +124,9 @@ Rectangle {
             Flickable {
                 id: flickable
                 anchors.fill: parent
-                ScrollBar.vertical: ScrollBar { }
+                ScrollBar.vertical: ScrollBar {
+                    onActiveChanged: if (!active && !isMac) active = true
+                }
                 boundsBehavior: isMac ? Flickable.DragAndOvershootBounds : Flickable.StopAtBounds
 
                 TextArea.flickable: TextArea {

--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -150,6 +150,7 @@ Rectangle {
             Flickable {
                 id: flickable
                 anchors.fill: parent
+                boundsBehavior: isMac ? Flickable.DragAndOvershootBounds : Flickable.StopAtBounds
 
                 TextArea.flickable: TextArea {
                     id : consoleArea
@@ -203,7 +204,9 @@ Rectangle {
                     }
                 }
 
-                ScrollBar.vertical: ScrollBar {}
+                ScrollBar.vertical: ScrollBar {
+                    onActiveChanged: if (!active && !isMac) active = true
+                }
             }
         }
 

--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -277,6 +277,7 @@ Rectangle {
                 anchors.topMargin: persistentSettings.customDecorations ? 60 : 10
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: persistentSettings.customDecorations ? 15 : 10
+                onActiveChanged: if (!active && !isMac) active = true
             }
 
             onFlickingChanged: {


### PR DESCRIPTION
closes #2662

Unfortunately there seems to be no better way to do this.
`ScrollBar.AsNeeded` will autohide and `ScrollBar.AlwaysOn` will always display the scrollbar, even when not needed.