### PR TITLE
Transfer: fix y position of recipient elements

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -340,6 +340,7 @@ Rectangle {
 
                         Rectangle {
                             Layout.fillWidth: true
+                            Layout.topMargin: -1
                             Layout.rightMargin: recipientLayout.thirdRowWidth
                             color: MoneroComponents.Style.inputBorderColorInActive
                             height: 1
@@ -521,6 +522,7 @@ Rectangle {
                         Layout.column: 0
                         Layout.row: 0
                         Layout.fillWidth: true
+                        Layout.topMargin: recipientModel.count > 1 ? 0 : 5
                         spacing: 0
 
                         CheckBox {
@@ -584,6 +586,7 @@ Rectangle {
                         Layout.column: 1
                         Layout.row: recipientModel.count > 1 ? 1 : 0
                         Layout.preferredWidth: recipientLayout.secondRowWidth
+                        Layout.topMargin: recipientModel.count > 1 ? 0 : 5
                         borderDisabled: true
                         fontFamily: MoneroComponents.Style.fontMonoRegular.name
                         fontSize: 14
@@ -599,6 +602,7 @@ Rectangle {
                         Layout.column: 2
                         Layout.row: recipientModel.count > 1 ? 1 : 0
                         Layout.preferredWidth: recipientLayout.thirdRowWidth
+                        Layout.topMargin: recipientModel.count > 1 ? 0 : 5
                         font.family: MoneroComponents.Style.fontRegular.name
                         horizontalAlignment: Text.AlignHCenter
                         opacity: 0.7


### PR DESCRIPTION
Changes:
- Fix y position of horizontal line dividing recipients
- Fix y position of elements in bottom row, so that 0.00 USD stays vertically aligned with the "0.00" placeholder when a new recipient row is added

Before:
![linesep1](https://user-images.githubusercontent.com/45968869/120827280-92c4d100-c55b-11eb-81d7-689571148c19.gif)

After:
![newline2](https://user-images.githubusercontent.com/45968869/120840558-b5121b00-c56a-11eb-931a-979bbc648262.gif)

