### PR TITLE
cmake: explicitly link Qt5::GuiPrivate during debug build

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The following instructions will fetch Qt from your distribution's repositories i
 
   - For Ubuntu 17.10+
 
-    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtqml-models2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-xmllistmodel qml-module-qt-labs-settings qml-module-qt-labs-platform qml-module-qt-labs-folderlistmodel qttools5-dev-tools qml-module-qtquick-templates2 libqt5svg5-dev`
+    `sudo apt install qtbase5-dev qt5-default qtdeclarative5-dev qml-module-qtqml-models2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-xmllistmodel qml-module-qt-labs-settings qml-module-qt-labs-platform qml-module-qt-labs-folderlistmodel qttools5-dev-tools qml-module-qtquick-templates2 libqt5svg5-dev qtbase5-private-dev`
 
   - For Gentoo
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,6 +162,10 @@ target_link_libraries(monero-wallet-gui
     translations
 )
 
+if(DEBUG)
+    target_link_libraries(monero-wallet-gui Qt5::GuiPrivate)
+endif()
+
 if(DEVICE_TREZOR_READY)
     target_link_libraries(monero-wallet-gui ${TREZOR_DEP_LIBS})
 endif()


### PR DESCRIPTION
Not sure if I should add this to the README, most users don't do a debug build.

Alternatively: #3441