### PR TITLE
Prevent automatic monero-gui.desktop file creation

### DIFF
--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -251,14 +251,29 @@ Rectangle {
             }
         }
 
-        MoneroComponents.StandardButton {
-            visible: !persistentSettings.customDecorations
-            Layout.topMargin: 10
-            small: true
-            text: qsTr("Change language") + translationManager.emptyString
+        RowLayout{
+            spacing: 20
 
-            onClicked: {
-                appWindow.toggleLanguageView();
+            MoneroComponents.StandardButton {
+                visible: !persistentSettings.customDecorations
+                Layout.topMargin: 10
+                small: true
+                text: qsTr("Change language") + translationManager.emptyString
+
+                onClicked: {
+                    appWindow.toggleLanguageView();
+                }
+            }
+
+            MoneroComponents.StandardButton {
+                Layout.topMargin: 10
+                visible: (isLinux || isTails) && !xdgDesktopEntryExists
+                small: true
+                text: qsTr("Create desktop entry") + translationManager.emptyString
+                onClicked: {
+                    if(mainApp.xdgDesktopEntryRegister())
+                        visible = false;
+                }
             }
         }
     }

--- a/qml.qrc
+++ b/qml.qrc
@@ -233,6 +233,7 @@
         <file>images/themes/white/minimize.svg</file>
         <file>components/effects/ColorTransition.qml</file>
         <file>components/effects/GradientBackground.qml</file>
+        <file>images/appicons/64x64.png</file>
         <file>images/check-white.svg</file>
         <file>images/copy.svg</file>
         <file>images/edit.svg</file>

--- a/src/main/MainApp.cpp
+++ b/src/main/MainApp.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "MainApp.h"
+#include "qt/utils.h"
 #include <QCloseEvent>
 
 bool MainApp::event (QEvent *event)
@@ -41,3 +42,10 @@ bool MainApp::event (QEvent *event)
     // Pass unhandled events to base class 
     return QApplication::event(event);
 }
+
+#ifdef Q_OS_LINUX
+bool MainApp::xdgDesktopEntryRegister() const {
+    // @TODO: Utils:: class would be nice for namespacing/scoping
+    return _xdgDesktopEntryRegister();
+}
+#endif

--- a/src/main/MainApp.h
+++ b/src/main/MainApp.h
@@ -35,6 +35,9 @@ class MainApp : public QApplication
     Q_OBJECT
 public:
     MainApp(int &argc, char** argv) : QApplication(argc, argv) {};
+#ifdef Q_OS_LINUX
+    Q_INVOKABLE bool xdgDesktopEntryRegister() const;
+#endif
 private:
     bool event(QEvent *e);
 signals:

--- a/src/main/filter.h
+++ b/src/main/filter.h
@@ -49,6 +49,7 @@ signals:
     void mousePressed(const QVariant &o, const QVariant &x, const QVariant &y);
     void mouseReleased(const QVariant &o, const QVariant &x, const QVariant &y);
     void userActivity();
+    void registerXdgEntry();
     void uriHandler(const QUrl &url);
 };
 

--- a/src/qt/utils.h
+++ b/src/qt/utils.h
@@ -39,8 +39,26 @@ QByteArray fileOpen(QString path);
 bool fileWrite(QString path, QString data);
 QString getAccountName();
 #ifdef Q_OS_LINUX
-QString xdgMime(QApplication &app);
-void registerXdgMime(QApplication &app);
+struct xdgDesktopEntryPaths {
+    QString pathApp;
+    QString pathIcon;
+    QString pathAppTails;
+    QString PathIconTails;
+    QString PathMime;
+};
+const xdgDesktopEntryPaths xdgPaths = {
+        QString("%1/monero-gui.desktop").arg(QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation)),
+        QString("%1/.local/share/icons/monero.png").arg(QDir::homePath()),
+        QString("/live/persistence/TailsData_unlocked/dotfiles/.local/share/applications/monero-gui.desktop"),
+        QString("/live/persistence/TailsData_unlocked/dotfiles/.local/share/icons/monero.png"),
+        QString("/")
+};
+bool pixmapWrite(const QString &path, const QPixmap &pixmap);
+QString xdgDesktopEntry();
+bool xdgDesktopEntryWrite(const QString &path);
+QString xdgDesktopEntryPath();
+bool _xdgDesktopEntryRegister();
+void xdgRefreshApplications();
 #endif
 const static QRegExp reURI = QRegExp("^\\w+:\\/\\/([\\w+\\-?\\-_\\-=\\-&]+)");
 QString randomUserAgent();


### PR DESCRIPTION
Disables automatic writing of xdg entry on Linux machines to `~/.local/share/applications/monero-gui.desktop`. 

- User needs to give consent to write to xdg location(s).
- GUI will keep the xdg entry updated to latest version if the path already exists.
- GUI will refresh xdg with `update-desktop-database`
- Added xdg icon

![https://i.imgur.com/MeT5PWV.png](https://i.imgur.com/MeT5PWV.png)

Closes #2815
Closes #2802
Closes #2598