### PR TITLE
history: change sent transaction dot color from orange to red

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -595,7 +595,7 @@ Rectangle {
                         width: 10
                         height: 10
                         radius: 8
-                        color: isout ? "#d85a00" : "#2eb358"
+                        color: isout ? "#b30000" : "#2eb358"
                     }
                 }
 


### PR DESCRIPTION
Red is the most commonly used color for outgoing transactions in cryptocurrency wallets.
![image](https://user-images.githubusercontent.com/45968869/86934017-806bc880-c13b-11ea-9350-0565246adb32.png)
