### PR TITLE
History: address filter case insensitive

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1382,7 +1382,7 @@ Rectangle {
             if(root.sortSearchString.length >= 1){
                 if(item.amount && item.amount.toString().startsWith(root.sortSearchString)){
                     txs.push(item);
-                } else if(item.address !== "" && item.address.startsWith(root.sortSearchString)){
+                } else if(item.address !== "" && item.address.toLowerCase().startsWith(root.sortSearchString.toLowerCase())){
                     txs.push(item);
                 } else if(item.blockheight.toString().startsWith(root.sortSearchString)) {
                     txs.push(item);


### PR DESCRIPTION
Closes #2743

Case sensitive is only needed when sending a transaction. When you are searching for an address in transaction history, it is better to have a case insensitive filter.

