### PR TITLE
README: update list of third party monero packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ Status of the translations:
 ## Installing the Monero GUI from a package
 
 Packages are available for
-
-* Arch Linux: pacman -S monero-gui
-* Void Linux: xbps-install -S monero-core
-* GuixSD: guix package -i monero-core
+* Arch Linux: [monero-gui](https://www.archlinux.org/packages/community/x86_64/monero-gui/)
+* Debian: See the [whonix/monero-gui repository](https://gitlab.com/whonix/monero-gui#how-to-install-monero-using-apt-get)
+* Void Linux: `xbps-install -S monero-gui`
+* GuixSD: `guix package -i monero-gui`
+* macOS (homebrew): `brew cask install monero-wallet`
 
 Packaging for your favorite distribution would be a welcome contribution!
 


### PR DESCRIPTION
Removed AUR package, since doesn't seem to exist anymore, added Debian package (the CCS-funded one) and updated xbps and guix packages.

We will link to this list from the website: https://github.com/monero-project/monero-site/pull/1135