### PR TITLE
Transfer: redesign advanced options

### DIFF
--- a/components/AdvancedOptionsItem.qml
+++ b/components/AdvancedOptionsItem.qml
@@ -1,0 +1,106 @@
+import QtQuick 2.9
+import QtQuick.Layouts 1.1
+import FontAwesome 1.0
+
+import "../components" as MoneroComponents
+
+RowLayout {
+    id: advancedOptionsItem
+    
+    property alias title: title.text
+    property alias button1: button1
+    property alias button2: button2
+    property alias button3: button3
+    property alias helpTextLarge: helpTextLarge
+    property alias helpTextSmall: helpTextSmall
+      
+    RowLayout {
+        id: titlecolumn
+        Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+        Layout.preferredWidth: 195
+        Layout.maximumWidth: 195
+        Layout.leftMargin: 10
+
+        MoneroComponents.Label {
+            id: title
+            fontSize: 14
+        }
+
+        MoneroComponents.Label {
+            id: iconLabel
+            fontSize: 12
+            text: FontAwesome.questionCircle
+            fontFamily: FontAwesome.fontFamily
+            opacity: 0.3
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: helpText.visible = !helpText.visible
+                onEntered: parent.opacity = 0.4
+                onExited: parent.opacity = 0.3
+            }  
+        }
+        
+        Rectangle {
+            id: separator
+            Layout.fillWidth: true
+            height: 10
+            color: "transparent"
+        }
+    }
+
+    ColumnLayout {
+        Layout.fillWidth: false
+        Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+        spacing: 4
+                
+        RowLayout {
+            Layout.fillWidth: false
+            spacing: 12
+            Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+            
+            StandardButton {
+                id: button1
+                small: true
+                visible: button1.text
+            }
+    
+            StandardButton {
+                id: button2
+                small: true
+                visible: button2.text
+            }
+            
+            StandardButton {
+                id: button3
+                small: true
+                visible: button3.text
+            }
+        }
+        
+        ColumnLayout {
+            id: helpText
+            visible: false     
+            Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+            
+            MoneroComponents.TextPlain {
+                id: helpTextLarge
+                visible: helpTextLarge.text
+                font.family: MoneroComponents.Style.fontRegular.name
+                font.pixelSize: 13
+                color: MoneroComponents.Style.defaultFontColor
+            }
+            
+            MoneroComponents.TextPlain {
+                id: helpTextSmall
+                visible: helpTextSmall.text
+                Layout.leftMargin: 5
+                textFormat: Text.RichText
+                font.family: MoneroComponents.Style.fontRegular.name
+                font.pixelSize: 12
+                color: MoneroComponents.Style.defaultFontColor
+            }
+        }
+    }
+}

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -514,10 +514,9 @@ Rectangle {
         id: advancedLayout
         anchors.top: pageRoot.bottom
         anchors.left: parent.left
-        anchors.right: parent.right
         anchors.margins: 20
         anchors.topMargin: 32
-        spacing: 26
+        spacing: 10
         enabled: !viewOnly || pageRoot.enabled
 
         RowLayout {
@@ -532,84 +531,88 @@ Rectangle {
             }
         }
 
-        GridLayout {
+        AdvancedOptionsItem {
             visible: persistentSettings.transferShowAdvanced && appWindow.walletMode >= 2
-            columns: 6
-
-            StandardButton {
-                id: sweepUnmixableButton
-                text: qsTr("Sweep Unmixable") + translationManager.emptyString
-                enabled : pageRoot.enabled
-                small: true
-                onClicked: {
-                    console.log("Transfer: sweepUnmixableClicked")
-                    root.sweepUnmixableClicked()
-                }
+            title: qsTr("Key images") + translationManager.emptyString
+            button1.text: qsTr("Export") + translationManager.emptyString
+            button1.enabled: !appWindow.viewOnly
+            button1.onClicked: {
+                console.log("Transfer: export key images clicked")
+                exportKeyImagesDialog.open();
             }
-
-            StandardButton {
-                id: saveTxButton
-                text: qsTr("Create tx file") + translationManager.emptyString
-                visible: appWindow.viewOnly
-                enabled: pageRoot.checkInformation(amountLine.text, addressLine.text, appWindow.persistentSettings.nettype)
-                small: true
-                onClicked: {
-                    console.log("Transfer: saveTx Clicked")
-                    var priority = priorityModelV5.get(priorityDropdown.currentIndex).priority
-                    console.log("priority: " + priority)
-                    console.log("amount: " + amountLine.text)
-                    addressLine.text = addressLine.text.trim()
-                    setPaymentId(paymentIdLine.text.trim());
-                    root.paymentClicked(addressLine.text, paymentIdLine.text, amountLine.text, root.mixin, priority, descriptionLine.text)
-
-                }
+            button2.text: qsTr("Import") + translationManager.emptyString
+            button2.enabled: appWindow.viewOnly && appWindow.isTrustedDaemon()
+            button2.onClicked: {
+                console.log("Transfer: import key images clicked")
+                importKeyImagesDialog.open(); 
             }
+            helpTextLarge.text: qsTr("Required for view-only wallets to display the real balance") + translationManager.emptyString
+            helpTextSmall.text: {
+                var errorMessage = "";
+                if (appWindow.viewOnly && !appWindow.isTrustedDaemon()){
+                    errorMessage = "<p class='orange'>" + qsTr("* To import, you must connect to a local node or a trusted remote node") + "</p>";
+                }
+                return "<style type='text/css'>p{line-height:20px; margin-top:0px; margin-bottom:0px; color:#ffffff;} p.orange{color:#ff9323;}</style>" +
+                       "<p>" + qsTr("1. Using cold wallet, export the key images into a file") + "</p>" +
+                       "<p>" + qsTr("2. Using view-only wallet, import the key images file") + "</p>" +
+                       errorMessage + translationManager.emptyString
+            }
+            helpTextSmall.themeTransition: false
+        }
+        
+        AdvancedOptionsItem {
+            visible: persistentSettings.transferShowAdvanced && appWindow.walletMode >= 2
+            title: qsTr("Offline transaction signing") + translationManager.emptyString
+            button1.text: qsTr("Create") + translationManager.emptyString
+            button1.enabled: appWindow.viewOnly && pageRoot.checkInformation(amountLine.text, addressLine.text, appWindow.persistentSettings.nettype)
+            button1.onClicked: {
+                console.log("Transfer: saveTx Clicked")
+                var priority = priorityModelV5.get(priorityDropdown.currentIndex).priority
+                console.log("priority: " + priority)
+                console.log("amount: " + amountLine.text)
+                addressLine.text = addressLine.text.trim()
+                setPaymentId(paymentIdLine.text.trim());
+                root.paymentClicked(addressLine.text, paymentIdLine.text, amountLine.text, root.mixin, priority, descriptionLine.text)
+            }
+            button2.text: qsTr("Sign (offline)") + translationManager.emptyString
+            button2.enabled: !appWindow.viewOnly
+            button2.onClicked: {
+                console.log("Transfer: sign tx clicked")
+                signTxDialog.open();
+            }
+            button3.text: qsTr("Submit") + translationManager.emptyString
+            button3.enabled: appWindow.viewOnly
+            button3.onClicked: {
+                console.log("Transfer: submit tx clicked")
+                submitTxDialog.open();
+            }
+            helpTextLarge.text: qsTr("Spend XMR from a cold (offline) wallet") + translationManager.emptyString
+            helpTextSmall.text: {
+                var errorMessage = "";
+                if (appWindow.viewOnly && !pageRoot.checkInformation(amountLine.text, addressLine.text, appWindow.persistentSettings.nettype)){
+                    errorMessage = "<p class='orange'>" + qsTr("* To create a transaction file, please enter address and amount above") + "</p>";
+                }
+                return "<style type='text/css'>p{line-height:20px; margin-top:0px; margin-bottom:0px; color:#ffffff;} p.orange{color:#ff9323;}</style>" +
+                       "<p>"  + qsTr("1. Using view-only wallet, export the outputs into a file") +
+                       "<p>" + qsTr("2. Using cold wallet, import the outputs file and export the key images") + "</p>" +
+                       "<p>" + qsTr("3. Using view-only wallet, import the key images file and create a transaction file") + "</p>" +
+                       errorMessage +
+                       "<p>" + qsTr("4. Using cold wallet, sign your transaction file") + "</p>" +
+                       "<p>" + qsTr("5. Using view-only wallet, submit your signed transaction") + "</p>" + translationManager.emptyString
+            }
+            helpTextSmall.themeTransition: false
+        }
 
-            StandardButton {
-                id: signTxButton
-                text: qsTr("Sign tx file") + translationManager.emptyString
-                small: true
-                visible: !appWindow.viewOnly
-                onClicked: {
-                    console.log("Transfer: sign tx clicked")
-                    signTxDialog.open();
-                }
+        AdvancedOptionsItem {
+            visible: persistentSettings.transferShowAdvanced && appWindow.walletMode >= 2
+            title: qsTr("Unmixable outputs") + translationManager.emptyString
+            button1.text: qsTr("Sweep") + translationManager.emptyString
+            button1.enabled : pageRoot.enabled
+            button1.onClicked: {
+                console.log("Transfer: sweepUnmixableClicked")
+                root.sweepUnmixableClicked()
             }
-
-            StandardButton {
-                id: submitTxButton
-                text: qsTr("Submit tx file") + translationManager.emptyString
-                small: true
-                visible: appWindow.viewOnly
-                enabled: pageRoot.enabled
-                onClicked: {
-                    console.log("Transfer: submit tx clicked")
-                    submitTxDialog.open();
-                }
-            }
-            
-            StandardButton {
-                id: exportKeyImagesButton
-                text: qsTr("Export key images") + translationManager.emptyString
-                small: true
-                visible: !appWindow.viewOnly
-                enabled: pageRoot.enabled
-                onClicked: {
-                    console.log("Transfer: export key images clicked")
-                    exportKeyImagesDialog.open();
-                }
-            }
-
-            StandardButton {
-                id: importKeyImagesButton
-                text: qsTr("Import key images") + translationManager.emptyString
-                small: true
-                enabled: appWindow.viewOnly && appWindow.isTrustedDaemon()
-                onClicked: {
-                    console.log("Transfer: import key images clicked")
-                    importKeyImagesDialog.open();
-                }
-            }
+            helpTextLarge.text: qsTr("Create a transaction that spends old unmovable outputs") + translationManager.emptyString
         }
     }
 

--- a/qml.qrc
+++ b/qml.qrc
@@ -237,5 +237,6 @@
         <file>images/edit.svg</file>
         <file>images/arrow-right-in-circle-outline-medium-white.svg</file>
         <file>images/tails-grey.png</file>
+        <file>components/AdvancedOptionsItem.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Changes:
- Group buttons according to functionality + add labels
- Functionalities are ordered according to instructions in https://monero.stackexchange.com/questions/2868/is-there-any-way-to-construct-a-transaction-manually/2916#2916
- Buttons are always visible
- Buttons are disabled when they aren't intended for use (watch-only vs. spend wallet)
- Add ? buttons which display instruction messages 
- Information message 1 (in orange): it appears when wallet is view-only and the amount and/or address field(s) are empty, which disables the create tx button: "To create a transaction file, please enter amount and address above"
- Information message 2 (in orange): it appears in Key images row, when the wallet is connected to a non-trusted remote node: "Step 2 requires connection to a local node or a trusted remote node" (https://github.com/monero-project/monero-gui/issues/2816#issuecomment-606176282)
- Moved sweep unmixable outputs to the last position (it is the least used)
- outputs export/import buttons not added (functionality not implemented in GUI yet) (#2816)

Spend (cold) wallet:
![coldwalletadvopt](https://user-images.githubusercontent.com/45968869/79637520-85465f00-8180-11ea-8fc3-b90ce4987717.gif)

View-only (hot) wallet with amount + address filled (create tx button enabled):
![advoptviewonly](https://user-images.githubusercontent.com/45968869/79637463-2b459980-8180-11ea-8ab7-9d6b641219b8.gif)

Offline transaction signing information message in a view-only (hot) wallet with amount and address empty (create tx button disabled):
![offlinetxsignerror](https://user-images.githubusercontent.com/45968869/79637607-32b97280-8181-11ea-9ea4-bf5e8c38a857.png)

Key images information message in a view-only (hot) wallet not using local node or trusted remote node (import key images button disabled):
![KIerror](https://user-images.githubusercontent.com/45968869/79637571-f0903100-8180-11ea-9293-2d7c64ba40cc.png)

Current design:
![image](https://user-images.githubusercontent.com/45968869/79511365-73a96e00-803f-11ea-959e-0b4aa3646cdb.png)