### PR TITLE
simple mode: enable settings log tab

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -2139,7 +2139,7 @@ ApplicationWindow {
         if (mode < 2) {
             persistentSettings.useRemoteNode = false;
 
-            if (middlePanel.settingsView.settingsStateViewState === "Node" || middlePanel.settingsView.settingsStateViewState === "Log") {
+            if (middlePanel.settingsView.settingsStateViewState === "Node") {
                 middlePanel.settingsView.settingsStateViewState = "Wallet"
             }
         }

--- a/pages/settings/Navbar.qml
+++ b/pages/settings/Navbar.qml
@@ -273,7 +273,6 @@ Rectangle {
                 // LOG
                 id: navLog
                 property bool isActive: settingsStateView.state === "Log"
-                visible: appWindow.walletMode >= 2
                 Layout.preferredWidth: navLogText.width + grid.textMargin
                 Layout.preferredHeight: 32
                 Layout.minimumWidth: 72


### PR DESCRIPTION
Can useful in simple mode bootstrap to see the sync status and also useful when doing trying to help a user.