### PR TITLE
Logger: runtime log config, no logs till a user selects wallet mode

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1367,6 +1367,7 @@ ApplicationWindow {
         } else {
             wizard.wizardState = "wizardHome";
             rootItem.state = "normal"
+            logger.resetLogFilePath(persistentSettings.portable);
             openWallet("wizard");
         }
 

--- a/pages/settings/SettingsInfo.qml
+++ b/pages/settings/SettingsInfo.qml
@@ -272,9 +272,9 @@ Rectangle {
                     <style type='text/css'>\
                         a {cursor:pointer;text-decoration: none; color: #FF6C3C}\
                     </style>\
-                    <a href='#'>%1</a>".arg(walletLogPath)
+                    <a href='#'>%1</a>".arg(logger.logFilePath)
                 textFormat: Text.RichText
-                onLinkActivated: oshelper.openContainingFolder(walletLogPath)
+                onLinkActivated: oshelper.openContainingFolder(logger.logFilePath)
 
                 MouseArea {
                     anchors.fill: parent
@@ -397,7 +397,7 @@ Rectangle {
                     if(currentWallet)
                         data += currentWallet.walletCreationHeight;
 
-                    data += "\nWallet log path: " + walletLogPath;
+                    data += "\nWallet log path: " + logger.logFilePath;
                     data += "\nWallet mode: " + walletModeString;
                     data += "\nGraphics mode: " + isOpenGL ? "OpenGL" : "Low graphics mode";
                     if (isTails)

--- a/src/main/Logger.h
+++ b/src/main/Logger.h
@@ -26,11 +26,28 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef LOGGER_H
-#define LOGGER_H
+#pragma once
 
-const QString getLogPath(const QString logPath);
-void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message);
+#include <QCoreApplication>
+#include <QObject>
+#include <QString>
 
-#endif // LOGGER_H
+class Logger : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString logFilePath READ logFilePath NOTIFY logFilePathChanged)
 
+public:
+    Logger(QCoreApplication &parent, QString userDefinedLogFilePath);
+
+    Q_INVOKABLE void resetLogFilePath(bool portable);
+    QString logFilePath() const;
+
+signals:
+    void logFilePathChanged() const;
+
+private:
+    const std::string m_applicationFilePath;
+    QString m_logFilePath;
+    const QString m_userDefinedLogFilePath;
+};

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -61,7 +61,6 @@
 #include "model/SubaddressModel.h"
 #include "SubaddressAccount.h"
 #include "model/SubaddressAccountModel.h"
-#include "wallet/api/wallet2_api.h"
 #include "Logger.h"
 #include "MainApp.h"
 #include "qt/downloader.h"
@@ -269,10 +268,7 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 
     Monero::Utils::onStartup();
 
-    // Log settings
-    const QString logPath = QDir::toNativeSeparators(getLogPath(parser.value(logPathOption)));
-    Monero::Wallet::init(argv[0], "monero-wallet-gui", logPath.toStdString().c_str(), true);
-    qInstallMessageHandler(messageHandler);
+    Logger logger(app, parser.value(logPathOption));
 
     // loglevel is configured in main.qml. Anything lower than
     // qWarning is not shown here unless MONERO_LOG_LEVEL env var is set
@@ -281,7 +277,7 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
     if (logLevelOk && logLevel >= 0 && logLevel <= Monero::WalletManagerFactory::LogLevel_Max){
         Monero::WalletManagerFactory::setLogLevel(logLevel);
     }
-    qWarning().noquote() << "app startd" << "(log: " + logPath + ")";
+    qWarning().noquote() << "app startd" << "(log: " + logger.logFilePath() + ")";
 
     if (parser.isSet(verifyUpdateOption))
     {
@@ -446,13 +442,13 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 
     engine.addImageProvider(QLatin1String("qrcode"), new QRCodeImageProvider());
 
+    engine.rootContext()->setContextProperty("logger", &logger);
+
     engine.rootContext()->setContextProperty("mainApp", &app);
 
     engine.rootContext()->setContextProperty("IPC", ipc);
 
     engine.rootContext()->setContextProperty("qtRuntimeVersion", qVersion());
-
-    engine.rootContext()->setContextProperty("walletLogPath", logPath);
 
     engine.rootContext()->setContextProperty("tailsUsePersistence", TailsOS::usePersistence);
 

--- a/src/qt/MoneroSettings.cpp
+++ b/src/qt/MoneroSettings.cpp
@@ -191,7 +191,7 @@ QString MoneroSettings::portableFilePath() const
     return filename;
 }
 
-QString MoneroSettings::portableFolderName() const
+QString MoneroSettings::portableFolderName()
 {
     return "monero-storage";
 }

--- a/src/qt/MoneroSettings.h
+++ b/src/qt/MoneroSettings.h
@@ -63,6 +63,8 @@ public:
     Q_INVOKABLE bool setPortable(bool enabled);
     Q_INVOKABLE void setWritable(bool enabled);
 
+    static QString portableFolderName();
+
 public slots:
     void _q_propertyChanged();
 
@@ -84,7 +86,6 @@ private:
     bool portable() const;
     bool portableConfigExists() const;
     QString portableFilePath() const;
-    QString portableFolderName() const;
     std::unique_ptr<QSettings> portableSettings() const;
     std::unique_ptr<QSettings> unportableSettings() const;
     void swap(std::unique_ptr<QSettings> newSettings);

--- a/wizard/WizardModeSelection.qml
+++ b/wizard/WizardModeSelection.qml
@@ -48,6 +48,7 @@ Rectangle {
             return;
         }
 
+        logger.resetLogFilePath(portable);
         appWindow.changeWalletMode(mode);
         wizardController.wizardStackView.backTransition = false;
         wizardController.wizardState = wizardState;


### PR DESCRIPTION
* Should't create/write any log file till wallet mode gets selected If a user starts Monero GUI for the first time,
* Portable mode: writes log file to `monero-storage` folder.
