### PR TITLE
daemon manager: add remote node and offline options

### DIFF
--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -40,8 +40,10 @@ Window {
     modality: Qt.ApplicationModal
     flags: Qt.Window | Qt.FramelessWindowHint
     property int countDown: 10;
-    signal rejected()
     signal started();
+    signal remoteChose();
+    signal offlineChose();
+    signal rejected();
 
     function open() {
         show()
@@ -91,7 +93,7 @@ Window {
             }
 
             MoneroComponents.TextPlain {
-                text: qsTr("Starting local node in %1 seconds").arg(countDown) + translationManager.emptyString;
+                text: qsTr("Starting local node in %1 seconds\n or").arg(countDown) + translationManager.emptyString;
                 font.pixelSize: 18
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
@@ -104,7 +106,7 @@ Window {
 
         RowLayout {
             id: buttons
-            spacing: 60
+            spacing: 20
             Layout.alignment: Qt.AlignHCenter
 
             MoneroComponents.StandardButton {
@@ -112,7 +114,7 @@ Window {
                 visible:false
                 fontSize: 14
                 text: qsTr("Start daemon (%1)").arg(countDown) + translationManager.emptyString
-                KeyNavigation.tab: cancelButton
+                KeyNavigation.tab: buttonsRow
                 onClicked: {
                     timer.stop();
                     root.close()
@@ -121,15 +123,42 @@ Window {
                 }
             }
 
-            MoneroComponents.StandardButton {
-                id: cancelButton
-                fontSize: 14
-                text: qsTr("Use custom settings") + translationManager.emptyString
+            RowLayout {
+                id: buttonsRow
+                MoneroComponents.StandardButton {
+                    id: remoteNodeButton
+                    fontSize: 14
+                    text: qsTr("Remote Node") + translationManager.emptyString
 
-                onClicked: {
-                    timer.stop();
-                    root.close()
-                    root.rejected()
+                    onClicked: {
+                        timer.stop();
+                        root.close()
+                        root.remoteChose();
+                    }
+                }
+
+                MoneroComponents.StandardButton {
+                    id: offlineButton
+                    fontSize: 14
+                    text: qsTr("Offline") + translationManager.emptyString
+
+                    onClicked: {
+                        timer.stop();
+                        root.close();
+                        root.offlineChose();
+                    }
+                }
+
+                MoneroComponents.StandardButton {
+                    id: cancelButton
+                    fontSize: 14
+                    text: qsTr("Custom") + translationManager.emptyString
+
+                    onClicked: {
+                        timer.stop();
+                        root.close()
+                        root.rejected()
+                    }
                 }
             }
         }

--- a/main.qml
+++ b/main.qml
@@ -614,6 +614,7 @@ ApplicationWindow {
     function connectRemoteNode() {
         console.log("connecting remote node");
 
+        currentWallet.setOffline(false); // make sure
         const callback = function() {
             persistentSettings.useRemoteNode = true;
             currentDaemonAddress = persistentSettings.remoteNodeAddress;
@@ -1614,6 +1615,12 @@ ApplicationWindow {
 
     DaemonManagerDialog {
         id: daemonManagerDialog
+        onRemoteChose: {
+            connectRemoteNode();
+        }
+        onOfflineChose: {
+            currentWallet.setOffline(true);
+        }
         onRejected: {
             middlePanel.settingsView.settingsStateViewState = "Node";
             loadPage("Settings");

--- a/pages/settings/SettingsNode.qml
+++ b/pages/settings/SettingsNode.qml
@@ -138,6 +138,7 @@ Rectangle{
                 anchors.fill: parent
                 enabled: persistentSettings.useRemoteNode
                 onClicked: {
+                    appWindow.currentWallet.setOffline(false); // make sure wallet will connect
                     persistentSettings.useRemoteNode = false;
                     appWindow.disconnectRemoteNode();
                 }

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -961,6 +961,11 @@ QString Wallet::getDaemonLogPath() const
     return QString::fromStdString(m_walletImpl->getDefaultDataDir()) + "/bitmonero.log";
 }
 
+void Wallet::setOffline(bool offline) 
+{
+    m_walletImpl->setOffline(offline);
+}
+
 bool Wallet::blackballOutput(const QString &amount, const QString &offset)
 {
     return m_walletImpl->blackballOutput(amount.toStdString(), offset.toStdString());

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -336,6 +336,9 @@ public:
     QString getDaemonLogPath() const;
     QString getWalletLogPath() const;
 
+    // toggle offline = true, offline = false
+    Q_INVOKABLE void setOffline(bool offline);
+
     // Blackalled outputs
     Q_INVOKABLE bool blackballOutput(const QString &amount, const QString &offset);
     Q_INVOKABLE bool blackballOutputs(const QList<QString> &outputs, bool add);


### PR DESCRIPTION
I thought this seemed like a good way to add an offline mode as suggested in #3226.

![daemon_options](https://user-images.githubusercontent.com/55565574/113616053-3bb58500-961a-11eb-8211-c80cd346917a.png)

Depends on [these changes](https://github.com/benevanoff/monero/commit/25e82545f35b5bfe8beb17220c232fb89411d4da) to core but I'm blocked by the filter rn :/