### PR TITLE
Save wallet on money received

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -735,6 +735,8 @@ ApplicationWindow {
 
         if(middlePanel.state == "History")
             middlePanel.historyView.update();
+
+        currentWallet.store();
     }
 
     function onWalletUnconfirmedMoneyReceived(txId, amount) {


### PR DESCRIPTION
Displaying an accurate balance is fundamental to the concept of a wallet, and it is therefore imperative that the balance shown when the wallet is exited is always the same amount that is shown when the wallet is opened.

I've about had it with helping people that write anxiety ridden reports about "losing" their balance and fearing that it got stolen / lost / disappeared into the void because they forcefully closed their wallet / it crashed before it got saved.

I've tried to argue for wallet consistency (for subaddresses and accounts) before in #2639, but balance is more important.

The wallet is already saved after sending a transaction, but not after receiving one. This PR saves the wallet whenever money is received.