### PR TITLE
installers: fix warning

### DIFF
--- a/installers/windows/Monero.iss
+++ b/installers/windows/Monero.iss
@@ -11,7 +11,7 @@ AppName=Monero GUI Wallet
 
 AppVersion={#GuiVersion}
 VersionInfoVersion={#GuiVersion}
-DefaultDirName={pf}\Monero GUI Wallet
+DefaultDirName={commonpf}\Monero GUI Wallet
 DefaultGroupName=Monero GUI Wallet
 UninstallDisplayIcon={app}\monero-wallet-gui.exe
 PrivilegesRequired=admin


### PR DESCRIPTION
```
Warning: Constant "pf" has been renamed. Use "commonpf" instead or consider using its "auto" form.
```