### PR TITLE
StandardDropdown: fix margins, text overlapping

### DIFF
--- a/components/StandardDropdown.qml
+++ b/components/StandardDropdown.qml
@@ -84,6 +84,8 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: 12
+            anchors.right: dropIndicator.left
+            anchors.rightMargin: 12
             elide: Text.ElideRight
             font.family: MoneroComponents.Style.fontRegular.name
             font.bold: dropdown.headerFontBold
@@ -96,7 +98,8 @@ Item {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             anchors.right: parent.right
-            width: 32
+            anchors.rightMargin: 12
+            width: dropdownIcon.width
 
             Image {
                 id: dropdownIcon


### PR DESCRIPTION
Before:
![monero-gui-dropdown-overlapping-before](https://user-images.githubusercontent.com/26060097/80774219-e3dde680-8b4b-11ea-9cb4-5280a3ba8901.png)
After:
![monero-gui-dropdown-overlapping-after](https://user-images.githubusercontent.com/26060097/80774220-e5a7aa00-8b4b-11ea-9581-4473da65a9a3.png)

