### PR TITLE
history: fix amount display + remove trailing zeros in amount

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1511,7 +1511,7 @@ Rectangle {
                 "i": i,
                 "isout": isout,
                 "amount": Number(amount),
-                "displayAmount": displayAmount + " XMR",
+                "displayAmount": Utils.removeTrailingZeros(displayAmount.toFixed(12)) + " XMR",
                 "hash": hash,
                 "paymentId": paymentId,
                 "address": address,


### PR DESCRIPTION
- Amounts like 0.000000000001 are now displayed correctly (fixes #2993)
- Amounts with trailing zeros like 0.000100000000 are displayed as 0.0001
