### PR TITLE
workflows: fix windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: numworks/setup-msys2@v1
-    - name: update pacman
-      run: msys2do pacman -Syu --noconfirm
+    - uses: eine/setup-msys2@v0
+      with:
+        update: true
     - name: install monero dependencies
       run: msys2do pacman -S --noconfirm mingw-w64-x86_64-toolchain make mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb git mingw-w64-x86_64-qt5 mingw-w64-x86_64-libgcrypt
+    - name: disable qtquickcompiler
+      run: msys2do sed -i s/CONFIG\ +=\ qtquickcompiler// monero-wallet-gui.pro
     - name: build
       run: msys2do ./build.sh release
     - name: test qml


### PR DESCRIPTION
`eine/setup-msys2@v0` is better maintained.

Disabling qtquickcompiler “solves” the bad address Qt bug.