### PR TITLE
Simple mode: don't override bootstrap daemon textbox

### DIFF
--- a/components/NetworkStatusItem.qml
+++ b/components/NetworkStatusItem.qml
@@ -163,7 +163,7 @@ Rectangle {
                 visible: (
                     !appWindow.disconnected &&
                     !persistentSettings.useRemoteNode &&
-                    persistentSettings.bootstrapNodeAddress == "auto"
+                    (persistentSettings.bootstrapNodeAddress == "auto" || persistentSettings.walletMode < 2)
                 )
 
                 MouseArea {

--- a/main.qml
+++ b/main.qml
@@ -675,7 +675,8 @@ ApplicationWindow {
 
         appWindow.showProcessingSplash(qsTr("Waiting for daemon to start..."))
         const noSync = appWindow.walletMode === 0;
-        daemonManager.start(flags, persistentSettings.nettype, persistentSettings.blockchainDataDir, persistentSettings.bootstrapNodeAddress, noSync);
+        const bootstrapNodeAddress = persistentSettings.walletMode < 2 ? "auto" : persistentSettings.bootstrapNodeAddress
+        daemonManager.start(flags, persistentSettings.nettype, persistentSettings.blockchainDataDir, bootstrapNodeAddress, noSync);
     }
 
     function stopDaemon(){
@@ -2079,7 +2080,6 @@ ApplicationWindow {
     function applyWalletMode(mode){
         if (mode < 2) {
             persistentSettings.useRemoteNode = false;
-            persistentSettings.bootstrapNodeAddress = "auto";
 
             if (middlePanel.settingsView.settingsStateViewState === "Node" || middlePanel.settingsView.settingsStateViewState === "Log") {
                 middlePanel.settingsView.settingsStateViewState = "Wallet"


### PR DESCRIPTION
I’ve read a few reports of people being confused when switching from simple to advanced mode, as they have to manually remove `auto` from the bootstrap daemon textbox.

E.g. https://www.reddit.com/r/Monero/comments/f4oj9a/advanced_mode_in_gui_but_still_bootstrapping/