### PR TITLE
History: display Address Book names for known destination addresses

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -633,7 +633,17 @@ Rectangle {
                                 MoneroComponents.TextPlain {
                                     font.family: MoneroComponents.Style.fontRegular.name
                                     font.pixelSize: 15
-                                    text: isout ? qsTr("Sent") : qsTr("Received") + translationManager.emptyString
+                                    text: {
+                                        if (!isout) {
+                                            return qsTr("Received") + translationManager.emptyString;
+                                        }
+                                        const addressBookName = currentWallet ? currentWallet.addressBook.getDescription(address) : null;
+                                        if (!addressBookName)
+                                        {
+                                            return qsTr("Sent") + translationManager.emptyString;
+                                        }
+                                        return addressBookName;
+                                    }
                                     color: MoneroComponents.Style.historyHeaderTextColor
                                     anchors.verticalCenter: parent.verticalCenter
                                     themeTransitionBlackColor: MoneroComponents.Style._b_historyHeaderTextColor

--- a/src/libwalletqt/AddressBook.cpp
+++ b/src/libwalletqt/AddressBook.cpp
@@ -55,8 +55,10 @@ void AddressBook::getAll()
     {
         QWriteLocker locker(&m_lock);
 
+        m_addresses.clear();
         m_rows.clear();
         for (auto &abr: m_addressBookImpl->getAll()) {
+            m_addresses.insert(QString::fromStdString(abr->getAddress()), m_rows.size());
             m_rows.append(abr);
         }
     }
@@ -127,4 +129,16 @@ int AddressBook::lookupPaymentID(const QString &payment_id) const
     QReadLocker locker(&m_lock);
 
     return m_addressBookImpl->lookupPaymentID(payment_id.toStdString());
+}
+
+QString AddressBook::getDescription(const QString &address) const
+{
+    QReadLocker locker(&m_lock);
+
+    const QMap<QString, size_t>::const_iterator it = m_addresses.find(address);
+    if (it == m_addresses.end())
+    {
+        return {};
+    }
+    return QString::fromStdString(m_rows.value(*it)->getDescription());
 }

--- a/src/libwalletqt/AddressBook.h
+++ b/src/libwalletqt/AddressBook.h
@@ -30,6 +30,7 @@
 #define ADDRESSBOOK_H
 
 #include <wallet/api/wallet2_api.h>
+#include <QMap>
 #include <QObject>
 #include <QReadWriteLock>
 #include <QList>
@@ -51,6 +52,7 @@ public:
     Q_INVOKABLE QString errorString() const;
     Q_INVOKABLE int errorCode() const;
     Q_INVOKABLE int lookupPaymentID(const QString &payment_id) const;
+    Q_INVOKABLE QString getDescription(const QString &address) const;
 
     enum ErrorCode {
         Status_Ok,
@@ -76,7 +78,8 @@ private:
     friend class Wallet;
     Monero::AddressBook * m_addressBookImpl;
     mutable QReadWriteLock m_lock;
-    mutable QList<Monero::AddressBookRow*> m_rows;
+    QList<Monero::AddressBookRow*> m_rows;
+    QMap<QString, size_t> m_addresses;
 };
 
 #endif // ADDRESSBOOK_H

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -74,7 +74,7 @@ class Wallet : public QObject
     Q_PROPERTY(TransactionHistorySortFilterModel * historyModel READ historyModel NOTIFY historyModelChanged)
     Q_PROPERTY(QString path READ path)
     Q_PROPERTY(AddressBookModel * addressBookModel READ addressBookModel)
-    Q_PROPERTY(AddressBook * addressBook READ addressBook)
+    Q_PROPERTY(AddressBook * addressBook READ addressBook NOTIFY addressBookChanged)
     Q_PROPERTY(SubaddressModel * subaddressModel READ subaddressModel)
     Q_PROPERTY(Subaddress * subaddress READ subaddress)
     Q_PROPERTY(SubaddressAccountModel * subaddressAccountModel READ subaddressAccountModel)
@@ -357,6 +357,7 @@ signals:
     void moneyReceived(const QString &txId, quint64 amount);
     void unconfirmedMoneyReceived(const QString &txId, quint64 amount);
     void newBlock(quint64 height, quint64 targetHeight);
+    void addressBookChanged() const;
     void historyModelChanged() const;
     void walletCreationHeightChanged();
     void deviceButtonRequest(quint64 buttonCode);


### PR DESCRIPTION
Closes https://github.com/monero-project/monero-gui/issues/2757

![monero-gui-history-names](https://user-images.githubusercontent.com/26060097/74588626-06a13a00-4ff6-11ea-98c8-31a10089472c.png)
