### PR TITLE
SettingsLayout: add "Tor" to "Socks5 proxy"

### DIFF
--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -265,7 +265,7 @@ Rectangle {
             onClicked: {
                 persistentSettings.proxyEnabled = !persistentSettings.proxyEnabled;
             }
-            text: qsTr("Socks5 proxy (%1%2)")
+            text: qsTr("Tor Socks5 proxy (%1%2)")
                 .arg(appWindow.walletMode >= 2 ? qsTr("remote node connections, ") : "")
                 .arg(qsTr("updates downloading, fetching price sources")) + translationManager.emptyString
         }


### PR DESCRIPTION
Not everyone knows that Socks5 proxy is used by Tor