### PR TITLE
WizardWalletInput: disallow (back)slash

### DIFF
--- a/wizard/WizardWalletInput.qml
+++ b/wizard/WizardWalletInput.qml
@@ -64,7 +64,7 @@ GridLayout {
         Layout.fillWidth: true
 
         function verify(){
-            if(walletLocation === "") return false;
+            if(walletLocation === "" || /[\\\/]/.test(walletName.text)) return false;
 
             var exists = Wizard.walletPathExists(walletLocation.text, walletName.text, isIOS, walletManager);
             return !exists && walletLocation.error === false;


### PR DESCRIPTION
Report of "failed to save wallet" because someone added `/` to the end of the wallet name.