### PR TITLE
WizardRestoreWallet1: fix "wallet name" check in keys mode

### DIFF
--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -48,8 +48,7 @@ Rectangle {
 
         var valid = false;
         if(wizardController.walletRestoreMode === "keys") {
-            valid = wizardRestoreWallet1.verifyFromKeys();
-            return valid;
+            return wizardWalletInput.verify() && wizardRestoreWallet1.verifyFromKeys();
         } else if(wizardController.walletRestoreMode === "seed") {
             valid = wizardWalletInput.verify();
             if(!valid) return false;


### PR DESCRIPTION
You could click "next" even if the wallet name is invalid.