### PR TITLE
Restore: display red border if invalid seed

### DIFF
--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -51,10 +51,8 @@ Rectangle {
             valid = wizardRestoreWallet1.verifyFromKeys();
             return valid;
         } else if(wizardController.walletRestoreMode === "seed") {
-            valid = wizardWalletInput.verify();
-            if(!valid) return false;
-            valid = Wizard.checkSeed(seedInput.text);
-            return valid;
+            seedInput.error = seedInput.text && !Wizard.checkSeed(seedInput.text);
+            return wizardWalletInput.verify() && seedInput.text && Wizard.checkSeed(seedInput.text);
         }
 
         return false;


### PR DESCRIPTION
Changes:
- If seed field contains a seed <24 or >25 words (word count is done in function `checkSeed(seed)` in `/js/Wizard.js`), a red border is displayed to indicate an invalid seed