### PR TITLE
[WIP] Transfer: redesign transaction flow

### DIFF
--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -46,7 +46,9 @@ Rectangle {
     property alias cancelVisible: cancelButton.visible
     property alias okVisible: okButton.visible
     property alias textArea: dialogContent
+    property alias okButton: okButton
     property alias okText: okButton.text
+    property alias cancelButton: cancelButton
     property alias cancelText: cancelButton.text
     property alias closeVisible: closeButton.visible
 


### PR DESCRIPTION
Closes #2467

After:
![image](https://user-images.githubusercontent.com/45968869/73599416-9699ab00-4543-11ea-97da-72d6505d4458.png)

Before:
![image](https://user-images.githubusercontent.com/45968869/73356182-08e76280-429a-11ea-9de1-dc56c321e20e.png)

Changes:
* Added blur behind the transaction confirmation popup
* Added From: (spending Wallet & Account)
* Amount with larger font
* Amount and fee: removed extra zeros at the end + "XMR" suffix + fiat conversion
* Buttons have the same width
* "Cancel" button renamed to "Back"
* "Ok" button renamed to "Confirm" + confirm icon
* Removed payment ID, ring size, transaction count and spending address(es) index(es)