### PR TITLE
FutureScheduler: drop moveToThread, setParent might silently fail

### DIFF
--- a/src/qt/FutureScheduler.h
+++ b/src/qt/FutureScheduler.h
@@ -32,12 +32,6 @@ private:
     QFutureWatcher<T> *newWatcher()
     {
         QFutureWatcher<T> *watcher = new QFutureWatcher<T>();
-        QThread *schedulerThread = this->thread();
-        if (watcher->thread() != schedulerThread)
-        {
-            watcher->moveToThread(schedulerThread);
-        }
-        watcher->setParent(this);
 
         return watcher;
     }


### PR DESCRIPTION
The last patch of crash-related fixes, finally closes https://github.com/monero-project/monero-gui/issues/2483