### PR TITLE
SettingsWallet: disable creating view-only wallet for Ledger

### DIFF
--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -62,7 +62,7 @@ Rectangle {
             iconText: FontAwesome.eye
             description: qsTr("Creates a new wallet that can only view and initiate transactions, but requires a spendable wallet to sign transactions before sending.") + translationManager.emptyString
             title: qsTr("Create a view-only wallet") + translationManager.emptyString
-            visible: !appWindow.viewOnly
+            visible: !appWindow.viewOnly && !currentWallet.isLedger()
 
             onClicked: {
                 var newPath = currentWallet.path + "_viewonly";


### PR DESCRIPTION
Ledger doesn't support creating view-only wallet. See #3151 and https://www.reddit.com/r/monerosupport/comments/jcaet1/error_couldnt_open_wallet_file_mywallet_viewonly/