### PR TITLE
WalletManager: support kdf round in device wallet restore

### DIFF
--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -169,7 +169,7 @@ Wallet *WalletManager::createWalletFromKeys(const QString &path, const QString &
 }
 
 Wallet *WalletManager::createWalletFromDevice(const QString &path, const QString &password, NetworkType::Type nettype,
-                                              const QString &deviceName, quint64 restoreHeight, const QString &subaddressLookahead)
+                                              const QString &deviceName, quint64 restoreHeight, const QString &subaddressLookahead, quint64 kdfRounds)
 {
     QMutexLocker locker(&m_mutex);
     WalletPassphraseListenerImpl tmpListener(this);
@@ -187,7 +187,7 @@ Wallet *WalletManager::createWalletFromDevice(const QString &path, const QString
         m_currentWallet = NULL;
     }
     Monero::Wallet * w = m_pimpl->createWalletFromDevice(path.toStdString(), password.toStdString(), static_cast<Monero::NetworkType>(nettype),
-                                                         deviceName.toStdString(), restoreHeight, subaddressLookahead.toStdString(), 1, &tmpListener);
+                                                         deviceName.toStdString(), restoreHeight, subaddressLookahead.toStdString(), kdfRounds, &tmpListener);
     w->setListener(nullptr);
 
     m_currentWallet = new Wallet(w);
@@ -202,10 +202,10 @@ Wallet *WalletManager::createWalletFromDevice(const QString &path, const QString
 
 
 void WalletManager::createWalletFromDeviceAsync(const QString &path, const QString &password, NetworkType::Type nettype,
-                                                const QString &deviceName, quint64 restoreHeight, const QString &subaddressLookahead)
+                                                const QString &deviceName, quint64 restoreHeight, const QString &subaddressLookahead, quint64 kdfRounds)
 {
-    m_scheduler.run([this, path, password, nettype, deviceName, restoreHeight, subaddressLookahead] {
-        Wallet *wallet = createWalletFromDevice(path, password, nettype, deviceName, restoreHeight, subaddressLookahead);
+    m_scheduler.run([this, path, password, nettype, deviceName, restoreHeight, subaddressLookahead, kdfRounds] {
+        Wallet *wallet = createWalletFromDevice(path, password, nettype, deviceName, restoreHeight, subaddressLookahead, kdfRounds);
         emit walletCreated(wallet);
     });
 }

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -103,14 +103,16 @@ public:
                                                 NetworkType::Type nettype,
                                                 const QString &deviceName,
                                                 quint64 restoreHeight = 0,
-                                                const QString &subaddressLookahead = "");
+                                                const QString &subaddressLookahead = "",
+                                                quint64 kdfRounds = 1);
 
     Q_INVOKABLE void createWalletFromDeviceAsync(const QString &path,
                                                 const QString &password,
                                                 NetworkType::Type nettype,
                                                 const QString &deviceName,
                                                 quint64 restoreHeight = 0,
-                                                const QString &subaddressLookahead = "");
+                                                const QString &subaddressLookahead = "",
+                                                quint64 kdfRounds = 1);
     /*!
      * \brief closeWallet - closes current open wallet and frees memory
      * \return wallet address

--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -450,12 +450,13 @@ Rectangle {
         tmpWalletFilename = oshelper.temporaryFilename();
         console.log("Creating temporary wallet", tmpWalletFilename)
         var nettype = persistentSettings.nettype;
+        var kdfRounds = persistentSettings.kdfRounds;
         var restoreHeight = wizardController.walletOptionsRestoreHeight;
         var subaddressLookahead = wizardController.walletOptionsSubaddressLookahead;
         var deviceName = wizardController.walletOptionsDeviceName;
 
         connect();
-        walletManager.createWalletFromDeviceAsync(tmpWalletFilename, "", nettype, deviceName, restoreHeight, subaddressLookahead);
+        walletManager.createWalletFromDeviceAsync(tmpWalletFilename, "", nettype, deviceName, restoreHeight, subaddressLookahead, kdfRounds);
         creatingWalletDeviceSplash();
     }
 


### PR DESCRIPTION
Related to #3088

`createWalletFromDeviceAsync()` would ignore the kdf value while `openWalletAsync()` would take it into account, leading to the bug that hardware wallets created with kdf > 1 would fail to open.