### PR TITLE
OpenGL: Windows - fall back to software renderer if OpenGL < 2.1

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -75,6 +75,10 @@
 #include "daemon/DaemonManager.h"
 #endif
 
+#if defined(Q_OS_WIN)
+#include <QOpenGLContext>
+#endif
+
 #ifdef WITH_SCANNER
 #include "QR-Code-scanner/QrCodeScanner.h"
 #endif
@@ -178,6 +182,17 @@ int main(int argc, char *argv[])
     qputenv("TERM", "goaway");
 
     MainApp app(argc, argv);
+
+#if defined(Q_OS_WIN)
+    if (isOpenGL)
+    {
+        QOpenGLContext ctx;
+        isOpenGL = ctx.create() && ctx.format().version() >= qMakePair(2, 1);
+        if (!isOpenGL) {
+            qputenv("QMLSCENE_DEVICE", "softwarecontext");
+        }
+    }
+#endif
 
     app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");


### PR DESCRIPTION
Report: https://www.reddit.com/r/Monero/comments/gmhxl6/im_having_trouble_running_monero_gui_wallet_on_my/

We don't need `start-low-graphics-mode.bat` anymore. Could keep it for a while and drop it later though.