### PR TITLE
Improved daemon sync progress bar

### DIFF
--- a/components/ProgressBar.qml
+++ b/components/ProgressBar.qml
@@ -42,7 +42,7 @@ Rectangle {
     function updateProgress(currentBlock,targetBlock, blocksToSync, statusTxt){
         if(targetBlock > 0) {
             var remaining = (currentBlock < targetBlock) ? targetBlock - currentBlock : 0
-            var progressLevel = (blocksToSync > 0 && blocksToSync != remaining) ? (100*(blocksToSync - remaining)/blocksToSync).toFixed(0) : (100*(currentBlock / targetBlock)).toFixed(0)
+            var progressLevel = (blocksToSync > 0 ) ? (100*(blocksToSync - remaining)/blocksToSync).toFixed(0) : 100
             fillLevel = progressLevel
             if(typeof statusTxt != "undefined" && statusTxt != "") {
                 progressText.text = statusTxt;


### PR DESCRIPTION
This finally implements the idea described in my issue #2713 from January: 100% for the daemon sync progress bar in the lower left corner is not current blockchain height anymore, but the total number of blocks to sync, starting from the height at GUI wallet startup, so the progress bar is able to show progress.

![rel_sync](https://user-images.githubusercontent.com/10373537/80866364-83a38d80-8c8e-11ea-8fa3-c3d29b263290.png)
