### PR TITLE
cmake: link translations target with Qt5::Core

### DIFF
--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -46,3 +46,4 @@ set_source_files_properties(${TRANSLATIONS_CPP} PROPERTIES SKIP_AUTOMOC ON)
 set_source_files_properties(${TRANSLATIONS_CPP} PROPERTIES SKIP_AUTOUIC ON)
 
 add_library(translations ${TRANSLATIONS_CPP})
+target_link_libraries(translations PUBLIC Qt5::Core)


### PR DESCRIPTION
Required for debug build on Mac.

```
[360/428] Linking CXX shared library translations/libtranslations.dylib
FAILED: translations/libtranslations.dylib 
: && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -march=x86-64 -fvisibility=default -std=c++11 -fvisibility=default -DGTEST_HAS_TR1_TUPLE=0 -std=c++11  -Werror -Wformat -Wformat-security -fstack-protector -fstack-protector-strong -fcf-protection=full -fno-strict-aliasing -fPIC -g -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk -dynamiclib -Wl,-headerpad_max_install_names  -o translations/libtranslations.dylib -install_name @rpath/libtranslations.dylib translations/CMakeFiles/translations.dir/translations_autogen/mocs_compilation.cpp.o translations/CMakeFiles/translations.dir/qrc_translations.cpp.o  -Wl,-rpath,/usr/local/opt/qt@5/lib && :
Undefined symbols for architecture x86_64:
  "qRegisterResourceData(int, unsigned char const*, unsigned char const*, unsigned char const*)", referenced from:
      qInitResources_translations() in qrc_translations.cpp.o
  "qUnregisterResourceData(int, unsigned char const*, unsigned char const*, unsigned char const*)", referenced from:
      qCleanupResources_translations() in qrc_translations.cpp.o
  "_qt_resourceFeatureZlib", referenced from:
      qResourceFeatureZlib() in qrc_translations.cpp.o
ld: symbol(s) not found for architecture x86_64--
```

Fix found by @perfect-daemon