### PR TITLE
main: remove redundant assignment

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -2246,7 +2246,6 @@ ApplicationWindow {
 
     function changeWalletMode(mode){
         appWindow.disconnectedEpoch = 0;
-        appWindow.walletMode = mode;
         persistentSettings.walletMode = mode;
         applyWalletMode(mode);
     }


### PR DESCRIPTION
The redundant assignment removes the binding from `appWindow.walletMode` which is something we don't want.