### PR TITLE
WizardHome: fix kdf textbox displaying incorrect value

### DIFF
--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -223,7 +223,7 @@ Rectangle {
                     validator: IntValidator { bottom: 1 }
                     text: persistentSettings.kdfRounds ? persistentSettings.kdfRounds : "1"
                     onTextChanged: {
-                        kdfRoundsText.text = persistentSettings.kdfRounds = parseInt(kdfRoundsText.text) >= 1 ? parseInt(kdfRoundsText.text) : 1;
+                        persistentSettings.kdfRounds = parseInt(kdfRoundsText.text) >= 1 ? parseInt(kdfRoundsText.text) : 1;
                     }
                 }
 


### PR DESCRIPTION
Related to #3088

Textbox would always display 1, even if the `persistentSettings.kdfRounds` value is different.