### PR TITLE
QML: fix some Qt 5.15 warnings

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -265,11 +265,11 @@ Rectangle {
     Connections {
         ignoreUnknownSignals: false
         target: transferView
-        onPaymentClicked : {
+        function paymentClicked(address, paymentId, amount, mixinCount, priority, description) {
             console.log("MiddlePanel: paymentClicked")
             paymentClicked(address, paymentId, amount, mixinCount, priority, description)
         }
-        onSweepUnmixableClicked : {
+        function onSweepUnmixableClicked() {
             console.log("MiddlePanel: sweepUnmixableClicked")
             sweepUnmixableClicked()
         }

--- a/components/DatePicker.qml
+++ b/components/DatePicker.qml
@@ -117,7 +117,7 @@ Item {
 
             Connections {
                 target: datePicker
-                onCurrentDateChanged: {
+                function onCurrentDateChanged() {
                     dateInput.setDate(datePicker.currentDate)
                 }
             }

--- a/pages/Account.qml
+++ b/pages/Account.qml
@@ -186,7 +186,7 @@ Rectangle {
                     delegate: Rectangle {
                         id: tableItem2
                         height: subaddressAccountListRow.subaddressAccountListItemHeight
-                        width: parent.width
+                        width: parent ? parent.width : undefined
                         Layout.fillWidth: true
                         color: "transparent"
 

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -569,8 +569,8 @@ Rectangle {
             delegate: Rectangle {
                 id: delegate
                 property bool collapsed: root.txDataCollapsed.indexOf(hash) >= 0 ? true : false
-                anchors.left: parent.left
-                anchors.right: parent.right
+                anchors.left: parent ? parent.left : undefined
+                anchors.right: parent ? parent.right : undefined
                 height: {
                     if(!collapsed) return 60;
                     if(isout && delegate.address !== "") return 320;

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -105,7 +105,7 @@ Rectangle {
                     delegate: Rectangle {
                         id: tableItem2
                         height: subaddressListRow.subaddressListItemHeight
-                        width: parent.width
+                        width: parent ? parent.width : undefined
                         Layout.fillWidth: true
                         color: "transparent"
 


### PR DESCRIPTION
Untested with Qt 5.9, the `function onFoo() {}` syntax might not be available.