### PR TITLE
main: store only when wallet is synced

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1895,7 +1895,7 @@ ApplicationWindow {
         repeat: true
         running: persistentSettings.autosave
         onTriggered: {
-            if (currentWallet) {
+            if (currentWallet && walletSynced) {
                 currentWallet.storeAsync(function(success) {
                     if (success) {
                         appWindow.showStatusMessage(qsTr("Autosaved the wallet"), 3);


### PR DESCRIPTION
Storing the wallet cache to disk can cause a crash
during wallet scan.