### PR TITLE
DaemonManagerDialog use preferred color scheme

### DIFF
--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -52,6 +52,7 @@ Window {
     // TODO: implement without hardcoding sizes
     width: 480
     height: 200
+    color: MoneroComponents.Style.middlePanelBackgroundColor
 
     // Make window draggable
     MouseArea {
@@ -96,7 +97,7 @@ Window {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 themeTransition: false
-                color: "black"
+                color: MoneroComponents.Style.defaultFontColor
             }
 
         }


### PR DESCRIPTION
The white window with black text looks out of place when using the dark theme. Instead use the default colors for the currently selected theme.