### PR TITLE
Restore: add create view-only wallet option

### DIFF
--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -262,7 +262,7 @@ Rectangle {
                 visible: wizardController.walletRestoreMode === 'keys'
                 Layout.fillWidth: true
                 placeholderFontSize: 16
-                placeholderText: qsTr("Spend key (private)") + translationManager.emptyString
+                placeholderText: qsTr("Spend key (private)") + " / " + qsTr("Leave blank to create a view-only wallet") + translationManager.emptyString
 
                 onTextUpdated: {
                     wizardRestoreWallet1.verifyFromKeys();


### PR DESCRIPTION
Restore page can be used to create view-only wallets from address + private view key.
This PR updates the placeholder of private spend key field to inform that it's optional and should be left blank in order to generate a view-only wallet.