### PR TITLE
Transfer: add Address Book inline button in Address field

### DIFF
--- a/components/InlineButton.qml
+++ b/components/InlineButton.qml
@@ -53,6 +53,7 @@ Item {
     property alias fontPixelSize: inlineText.font.pixelSize
     property alias fontFamily: inlineText.font.family
     property alias buttonColor: rect.color
+    property alias buttonHeight: rect.height
     signal clicked()
 
     function doClick() {

--- a/components/LineEditMulti.qml
+++ b/components/LineEditMulti.qml
@@ -87,6 +87,8 @@ ColumnLayout {
 
     property alias inlineButton: inlineButtonId
     property bool inlineButtonVisible: false
+    property alias inlineButton2: inlineButton2Id
+    property bool inlineButton2Visible: false
 
     signal labelButtonClicked();
     signal inputLabelLinkActivated();
@@ -201,6 +203,13 @@ ColumnLayout {
             visible: (inlineButtonId.text || inlineButtonId.icon) && inlineButtonVisible ? true : false
             anchors.right: parent.right
             anchors.rightMargin: 8
+        }
+        
+        MoneroComponents.InlineButton {
+            id: inlineButton2Id
+            visible: (inlineButton2Id.text || inlineButton2Id.icon) && inlineButton2Visible ? true : false
+            anchors.right: parent.right
+            anchors.rightMargin: inlineButtonVisible ? 48 : 8
         }
     }
 }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -307,10 +307,9 @@ Rectangle {
           LineEditMulti {
               id: addressLine
               spacing: 0
+              inputPaddingRight: inlineButtonVisible && inlineButton2Visible ? 100 : 60
               fontBold: true
-              labelText: qsTr("<style type='text/css'>a {text-decoration: none; color: #858585; font-size: 14px;}</style>\
-                %1 <a href='#'>(%2)</a>").arg(qsTr("Address")).arg(qsTr("Address book"))
-                + translationManager.emptyString
+              labelText: qsTr("Address") + translationManager.emptyString
               labelButtonText: qsTr("Resolve") + translationManager.emptyString
               placeholderText: {
                   if(persistentSettings.nettype == NetworkType.MAINNET){
@@ -323,10 +322,6 @@ Rectangle {
               }
               wrapMode: Text.WrapAnywhere
               addressValidation: true
-              onInputLabelLinkActivated: {
-                  middlePanel.addressBookView.selectAndSend = true;
-                  appWindow.showPageRequest("AddressBook");
-              }
               onTextChanged: {
                   const parsed = walletManager.parse_uri_to_object(text);
                   if (!parsed.error) {
@@ -336,16 +331,27 @@ Rectangle {
                     setDescription(parsed.tx_description);
                   }
               }
-              inlineButton.text: FontAwesome.qrcode
+              inlineButton.text: FontAwesome.addressBook
+              inlineButton.buttonHeight: 30
               inlineButton.fontPixelSize: 22
               inlineButton.fontFamily: FontAwesome.fontFamily
               inlineButton.textColor: MoneroComponents.Style.defaultFontColor
-              inlineButton.buttonColor: MoneroComponents.Style.orange
               inlineButton.onClicked: {
-                  cameraUi.state = "Capture"
-                  cameraUi.qrcode_decoded.connect(updateFromQrCode)
+                  middlePanel.addressBookView.selectAndSend = true;
+                  appWindow.showPageRequest("AddressBook");
               }
-              inlineButtonVisible : appWindow.qrScannerEnabled && !addressLine.text
+              inlineButtonVisible: true
+              
+              inlineButton2.text: FontAwesome.qrcode
+              inlineButton2.buttonHeight: 30
+              inlineButton2.fontPixelSize: 22
+              inlineButton2.fontFamily: FontAwesome.fontFamily
+              inlineButton2.textColor: MoneroComponents.Style.defaultFontColor
+              inlineButton2.onClicked: {
+                   cameraUi.state = "Capture"
+                   cameraUi.qrcode_decoded.connect(updateFromQrCode)
+              }
+              inlineButton2Visible: appWindow.qrScannerEnabled
           }
       }
 


### PR DESCRIPTION
Changes:
- Remove "(Address Book)" link from address field label
- Add address book inline button with icon + adjust right margin of address field
- Add second inline button (scan QR code button)
- Change color of scan QR code button

Address book inline button as single inline button:
![inlineaddressbutton3](https://user-images.githubusercontent.com/45968869/79452368-58f7da80-7fe8-11ea-98c3-55b14d4d515e.gif)

With scan QR code button enabled:
![inlinewithqrcode](https://user-images.githubusercontent.com/45968869/79451962-ac1d5d80-7fe7-11ea-811d-40ca56ded457.gif)
