### PR TITLE
workflows: shorten name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: continuous-integration/gh-actions/gui
+name: ci/gh-actions/gui
 
 on: [push, pull_request]
 


### PR DESCRIPTION
No reason for such a long name now that we remove Travis.