### PR TITLE
Revert "Animation slow down for debugging"

### DIFF
--- a/src/main/filter.cpp
+++ b/src/main/filter.cpp
@@ -27,13 +27,8 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "filter.h"
-#include <QtGlobal>
 #include <QKeyEvent>
 #include <QDebug>
-
-#ifdef QT_DEBUG
-    #include "private/qabstractanimation_p.h"
-#endif
 
 filter::filter(QObject *parent) :
     QObject(parent)
@@ -90,21 +85,6 @@ bool filter::eventFilter(QObject *obj, QEvent *ev) {
     } break;
     case QEvent::KeyRelease: {
         QKeyEvent *ke = static_cast<QKeyEvent*>(ev);
-
-#ifdef QT_DEBUG
-        if(ke->key() == Qt::Key_F9){
-            QUnifiedTimer::instance()->setSlowModeEnabled(true);
-            QUnifiedTimer::instance()->setSlowdownFactor(10);
-            qDebug() << "Slow animations enabled";
-        }
-
-        if(ke->key() == Qt::Key_F10){
-            QUnifiedTimer::instance()->setSlowModeEnabled(false);
-            QUnifiedTimer::instance()->setSlowdownFactor(1);
-
-            qDebug() << "Slow animations disabled";
-        }
-#endif
 
         if(ke->key() == Qt::Key_Backtab)
             m_backtabPressed = false;


### PR DESCRIPTION
This reverts commit baff7f213f07b7ae134062cd54b22c691f48fbe4.

This is broken without private Qt headers. With qmake this was easy to add (`gui-private`), I did not figure out how to do it with cmake so I will revert this instead of having broken debug build.