### PR TITLE
workflows: update cache action, invalidate cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,12 +95,12 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - uses: satackey/action-docker-layer-caching@v0.0.10
+    - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
       with:
-        key: docker-linux-static-{hash}
+        key: docker-linux-static-1-{hash}
         restore-keys: |
-          docker-linux-static-
+          docker-linux-static-1-
     - name: install dependencies
       run: sudo apt -y install xvfb libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xkb1 libxkbcommon-x11-0
     - name: preprare build enviroment
@@ -124,12 +124,12 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - uses: satackey/action-docker-layer-caching@v0.0.10
+    - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
       with:
-        key: docker-windows-static-{hash}
+        key: docker-windows-static-1-{hash}
         restore-keys: |
-          docker-windows-static-
+          docker-windows-static-1-
     - name: preprare build enviroment
       run: docker build --tag monero:build-env-windows --build-arg THREADS=3 --file Dockerfile.windows .
     - name: build


### PR DESCRIPTION
It might be a good idea to invalidate the cache every time we update the workflows file. `-1-` can be bumped to `-2-` next time.