### PR TITLE
main: disable NetworkAccessBlockingFactory.h if Qt < 5.12

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -418,7 +418,9 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 
     QQmlApplicationEngine engine;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     engine.setNetworkAccessManagerFactory(new NetworkAccessBlockingFactory);
+#endif
     OSCursor cursor;
     engine.rootContext()->setContextProperty("globalCursor", &cursor);
     OSHelper osHelper;


### PR DESCRIPTION
Due to a potential Qt bug qrc:///lang/languages.xml gets
blocked resulting in broken translations.