### PR TITLE
History: add filter options in search field placeholder

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -156,7 +156,7 @@ Rectangle {
                 input.bottomPadding: 6
                 fontSize: 16
                 labelFontSize: 14
-                placeholderText: qsTr("Search...") + translationManager.emptyString
+                placeholderText: qsTr("Search by Transaction ID, Address, Description, Amount or Blockheight") + translationManager.emptyString
                 placeholderFontSize: 16
                 inputHeight: 34
                 onTextUpdated: {


### PR DESCRIPTION
Closes #2628

Add filter options in search field placeholder: "Search by Transaction ID, Address, Description, Amount or Blockheight"

Currently only destination address is supported in search, but I decided to use "Address" (see issue #2705 for adding receiving address as search option)