### PR TITLE
Keys: stop displaying hardware device message in view-only wallets

### DIFF
--- a/pages/Keys.qml
+++ b/pages/Keys.qml
@@ -281,7 +281,7 @@ Rectangle {
                 secretSpendKey.text = qsTr("(View Only Wallet - No secret spend key available)") + translationManager.emptyString
             }
             // hardware device wallet
-            if(currentWallet.seed === "") {
+            if(appWindow.currentWallet.isHwBacked() === true) {
                 showFullQr.visible = false
                 viewOnlyQRCode.visible = true
                 showViewOnlyQr.visible = false


### PR DESCRIPTION
Closes #2686