### PR TITLE
RemoteNodeEdit: fix treatment of IPv6 addresses

### DIFF
--- a/components/RemoteNodeEdit.qml
+++ b/components/RemoteNodeEdit.qml
@@ -73,6 +73,12 @@ GridLayout {
         if(addr === "" || addr.length < 2) return "";
         if(!Utils.isNumeric(port)) return "";
 
+        // IPv6 addresses get special treatment, they're enclosed in square
+        // brackets, e.g.: [fe80:cafe::1]: 18081.
+        if (Utils.isIPv6(addr)) {
+            return "[" + addr + "]:" + port;
+        }
+
         return addr + ":" + port;
     }
 

--- a/pages/settings/SettingsNode.qml
+++ b/pages/settings/SettingsNode.qml
@@ -31,6 +31,7 @@ import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.0
 import FontAwesome 1.0
 
+import "../../js/Utils.js" as Utils
 import "../../components" as MoneroComponents
 import "../../components/effects" as MoneroEffects
 
@@ -269,8 +270,15 @@ Rectangle{
                 daemonPortLabelText: qsTr("Port") + translationManager.emptyString
 
                 property var rna: persistentSettings.remoteNodeAddress
-                daemonAddrText: rna.search(":") != -1 ? rna.split(":")[0].trim() : ""
-                daemonPortText: rna.search(":") != -1 ? (rna.split(":")[1].trim() == "") ? appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype) : rna.split(":")[1] : ""
+                daemonAddrText: Utils.getAddressParts(rna).host
+                daemonPortText: {
+                    var parts = Utils.getAddressParts(rna);
+                    if(parts.port != ""){
+                        return parts.port;
+                    }
+
+                    return appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype);
+                }
                 onEditingFinished: {
                     persistentSettings.remoteNodeAddress = remoteNodeEdit.getAddress();
                     console.log("setting remote node to " + persistentSettings.remoteNodeAddress);
@@ -419,14 +427,14 @@ Rectangle{
 
                         daemonAddrLabelText: qsTr("Bootstrap Address") + translationManager.emptyString
                         daemonPortLabelText: qsTr("Bootstrap Port") + translationManager.emptyString
-                        daemonAddrText: persistentSettings.bootstrapNodeAddress.split(":")[0].trim()
+                        daemonAddrText: Utils.getAddressParts(persistentSettings.bootstrapNodeAddress).host
                         daemonPortText: {
-                            var node_split = persistentSettings.bootstrapNodeAddress.split(":");
-                            if(node_split.length == 2){
-                                (node_split[1].trim() == "") ? appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype) : node_split[1];
-                            } else {
-                                return ""
+                            var parts = Utils.getAddressParts(persistentSettings.bootstrapNodeAddress);
+                            if(parts.port != ""){
+                                return parts.port;
                             }
+
+                            return appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype);
                         }
                         onEditingFinished: {
                             if (daemonAddrText == "auto") {

--- a/wizard/WizardDaemonSettings.qml
+++ b/wizard/WizardDaemonSettings.qml
@@ -31,6 +31,7 @@ import QtQuick.Dialogs 1.2
 import QtQuick.Layouts 1.2
 import QtQuick.Controls 2.0
 
+import "../js/Utils.js" as Utils
 import "../js/Wizard.js" as Wizard
 import "../components" as MoneroComponents
 
@@ -147,14 +148,14 @@ ColumnLayout {
                 Layout.minimumWidth: 300
                 //labelText: qsTr("Bootstrap node (leave blank if not wanted)") + translationManager.emptyString
 
-                daemonAddrText: persistentSettings.bootstrapNodeAddress.split(":")[0].trim()
+                daemonAddrText: Utils.getAddressParts(persistentSettings.bootstrapNodeAddress).host
                 daemonPortText: {
-                    var node_split = persistentSettings.bootstrapNodeAddress.split(":");
-                    if(node_split.length == 2){
-                        (node_split[1].trim() == "") ? appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype) : node_split[1];
-                    } else {
-                        return ""
+                    var parts = Utils.getAddressParts(persistentSettings.bootstrapNodeAddress);
+                    if(parts.port != ""){
+                        return parts.port;
                     }
+
+                    return appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype);
                 }
             }
         }
@@ -185,8 +186,15 @@ ColumnLayout {
             Layout.fillWidth: true
 
             property var rna: persistentSettings.remoteNodeAddress
-            daemonAddrText: rna.search(":") != -1 ? rna.split(":")[0].trim() : ""
-            daemonPortText: rna.search(":") != -1 ? (rna.split(":")[1].trim() == "") ? appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype) : persistentSettings.remoteNodeAddress.split(":")[1] : ""
+            daemonAddrText: Utils.getAddressParts(rna).host
+            daemonPortText: {
+                var parts = Utils.getAddressParts(rna);
+                if(parts.port != ""){
+                    return parts.port;
+                }
+
+                return appWindow.getDefaultDaemonRpcPort(persistentSettings.nettype);
+            }
         }
     }
 }


### PR DESCRIPTION
Now RemoteNodeEdit items check if the host is an IPv6 address and fixes
the return of `getAddress()`, for example, if it's an IPv6 address, it
returns [2001:db8::1]:18081 instead of 2001:db8::1:18081 which is
ambiguous and also showed up incorrectly on the GUI.

Previously the user had to enter the address inside square brackets in
order to connect to an IPv6 remote node (and it succeed, ofc) however
the GUI didn't parsed it correctly.

These bugs were found during the test of the **Locha Mesh** network (which
uses `fc00::/16` unique local addresses) as can be seen on the
[demonstration].

[demonstration]: https://twitter.com/Locha_io/status/1276930442030133248

The incorrect parsing is showed on issue #2971

The `getAddressParts()` will try to guess, depending on the input, how
the address is structured, if it is:

1. IPv6 with a port.
2. IPv6 without a port.
3. IPv4/DNS with a port.
4. IPv4/DNS without a port.
5. Treat anything else as an error and use the entire string as the
host.

Fixes #2971 

Signed-off-by: Jean Pierre Dudey <jeandudey@hotmail.com>