### PR TITLE
cmake: explicitly link net and common

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 
 target_link_libraries(monero-wallet-gui
     epee
+    common
+    net
     wallet_api
     qrcodegen
     easylogging


### PR DESCRIPTION
- `common` was introduced in https://github.com/monero-project/monero-gui/pull/2942
- `net` was introduced in https://github.com/monero-project/monero-gui/pull/2799