### PR TITLE
WizardCreateDevice1: subaddress lookahead option visible only when re…

### DIFF
--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -138,6 +138,7 @@ Rectangle {
                 CheckBox2 {
                     id: showAdvancedCheckbox
                     checked: false
+                    visible: !newDeviceWallet.checked
                     text: qsTr("Advanced options") + translationManager.emptyString
                 }
 


### PR DESCRIPTION
…storing a wallet

There is no use for "subaddress lookahead" option when you are creating a new wallet from device, since you're not restoring anything. More info [here](https://monero.stackexchange.com/questions/11223/when-setting-up-monero-wallet-with-ledger-nano-s-what-are-the-options-restore).