### PR TITLE
cmake: move autogen to avoid warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,6 @@ include(CheckCXXCompilerFlag)
 include(CheckLinkerFlag)
 include(FindCcache)
 
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
 if(DEBUG)
 	set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()
@@ -79,6 +76,11 @@ if(GIT_FOUND)
 endif()
 
 add_subdirectory(monero)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
 set_property(TARGET wallet_merged PROPERTY FOLDER "monero")
 get_directory_property(ARCH_WIDTH DIRECTORY "monero" DEFINITION ARCH_WIDTH)
 get_directory_property(UNBOUND_LIBRARY DIRECTORY "monero" DEFINITION UNBOUND_LIBRARY)


### PR DESCRIPTION
Avoids the console getting spammed with warnings like this:

```
CMake Warning (dev) in monero/external/miniupnp/miniupnpc/CMakeLists.txt:
  AUTOGEN: No valid Qt version found for target libminiupnpc-static.
  AUTOMOC, AUTOUIC and AUTORCC disabled.  Consider adding:

    find_package(Qt<QTVERSION> COMPONENTS Widgets)

  to your CMakeLists.txt file.
This warning is for project developers.  Use -Wno-dev to suppress it.
```