### PR TITLE
cmake: don't add fstack-clash-protection with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,7 +477,7 @@ if (NOT OPENBSD AND NOT (WIN32 AND (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE
   add_c_flag_if_supported(-fcf-protection=full C_SECURITY_FLAGS)
   add_cxx_flag_if_supported(-fcf-protection=full CXX_SECURITY_FLAGS)
 endif()
-if (NOT WIN32 AND NOT OPENBSD)
+if (NOT WIN32 AND NOT OPENBSD AND NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   add_c_flag_if_supported(-fstack-clash-protection C_SECURITY_FLAGS)
   add_cxx_flag_if_supported(-fstack-clash-protection CXX_SECURITY_FLAGS)
 endif()


### PR DESCRIPTION
Compilation fails due to `-Werror` and clang warning about `-fstack-clash-protection` not existing.