### PR TITLE
account: update balances of account page when new block is found

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -428,6 +428,10 @@ ApplicationWindow {
         leftPanel.minutesToUnlock = (balance !== balanceU) ? currentWallet.history.minutesToUnlock : "";
         leftPanel.balanceString = balance
         leftPanel.balanceUnlockedString = balanceU
+        if (middlePanel.state === "Account") {
+            middlePanel.accountView.balanceAllText = walletManager.displayAmount(appWindow.currentWallet.balanceAll());
+            middlePanel.accountView.unlockedBalanceAllText = walletManager.displayAmount(appWindow.currentWallet.unlockedBalanceAll());
+        }
     }
 
     function onUriHandler(uri){

--- a/pages/Account.qml
+++ b/pages/Account.qml
@@ -48,6 +48,8 @@ Rectangle {
     color: "transparent"
     property var model
     property alias accountHeight: mainLayout.height
+    property alias balanceAllText: balanceAll.text
+    property alias unlockedBalanceAllText: unlockedBalanceAll.text
     property bool selectAndSend: false
     property int currentAccountIndex
 


### PR DESCRIPTION
Update total balance and total unlocked balance when a new block is found and account page is open (fixes #2741).