### PR TITLE
workflows: cache android docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,12 +95,11 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - uses: satackey/action-docker-layer-caching@v0.0.10
+    - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
       with:
         key: docker-linux-static-{hash}
-        restore-keys: |
-          docker-linux-static-
+        restore-keys: docker-linux-static-
     - name: install dependencies
       run: sudo apt -y install xvfb libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0
     - name: preprare build enviroment
@@ -124,12 +123,11 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - uses: satackey/action-docker-layer-caching@v0.0.10
+    - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
       with:
         key: docker-windows-static-{hash}
-        restore-keys: |
-          docker-windows-static-
+        restore-keys: docker-windows-static-
     - name: preprare build enviroment
       run: docker build --tag monero:build-env-windows --build-arg THREADS=3 --file Dockerfile.windows .
     - name: build
@@ -149,6 +147,11 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
+      with:
+        key: docker-android-{hash}
+        restore-keys: docker-android-
     - name: preprare build enviroment
       run: docker build --tag monero:build-env-android --build-arg THREADS=3 --file Dockerfile.android .
     - name: build


### PR DESCRIPTION
As far as I can see both Linux and Windows cache are less than 1GB. Github allows 5GB cache per repo so it should be fine to cache android too.