### PR TITLE
Transfer: add Address Book inline button + improvements in Address Book

### DIFF
--- a/components/InlineButton.qml
+++ b/components/InlineButton.qml
@@ -53,6 +53,7 @@ Item {
     property alias fontPixelSize: inlineText.font.pixelSize
     property alias fontFamily: inlineText.font.family
     property alias buttonColor: rect.color
+    property alias buttonHeight: rect.height
     signal clicked()
 
     function doClick() {

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -67,25 +67,11 @@ Rectangle {
             spacing: 0
             Layout.fillWidth: true
 
-            Text {
+            MoneroComponents.Label {
                 id: titleLabel
-                Layout.fillWidth: true
-                color: MoneroComponents.Style.defaultFontColor
-                font.family: MoneroComponents.Style.fontRegular.name
-                font.pixelSize: 32
-                horizontalAlignment: TextInput.AlignLeft
-                wrapMode: Text.WordWrap;
-                leftPadding: 0
-                topPadding: 0
+                Layout.bottomMargin: 20
+                fontSize: 32
                 text: qsTr("Save your most used addresses here") + translationManager.emptyString
-                width: parent.width
-
-                // @TODO: Legacy. Remove after Qt 5.8.
-                // https://stackoverflow.com/questions/41990013
-                MouseArea {
-                   anchors.fill: parent
-                   enabled: false
-                }
             }
 
             Text {
@@ -108,12 +94,24 @@ Rectangle {
                 }
             }
 
-            MoneroComponents.StandardButton {
-                id: addFirstEntryButton
-                Layout.topMargin: 20
-                text: qsTr("Add an address") + translationManager.emptyString
-                onClicked: {
-                    root.showAddAddress();
+            RowLayout {
+                MoneroComponents.StandardButton {
+                    id: backButton2
+                    Layout.topMargin: 20
+                    text: qsTr("Back") + translationManager.emptyString
+                    visible: root.selectAndSend
+                    onClicked: {
+                        appWindow.showPageRequest("Transfer");
+                    }
+                }
+
+                MoneroComponents.StandardButton {
+                    id: addFirstEntryButton
+                    Layout.topMargin: 20
+                    text: qsTr("Add an address") + translationManager.emptyString
+                    onClicked: {
+                        root.showAddAddress();
+                    }
                 }
             }
         }
@@ -129,12 +127,34 @@ Rectangle {
                 text: qsTr("Address book") + translationManager.emptyString
             }
 
+            Text {
+                Layout.fillWidth: true
+                visible: root.selectAndSend
+                color: MoneroComponents.Style.dimmedFontColor
+                font.family: MoneroComponents.Style.fontRegular.name
+                font.pixelSize: 16
+                horizontalAlignment: TextInput.AlignLeft
+                wrapMode: Text.WordWrap;
+                leftPadding: 0
+                topPadding: 0
+                text: qsTr("Select an address from your Address Book") + translationManager.emptyString
+                width: parent.width
+
+                // @TODO: Legacy. Remove after Qt 5.8.
+                // https://stackoverflow.com/questions/41990013
+                MouseArea {
+                    anchors.fill: parent
+                    enabled: false
+                }
+            }
+
             ColumnLayout {
                 id: addressBookListRow
                 property int addressBookListItemHeight: 50
                 Layout.fillWidth: true
                 Layout.minimumWidth: 240
                 Layout.preferredHeight: addressBookListItemHeight * addressBookListView.count
+                Layout.topMargin: root.selectAndSend ? 20 : 0
 
                 ListView {
                     id: addressBookListView
@@ -291,7 +311,17 @@ Rectangle {
                 }
             }
 
+            MoneroComponents.StandardButton {
+                id: backButton
+                Layout.topMargin: 20
+                text: qsTr("Back") + translationManager.emptyString
+                visible: root.selectAndSend
+                onClicked: {
+                    appWindow.showPageRequest("Transfer");
+                }
+            }
         }
+        
         ColumnLayout {
             id: addContactLayout
             visible: false

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -260,10 +260,9 @@ Rectangle {
           LineEditMulti {
               id: addressLine
               spacing: 0
+              inputPaddingRight: 60
               fontBold: true
-              labelText: qsTr("<style type='text/css'>a {text-decoration: none; color: #858585; font-size: 14px;}</style>\
-                Address <font size='2'>  ( </font> <a href='#'>Address book</a><font size='2'> )</font>")
-                + translationManager.emptyString
+              labelText: qsTr("Address") + translationManager.emptyString
               labelButtonText: qsTr("Resolve") + translationManager.emptyString
               placeholderText: {
                   if(persistentSettings.nettype == NetworkType.MAINNET){
@@ -276,10 +275,6 @@ Rectangle {
               }
               wrapMode: Text.WrapAnywhere
               addressValidation: true
-              onInputLabelLinkActivated: {
-                  middlePanel.addressBookView.selectAndSend = true;
-                  appWindow.showPageRequest("AddressBook");
-              }
               onTextChanged: {
                   const parsed = walletManager.parse_uri_to_object(text);
                   if (!parsed.error) {
@@ -289,16 +284,28 @@ Rectangle {
                     setDescription(parsed.tx_description);
                   }
               }
-              inlineButton.text: FontAwesome.qrcode
+              //@TODO: add 2nd inlineButton when adding QR code scanner
+              //inlineButton.text: FontAwesome.qrcode
+              //inlineButton.fontPixelSize: 22
+              //inlineButton.fontFamily: FontAwesome.fontFamily
+              //inlineButton.textColor: MoneroComponents.Style.defaultFontColor
+              //inlineButton.buttonColor: MoneroComponents.Style.orange
+              //inlineButton.onClicked: {
+              //    cameraUi.state = "Capture"
+              //    cameraUi.qrcode_decoded.connect(updateFromQrCode)
+              //}
+              //inlineButtonVisible : appWindow.qrScannerEnabled && !addressLine.text
+
+              inlineButton.text: FontAwesome.addressBook
+              inlineButton.buttonHeight: 30
               inlineButton.fontPixelSize: 22
               inlineButton.fontFamily: FontAwesome.fontFamily
               inlineButton.textColor: MoneroComponents.Style.defaultFontColor
-              inlineButton.buttonColor: MoneroComponents.Style.orange
               inlineButton.onClicked: {
-                  cameraUi.state = "Capture"
-                  cameraUi.qrcode_decoded.connect(updateFromQrCode)
+                  middlePanel.addressBookView.selectAndSend = true;
+                  appWindow.showPageRequest("AddressBook");
               }
-              inlineButtonVisible : appWindow.qrScannerEnabled && !addressLine.text
+              inlineButtonVisible: true
           }
       }
 


### PR DESCRIPTION
Changes:
- Remove "(Address Book)" link from address field label
- Add address book inline button with icon + adjust right margin of address field
- Adjust margins for titles and subtitles of Address Book subpages
- Add "Select an address from your Address Book" subtitle + "Back" button when address book is called from Transfer page

Before:
![image](https://user-images.githubusercontent.com/45968869/74615485-8f68c480-5121-11ea-8d21-d29d857ff58c.png)

After:
![inlineaddressbutton](https://user-images.githubusercontent.com/45968869/74615392-993df800-5120-11ea-86d3-d7797d9c8044.gif)
