### PR TITLE
SettingsLog: add command history

### DIFF
--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -213,9 +213,27 @@ Rectangle {
         MoneroComponents.LineEdit {
             id: sendCommandText
             Layout.fillWidth: true
+            property var lastCommands: []
+            property int currentCommandIndex
             fontBold: false
             placeholderText: qsTr("command + enter (e.g 'help' or 'status')") + translationManager.emptyString
             placeholderFontSize: 16
+            Keys.onUpPressed: {
+                if (currentCommandIndex != 0) {
+                    sendCommandText.text = lastCommands[currentCommandIndex - 1]
+                    currentCommandIndex = currentCommandIndex - 1
+                }
+            }
+            Keys.onDownPressed: {
+                if (currentCommandIndex == lastCommands.length - 1) {
+                    currentCommandIndex = lastCommands.length;
+                    return text = "";
+                }
+                if (currentCommandIndex != lastCommands.length) {
+                    sendCommandText.text = lastCommands[currentCommandIndex + 1]
+                    currentCommandIndex = currentCommandIndex + 1
+                }
+            }
             onAccepted: {
                 if(text.length > 0) {
                     consoleArea.logCommand(">>> " + text)
@@ -225,6 +243,8 @@ Rectangle {
                         }
                     });
                 }
+                lastCommands.push(text);
+                currentCommandIndex = lastCommands.length;
                 text = ""
             }
         }


### PR DESCRIPTION
Allow users to navigate with up/down arrows the last commands entered in Settings > Log (during a session).