### PR TITLE
workflows: add experimental mac cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,30 @@ jobs:
   build-macos:
 
     runs-on: macOS-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - name: "qmake"
+            cmd: "export PATH=$PATH:/usr/local/opt/qt/bin && ./build.sh"
+            coe: false
+          - name: "cmake"
+            cmd: "CMAKE_PREFIX_PATH=/usr/local/opt/qt USE_SINGLE_BUILDDIR=ON DEV_MODE=ON make release -j3"
+            coe: true
+    name: build-macos-${{ matrix.toolchain.name }}
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: recursive
     - name: update brew and install dependencies
-      run: brew update && brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf qt5 libgcrypt
+      run: brew update && brew install boost hidapi zmq libpgm miniupnpc ldns expat libunwind-headers protobuf qt5 libgcrypt pkg-config
     - name: build
-      run: export PATH=$PATH:/usr/local/opt/qt/bin && ./build.sh
+      run: ${{ matrix.toolchain.cmd }}
+      continue-on-error: ${{ matrix.toolchain.coe }}
     - name: test qml
       run: build/release/bin/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui --test-qml
+      continue-on-error: ${{ matrix.toolchain.coe }}
 
   build-ubuntu:
 


### PR DESCRIPTION
The Mac cmake CI will show as success until Mac cmake support is fully added.

Not sure if we want this, might be useful to see how cmake changes are on macOS. Can close if not wanted.