### PR TITLE
Tails: Fix simple and bootstrap mode

### DIFF
--- a/components/NetworkStatusItem.qml
+++ b/components/NetworkStatusItem.qml
@@ -186,6 +186,7 @@ Rectangle {
                         daemonManager.sendCommandAsync(
                             ["set_bootstrap_daemon", "auto"],
                             appWindow.currentWallet.nettype,
+                            persistentSettings.rpcPort,
                             callback);
 
                         refreshMouseArea.visible = false;

--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -219,7 +219,7 @@ Rectangle {
             onAccepted: {
                 if(text.length > 0) {
                     consoleArea.logCommand(">>> " + text)
-                    daemonManager.sendCommandAsync(text.split(" "), currentWallet.nettype, function(result) {
+                    daemonManager.sendCommandAsync(text.split(" "), currentWallet.nettype, persistentSettings.rpcPort, function(result) {
                         if (!result) {
                             appWindow.showStatusMessage(qsTr("Failed to send command"), 3);
                         }

--- a/pages/settings/SettingsNode.qml
+++ b/pages/settings/SettingsNode.qml
@@ -347,6 +347,7 @@ Rectangle{
             visible: !persistentSettings.useRemoteNode
 
             MoneroComponents.StandardButton {
+                id: toggleDaemon
                 small: true
                 text: (appWindow.daemonRunning ? qsTr("Stop daemon") : qsTr("Start daemon")) + translationManager.emptyString
                 onClicked: {
@@ -385,6 +386,53 @@ Rectangle{
                     }
                     onLabelButtonClicked: persistentSettings.blockchainDataDir = ""
                 }
+            }
+
+            MoneroComponents.LineEditMulti {
+                id: daemonPort
+                Layout.preferredWidth: 200
+                Layout.fillWidth: true
+                fontSize: 15
+                labelFontSize: 14
+                property string style: "<style type='text/css'>a {cursor:pointer;text-decoration: none; color: #FF6C3C}</style>"
+                labelText: qsTr("Daemon port") + style + " <a href='#'> (%1)</a>".arg(qsTr("Change")) + translationManager.emptyString
+                labelButtonText: qsTr("Reset") + translationManager.emptyString
+                labelButtonVisible: text
+                placeholderText: qsTr("(default)") + translationManager.emptyString
+                placeholderFontSize: 15
+                readOnly: true
+                text: persistentSettings.rpcPort
+                addressValidation: false
+                onInputLabelLinkActivated: {
+                    inputDialog.labelText = qsTr("Set a port:") + translationManager.emptyString;
+                    inputDialog.onAcceptedCallback = function() {
+                        var _port = parseInt(inputDialog.inputText)
+                        if (!isNaN(_port)) {
+                            if(_port >= 0 && _port < 65535) {
+                                if (appWindow.daemonRunning) {
+                                    appWindow.stopDaemon()
+                                }
+                                persistentSettings.rpcPort = _port;
+                                toggleDaemon.enabled = false;
+                                appWindow.showStatusMessage(qsTr("Wallet restart required."),60);
+                                return;
+                            }
+                        }
+
+                        appWindow.showStatusMessage(qsTr("Invalid port specified."),3);
+                    }
+                    inputDialog.onRejectedCallback = null;
+                    inputDialog.open(persistentSettings.rpcPort ? persistentSettings.rpcPort : getDefaultDaemonRpcPort(persistentSettings.nettype))
+                }
+                onLabelButtonClicked: {
+                    if (appWindow.daemonRunning) {
+                        appWindow.stopDaemon()
+                    }
+                    persistentSettings.rpcPort = getDefaultDaemonRpcPort(persistentSettings.nettype)
+                    toggleDaemon.enabled = false;
+                    appWindow.showStatusMessage(qsTr("Wallet restart required."),60);
+                }
+                visible: isTails
             }
 
             MoneroComponents.LineEditMulti {

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -47,23 +47,23 @@ public:
 
     static DaemonManager * instance(const QStringList *args = nullptr);
 
-    Q_INVOKABLE bool start(const QString &flags, NetworkType::Type nettype, const QString &dataDir = "", const QString &bootstrapNodeAddress = "", bool noSync = false);
-    Q_INVOKABLE void stopAsync(NetworkType::Type nettype, const QJSValue& callback);
+    Q_INVOKABLE bool start(const QString &flags, NetworkType::Type nettype, int rpcPort, const QString &dataDir = "", const QString &bootstrapNodeAddress = "", bool noSync = false, bool torsocks = false);
+    Q_INVOKABLE void stopAsync(NetworkType::Type nettype, int rpcPort, const QJSValue& callback);
 
     Q_INVOKABLE bool noSync() const noexcept;
     // return true if daemon process is started
-    Q_INVOKABLE void runningAsync(NetworkType::Type nettype, const QJSValue& callback) const;
+    Q_INVOKABLE void runningAsync(NetworkType::Type nettype, int rpcPort, const QJSValue& callback) const;
     // Send daemon command from qml and prints output in console window.
-    Q_INVOKABLE void sendCommandAsync(const QStringList &cmd, NetworkType::Type nettype, const QJSValue& callback) const;
+    Q_INVOKABLE void sendCommandAsync(const QStringList &cmd, NetworkType::Type nettype, int rpcPort, const QJSValue& callback) const;
     Q_INVOKABLE void exit();
     Q_INVOKABLE QVariantMap validateDataDir(const QString &dataDir) const;
 
 private:
 
-    bool running(NetworkType::Type nettype) const;
-    bool sendCommand(const QStringList &cmd, NetworkType::Type nettype, QString &message) const;
-    bool startWatcher(NetworkType::Type nettype) const;
-    bool stopWatcher(NetworkType::Type nettype) const;
+    bool running(NetworkType::Type nettype, int rpcPort) const;
+    bool sendCommand(const QStringList &cmd, NetworkType::Type nettype, int rpcPort, QString &message) const;
+    bool startWatcher(NetworkType::Type nettype, int rpcPort) const;
+    bool stopWatcher(NetworkType::Type nettype, int rpcPort) const;
 signals:
     void daemonStarted() const;
     void daemonStopped() const;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -202,6 +202,7 @@ int main(int argc, char *argv[])
     // - Log file location
     // - QML Settings file location (monero-core.conf)
     // - Default wallets path
+    // - Blockchain data dir
     // Target directory is: ~/Persistent/Monero
     if (isTails) {
         if (!TailsOS::detectDataPersistence())


### PR DESCRIPTION
What worked before:
- Advanced mode with .onion remote node
- Connecting to daemons running on 18081 (with altered iptables).

What works with this PR:
- Simple mode
- Bootstrap mode with clearnet / .onion remote nodes
- Advanced mode with local node
  - Starts and connects to daemon on port 17600 instead of 18081
- Advanced mode with clearnet / .onion remote node
- Connecting to daemons running on 18081 (with altered iptables).
  - User can edit port in node settings. Wallet restart required.

Initial full node startup time takes 5 - 10 minutes, appears to be a downstream issue. GUI reports "daemon blocks remaining: 0" during this time.

Sometimes monerod refuses to close itself, needs to be SIGKILLed.