### PR TITLE
wallet: set right signedness

### DIFF
--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -1125,7 +1125,7 @@ void Wallet::startRefreshThread()
             if (m_refreshEnabled)
             {
                 const auto now = std::chrono::steady_clock::now();
-                const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - last).count();
+                const size_t elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - last).count();
                 if (elapsed >= refreshIntervalSec)
                 {
                     refresh(false);


### PR DESCRIPTION
libwalletqt fails to build with gcc 9.3.0 and QT 5.14.2 with the
following error

```
  x86_64-pc-linux-gnu-g++ -c -march=native -O2 -pipe -fomit-frame-pointer -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-0.17.1.0/src -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-0.17.1.0/contrib/epee/include -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-0.17.1.0/external/easylogging++ -fPIC -fstack-protector -fstack-protector-strong -Werror -Wformat -Wformat-security -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -O2 -std=gnu++11 -pthread -Wall -Wextra -D_REENTRANT -fPIC -DWITH_SCANNER -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_QUICK_LIB -DQT_MULTIMEDIA_LIB -DQT_GUI_LIB -DQT_QMLMODELS_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-gui-0.17.1.0/monero/include -Isrc/libwalletqt -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-gui-0.17.1.0/src/QR-Code-generator -Isrc -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-gui-0.17.1.0/monero/src -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-gui-0.17.1.0/monero/external/easylogging++ -I/var/tmp/portage/net-p2p/monero-gui-0.17.1.0/work/monero-gui-0.17.1.0/monero/contrib/epee/include -Isrc/QR-Code-scanner -isystem /usr/include/libusb-1.0 -isystem /usr/include/hidapi -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtSvg -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui/5.14.2 -isystem /usr/include/qt5/QtGui/5.14.2/QtGui -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtMultimedia -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQmlModels -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore/5.14.2 -isystem /usr/include/qt5/QtCore/5.14.2/QtCore -isystem /usr/include/qt5/QtCore -I. -I/usr/lib64/qt5/mkspecs/linux-g++ -o Wallet.o src/libwalletqt/Wallet.cpp
  src/libwalletqt/Wallet.cpp: In lambda function:
  src/libwalletqt/Wallet.cpp:1129:29: error: comparison of integer expressions of different signedness: 'const long int' and 'const size_t' {aka 'const long unsigned int'} [-Werror=sign-compare]
   1129 |                 if (elapsed >= refreshIntervalSec)
        |                     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
  cc1plus: all warnings being treated as errors
  make: *** [Makefile:1934: Wallet.o] Error 1
```