### PR TITLE
cmake: fix install targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -178,5 +178,5 @@ add_custom_command(TARGET monero-wallet-gui POST_BUILD COMMAND ${CMAKE_COMMAND} 
 include(Deploy)
 
 install(TARGETS monero-wallet-gui
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION bin
 )


### PR DESCRIPTION
Binary should be installed in bin/ relative to CMAKE_INSTALL_PREFIX,
prior to this commit, monero-wallet-gui is installed in usr/ instead of
usr/bin

  -- Installing: image/usr/monero-wallet-gui

With this comment, file is installed in the right location:

  -- Installing: image/usr/bin/monero-wallet-gui

See: https://cmake.org/cmake/help/latest/command/install.html