### PR TITLE
SuccessfulTxDialog: add View progress button

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -119,6 +119,12 @@ Rectangle {
         transferView.sendTo(address, paymentId, description);
     }
 
+    // open Transactions page with search term in search field
+    function searchInHistory(searchTerm){
+        root.state = "History";
+        historyView.searchInHistory(searchTerm);
+    }
+
         states: [
             State {
                 name: "History"

--- a/components/SuccessfulTxDialog.qml
+++ b/components/SuccessfulTxDialog.qml
@@ -132,13 +132,27 @@ Rectangle {
             fontSize: 16
         }
 
-        // open folder / done buttons
+        // view progress / open folder / done buttons
         RowLayout {
             id: buttons
             spacing: 70
             Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
             Layout.fillWidth: true
             Layout.preferredHeight: 50
+
+            MoneroComponents.StandardButton {
+                id: viewProgressButton
+                visible: !appWindow.viewOnly
+                text: qsTr("View progress") + translationManager.emptyString;
+                width: 200
+                primary: false
+                KeyNavigation.tab: doneButton
+                onClicked: {
+                    doSearchInHistory(root.transactionID);
+                    root.close()
+                    root.rejected()
+                }
+            }
 
             MoneroComponents.StandardButton {
                 id: openFolderButton
@@ -156,7 +170,7 @@ Rectangle {
                 text: qsTr("Done") + translationManager.emptyString;
                 width: 200
                 focus: root.visible
-                KeyNavigation.tab: openFolderButton
+                KeyNavigation.tab: appWindow.viewOnly ? openFolderButton : viewProgressButton
                 onClicked: {
                     root.close()
                     root.accepted()

--- a/main.qml
+++ b/main.qml
@@ -983,6 +983,11 @@ ApplicationWindow {
         });
     }
 
+    function doSearchInHistory(searchTerm) {
+        middlePanel.searchInHistory(searchTerm);
+        leftPanel.selectItem(middlePanel.state)
+    }
+
     // called on "getProof"
     function handleGetProof(txid, address, message) {
         console.log("Getting payment proof: ")
@@ -1113,6 +1118,7 @@ ApplicationWindow {
             middlePanel.addressBookView.clearFields();
             middlePanel.transferView.clearFields();
             middlePanel.receiveView.clearFields();
+            middlePanel.historyView.clearFields();
             // disable timers
             userInActivityTimer.running = false;
         });


### PR DESCRIPTION
Closes #2148

Main changes:
- SuccessfulTxDialog: add View progress (secondary) button
- History: auto collapse tx item if there is a single result
- History: clean searchInput + list of collapsed txs when closing page
- History: add FontAwesome icons for txs with Pending and Failed states
- History: Display Pending and Failed states to the right of "Sent" and "Received" labels