### PR TITLE
Receive: bring back large copy button (without uri)

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -301,6 +301,18 @@ Rectangle {
             MoneroComponents.StandardButton {
                 Layout.preferredWidth: 220
                 small: true
+                text: FontAwesome.clipboard + "  %1".arg(qsTr("Copy to clipboard")) + translationManager.emptyString
+                label.font.family: FontAwesome.fontFamily
+                fontSize: 13
+                onClicked: {
+                    clipboard.setText(TxUtils.makeQRCodeString(appWindow.current_address));
+                    appWindow.showStatusMessage(qsTr("Copied to clipboard") + translationManager.emptyString, 3);
+                }
+            }
+
+            MoneroComponents.StandardButton {
+                Layout.preferredWidth: 220
+                small: true
                 text: FontAwesome.eye + "  %1".arg(qsTr("Show on device")) + translationManager.emptyString
                 label.font.family: FontAwesome.fontFamily
                 fontSize: 13

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -305,7 +305,7 @@ Rectangle {
                 label.font.family: FontAwesome.fontFamily
                 fontSize: 13
                 onClicked: {
-                    clipboard.setText(TxUtils.makeQRCodeString(appWindow.current_address));
+                    clipboard.setText(appWindow.current_address);
                     appWindow.showStatusMessage(qsTr("Copied to clipboard") + translationManager.emptyString, 3);
                 }
             }


### PR DESCRIPTION
Suggested here: https://github.com/monero-project/monero-gui/issues/3243#issuecomment-781109208

I kinda agree that having a large copy button is more user friendly, especially on the receive page. Any other opinions?