### PR TITLE
Remove paste buttons

### DIFF
--- a/pages/Sign.qml
+++ b/pages/Sign.qml
@@ -187,7 +187,6 @@ Rectangle {
                     readOnly: false
                     onTextChanged: signSignatureLine.text = ''
                     wrapMode: Text.WrapAnywhere
-                    pasteButton: true
                 }
             }
 
@@ -302,7 +301,6 @@ Rectangle {
                 readOnly: false
                 wrapMode: Text.WrapAnywhere
                 text: ''
-                pasteButton: true
             }
 
             RowLayout {
@@ -344,7 +342,6 @@ Rectangle {
                 placeholderText: qsTr("Enter the Monero Address (example: 44AFFq5kSiGBoZ...)") + translationManager.emptyString
                 wrapMode: Text.WrapAnywhere
                 text: ''
-                pasteButton: true
             }
 
             MoneroComponents.LineEditMulti {
@@ -354,7 +351,6 @@ Rectangle {
                 placeholderFontSize: 16
                 placeholderText: qsTr("Enter the signature to verify") + translationManager.emptyString
                 Layout.fillWidth: true
-                pasteButton: true
                 wrapMode: Text.WrapAnywhere
                 text: ''
             }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -255,7 +255,6 @@ Rectangle {
                   middlePanel.addressBookView.selectAndSend = true;
                   appWindow.showPageRequest("AddressBook");
               }
-              pasteButton: true
               onTextChanged: {
                   const parsed = walletManager.parse_uri_to_object(text);
                   if (!parsed.error) {


### PR DESCRIPTION
Remove all paste buttons, cleaning UI.

Users can still paste from clipboard by right clicking on text fields.

After:
![image](https://user-images.githubusercontent.com/45968869/72319819-f4428200-367e-11ea-8a6e-0a8913ab12bb.png)

Before:
![image](https://user-images.githubusercontent.com/45968869/72319808-ebea4700-367e-11ea-8502-bf48c8d2dbd4.png)
