### PR TITLE
Renamed Norwegian translation file to the correct name.

### DIFF
--- a/translations/monero-core_nb.ts
+++ b/translations/monero-core_nb.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="nb_NO">
+<TS version="2.1" language="nb">
 <context>
     <name>Account</name>
     <message>


### PR DESCRIPTION
It seems like the name was incorrect since the Norwegian translation in the program did not function with that file name.

Fixes #3353