### PR TITLE
portable: use portable storage folder to store QML disk cache

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -190,6 +190,20 @@ int main(int argc, char *argv[])
     // Turn off colors in monerod log output.
     qputenv("TERM", "goaway");
 
+#if defined(Q_OS_MACOS)
+    QDir::setCurrent(QDir(MacOSHelper::bundlePath() + QDir::separator() + "..").canonicalPath());
+#endif
+
+    if (MoneroSettings::portableConfigExists())
+    {
+        const QString cacheDir(MoneroSettings::portableFolderName() + QDir::separator() + ".cache");
+        if (!qputenv("QML_DISK_CACHE_PATH", cacheDir.toUtf8()))
+        {
+            qCritical() << "Error: failed to set QML disk cache path";
+            return 1;
+        }
+    }
+
     MainApp app(argc, argv);
 
 #if defined(Q_OS_WIN)
@@ -325,10 +339,6 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 
     // start listening
     QTimer::singleShot(0, ipc, SLOT(bind()));
-
-#if defined(Q_OS_MACOS)
-    QDir::setCurrent(QDir(MacOSHelper::bundlePath() + QDir::separator() + "..").canonicalPath());
-#endif
 
     // screen settings
     // Mobile is designed on 128dpi

--- a/src/qt/MoneroSettings.cpp
+++ b/src/qt/MoneroSettings.cpp
@@ -179,13 +179,13 @@ bool MoneroSettings::portable() const
     return this->m_settings && this->m_settings->fileName() == portableFilePath();
 }
 
-bool MoneroSettings::portableConfigExists() const
+bool MoneroSettings::portableConfigExists()
 {
     QFileInfo info(portableFilePath());
     return info.exists() && info.isFile();
 }
 
-QString MoneroSettings::portableFilePath() const
+QString MoneroSettings::portableFilePath()
 {
     static QString filename(QDir(portableFolderName()).absoluteFilePath("settings.ini"));
     return filename;

--- a/src/qt/MoneroSettings.h
+++ b/src/qt/MoneroSettings.h
@@ -64,6 +64,7 @@ public:
     Q_INVOKABLE void setWritable(bool enabled);
 
     static QString portableFolderName();
+    static bool portableConfigExists();
 
 public slots:
     void _q_propertyChanged();
@@ -84,8 +85,7 @@ private:
     void store();
 
     bool portable() const;
-    bool portableConfigExists() const;
-    QString portableFilePath() const;
+    static QString portableFilePath();
     std::unique_ptr<QSettings> portableSettings() const;
     std::unique_ptr<QSettings> unportableSettings() const;
     void swap(std::unique_ptr<QSettings> newSettings);


### PR DESCRIPTION
Related https://github.com/monero-project/monero-gui/issues/3241