### PR TITLE
cmake: link with wallet_api instead of wallet_merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-set_property(TARGET wallet_merged PROPERTY FOLDER "monero")
 get_directory_property(ARCH_WIDTH DIRECTORY "monero" DEFINITION ARCH_WIDTH)
-get_directory_property(UNBOUND_LIBRARY DIRECTORY "monero" DEFINITION UNBOUND_LIBRARY)
-get_directory_property(DEVICE_TREZOR_READY DIRECTORY "monero" DEFINITION DEVICE_TREZOR_READY)
-get_directory_property(TREZOR_DEP_LIBS DIRECTORY "monero" DEFINITION TREZOR_DEP_LIBS)
 
 if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(-DQT_NO_DEBUG)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,21 +139,11 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 
 target_link_libraries(monero-wallet-gui
-    wallet_merged
-    ${LMDB_LIBRARY}
     epee
+    wallet_api
     qrcodegen
-    ${UNBOUND_LIBRARY}
-    ${SODIUM_LIBRARY}
     easylogging
-    blockchain_db
-    randomx
-    hardforks
     ${Boost_LIBRARIES}
-    ${OPENSSL_LIBRARIES}
-    ${CMAKE_DL_LIBS}
-    ${LibUSB_LIBRARIES}
-    ${HIDAPI_LIBRARIES}
     ${QT5_LIBRARIES}
     ${EXTRA_LIBRARIES}
     ${ICU_LIBRARIES}
@@ -161,10 +151,6 @@ target_link_libraries(monero-wallet-gui
     qrdecoder
     translations
 )
-
-if(DEVICE_TREZOR_READY)
-    target_link_libraries(monero-wallet-gui ${TREZOR_DEP_LIBS})
-endif()
 
 if(X11_FOUND)
     target_link_libraries(monero-wallet-gui ${X11_LIBRARIES})


### PR DESCRIPTION
Co-authored-by @perfect-daemon

- easylogging
- epee
- EXTRA_LIBRARIES

are used by wallet_api and monero-gui directly so we explicitly link to them.