### PR TITLE
WizardModeSelection: optional 'Portable mode' feature support

### DIFF
--- a/components/CheckBox.qml
+++ b/components/CheckBox.qml
@@ -109,6 +109,7 @@ Item {
             color: MoneroComponents.Style.defaultFontColor
             textFormat: Text.RichText
             wrapMode: Text.NoWrap
+            visible: text != ""
         }
     }
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -78,6 +78,8 @@
 
 #if defined(Q_OS_WIN)
 #include <QOpenGLContext>
+#elif defined(Q_OS_MACOS)
+#include "qt/macoshelper.h"
 #endif
 
 #ifdef WITH_SCANNER
@@ -322,6 +324,10 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 
     // start listening
     QTimer::singleShot(0, ipc, SLOT(bind()));
+
+#if defined(Q_OS_MACOS)
+    QDir::setCurrent(QDir(MacOSHelper::bundlePath() + QDir::separator() + "..").canonicalPath());
+#endif
 
     // screen settings
     // Mobile is designed on 128dpi

--- a/src/qt/macoshelper.h
+++ b/src/qt/macoshelper.h
@@ -36,6 +36,7 @@ class MacOSHelper
 public:
     static bool isCapsLock();
     static bool openFolderAndSelectItem(const QUrl &path);
+    static QString bundlePath();
 };
 
 #endif //MACOSHELPER_H

--- a/src/qt/macoshelper.mm
+++ b/src/qt/macoshelper.mm
@@ -55,3 +55,18 @@ bool MacOSHelper::openFolderAndSelectItem(const QUrl &path)
     [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:fileURLs];
     return true;
 }
+
+QString MacOSHelper::bundlePath()
+{
+    NSBundle *main = [NSBundle mainBundle];
+    if (!main)
+    {
+        return {};
+    }
+    NSString *bundlePathString = [main bundlePath];
+    if (!bundlePathString)
+    {
+        return {};
+    }
+    return QString::fromCFString(reinterpret_cast<const CFStringRef>(bundlePathString));
+}

--- a/wizard/WizardLanguage.qml
+++ b/wizard/WizardLanguage.qml
@@ -245,4 +245,8 @@ Rectangle {
     Timer {
         id: versionTimer
     }
+
+    function onPageCompleted() {
+        persistentSettings.setWritable(false);
+    }
 }

--- a/wizard/WizardMenuItem.qml
+++ b/wizard/WizardMenuItem.qml
@@ -39,6 +39,8 @@ RowLayout {
     Layout.fillWidth: true
     Layout.bottomMargin: 10
     property alias imageIcon: icon.source
+    property bool checkbox: false
+    property alias checked: checkboxItem.checked
     property alias headerText: header.text
     property alias bodyText: body.text
     signal menuClicked();
@@ -48,16 +50,24 @@ RowLayout {
         Layout.preferredWidth: 70
         Layout.preferredHeight: 70
 
+        MoneroComponents.CheckBox {
+            id: checkboxItem
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            toggleOnClick: false
+            visible: rowlayout.checkbox
+        }
+
         Image {
             id: icon
-            visible: !isOpenGL || MoneroComponents.Style.blackTheme
+            visible: !rowlayout.checkbox && (!isOpenGL || MoneroComponents.Style.blackTheme)
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
             source: ""
         }
 
         DropShadow {
-            visible: isOpenGL && !MoneroComponents.Style.blackTheme
+            visible: !rowlayout.checkbox && (isOpenGL && !MoneroComponents.Style.blackTheme)
             anchors.fill: icon
             horizontalOffset: 3
             verticalOffset: 3

--- a/wizard/WizardModeSelection.qml
+++ b/wizard/WizardModeSelection.qml
@@ -40,6 +40,18 @@ Rectangle {
 
     property alias pageHeight: pageRoot.height
     property string viewName: "wizardModeSelection1"
+    property bool portable: persistentSettings.portable
+
+    function applyWalletMode(mode, wizardState) {
+        if (!persistentSettings.setPortable(portable)) {
+            appWindow.showStatusMessage(qsTr("Failed to configure portable mode"), 3);
+            return;
+        }
+
+        appWindow.changeWalletMode(mode);
+        wizardController.wizardStackView.backTransition = false;
+        wizardController.wizardState = wizardState;
+    }
 
     ColumnLayout {
         id: pageRoot
@@ -78,9 +90,7 @@ Rectangle {
 
                 onMenuClicked: {
                     if(appWindow.persistentSettings.nettype == 0){
-                        appWindow.changeWalletMode(0);
-                        wizardController.wizardStackView.backTransition = false;
-                        wizardController.wizardState = 'wizardModeRemoteNodeWarning';
+                        applyWalletMode(0, 'wizardModeRemoteNodeWarning');
                     }
                 }
             }
@@ -108,9 +118,7 @@ Rectangle {
 
                 onMenuClicked: {
                     if(appWindow.persistentSettings.nettype == 0){
-                        appWindow.changeWalletMode(1);
-                        wizardController.wizardStackView.backTransition = false;
-                        wizardController.wizardState = 'wizardModeBootstrap';
+                        applyWalletMode(1, 'wizardModeBootstrap');
                     }
                 }
             }
@@ -130,10 +138,24 @@ Rectangle {
                 imageIcon: "qrc:///images/local-node-full.png"
 
                 onMenuClicked: {
-                    wizardController.wizardStackView.backTransition = false;
-                    appWindow.changeWalletMode(2);
-                    wizardController.wizardState = 'wizardHome';
+                    applyWalletMode(2, 'wizardHome');
                 }
+            }
+
+            WizardHeader {
+                Layout.topMargin: 20
+                title: qsTr("Optional features") + translationManager.emptyString
+                subtitle: qsTr("Select enhanced functionality you would like to enable.") + translationManager.emptyString
+            }
+
+            WizardMenuItem {
+                Layout.topMargin: 20
+                headerText: qsTr("Portable mode") + translationManager.emptyString
+                bodyText: qsTr("Create portable wallets and use them on any PC. Enable if you installed Monero on a USB stick, an external drive, or any other portable storage medium.") + translationManager.emptyString
+                checkbox: true
+                checked: wizardModeSelection1.portable
+
+                onMenuClicked: wizardModeSelection1.portable = !wizardModeSelection1.portable
             }
 
             WizardNav {
@@ -144,8 +166,12 @@ Rectangle {
                 autoTransition: false
 
                 onPrevClicked: {
-                    wizardController.wizardStackView.backTransition = !wizardController.wizardStackView.backTransition;
-                    wizardController.wizardState = wizardController.wizardStackView.backTransition ? 'wizardLanguage' : 'wizardHome';
+                    if (wizardController.wizardStackView.backTransition) {
+                        applyWalletMode(persistentSettings.walletMode, 'wizardHome');
+                    } else {
+                        wizardController.wizardStackView.backTransition = true;
+                        wizardController.wizardState = 'wizardLanguage';
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes https://github.com/monero-project/monero-gui/issues/3104

Requires https://github.com/monero-project/monero-gui/pull/3023, https://github.com/monero-project/monero-gui/pull/3025

In `Portable mode` it will store settings and wallets in 'storage' folder near monero-wallet-gui executable (based on current working directory).

![monero-gui-portable](https://user-images.githubusercontent.com/26060097/88720810-006ec800-d115-11ea-9f9e-3e02269cda42.gif)
