### PR TITLE
SettingsLog: disable daemon command input in Remote Node mode 

### DIFF
--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -215,6 +215,7 @@ Rectangle {
             Layout.fillWidth: true
             property var lastCommands: []
             property int currentCommandIndex
+            enabled: !persistentSettings.useRemoteNode
             fontBold: false
             placeholderText: qsTr("command + enter (e.g 'help' or 'status')") + translationManager.emptyString
             placeholderFontSize: 16


### PR DESCRIPTION
Closes https://github.com/monero-project/monero-gui/issues/3228