### PR TITLE
workflows: add static docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,25 @@ jobs:
       run: USE_SINGLE_BUILDDIR=ON DEV_MODE=ON make release-win64 -j2
     - name: test qml
       run: build/release/bin/monero-wallet-gui --test-qml
+
+  docker-linux-static:
+    runs-on: ubuntu-20.04 
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: preprare build enviroment
+      run: docker build --tag monero:build-env-linux --build-arg THREADS=3 --file Dockerfile.linux .
+    - name: build
+      run: docker run --rm -v /home/runner/work/monero-gui/monero-gui:/monero-gui -w /monero-gui monero:build-env-linux sh -c 'USE_SINGLE_BUILDDIR=ON make release-static -j3'
+
+  docker-windows-static:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: preprare build enviroment
+      run: docker build --tag monero:build-env-windows --build-arg THREADS=3 --file Dockerfile.windows .
+    - name: build
+      run: docker run --rm -v /home/runner/work/monero-gui/monero-gui:/monero-gui -w /monero-gui monero:build-env-windows sh -c 'make depends root=/depends target=x86_64-w64-mingw32 tag=win-x64 -j3'


### PR DESCRIPTION
We could upload the resulting bins somewhere but that get added at a later point.