### PR TITLE
StandardButton: fix warning with fallbackicon

### DIFF
--- a/components/StandardButton.qml
+++ b/components/StandardButton.qml
@@ -143,6 +143,7 @@ Item {
             width: button.small ? 16 : 20
             height: button.small ? 16 : 20
             source: {
+                if (fontAwesomeIcon) return "";
                 if(button.rightIconInactive !== "" && !button.enabled) {
                     return button.rightIconInactive;
                 }


### PR DESCRIPTION
Fixes following warning that shows up during transaction creation password dialog:

```
2021-05-13 17:47:33.234	W qrc:/components/StandardButton.qml:140:9: QML Image: Cannot open: qrc:/components/
```