### PR TITLE
without StartupWMClass=monero-wallet-gui gnome-shell users can not ad…

### DIFF
--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -105,6 +105,7 @@ QString xdgMime(){
         "StartupNotify=true\n"
         "X-GNOME-Bugzilla-Bugzilla=GNOME\n"
         "X-GNOME-UsesNotifications=true\n"
+        "StartupWMClass=monero-wallet-gui\n"
     ).arg(QCoreApplication::applicationFilePath());
 }
 


### PR DESCRIPTION

without StartupWMClass=monero-wallet-gui gnome-shell users can not add the applications to their favourites.
.I really do not know why this setting is required within gnome-shell - but it works.
![2](https://user-images.githubusercontent.com/3032624/114152804-fac1b700-991e-11eb-8771-938d973f5f91.png)
![1](https://user-images.githubusercontent.com/3032624/114152822-fdbca780-991e-11eb-8d4a-8670808476fd.png)

Distributor ID:	Debian
Description:	Debian GNU/Linux bullseye/sid
Release:	testing
Codename:	bullseye