### PR TITLE
Transfer: add XMR to amount of transaction with single recipient

### DIFF
--- a/components/InlineButton.qml
+++ b/components/InlineButton.qml
@@ -95,7 +95,10 @@ Item {
             cursorShape: rect.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
             hoverEnabled: true
             anchors.fill: parent
-            onClicked: doClick()
+            onClicked: {
+                tooltip.text ? tooltip.tooltipPopup.close() : ""
+                doClick()
+            }
             onEntered: {
                 tooltip.text ? tooltip.tooltipPopup.open() : ""
                 rect.color = buttonColor ? buttonColor : "#707070";

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -318,12 +318,32 @@ Rectangle {
                         }
                     }
 
-                    MoneroComponents.TextPlain {
-                        Layout.preferredWidth: recipientLayout.secondRowWidth
-                        font.family: MoneroComponents.Style.fontRegular.name
-                        font.pixelSize: 16
-                        color: MoneroComponents.Style.defaultFontColor
-                        text: qsTr("Amount") + translationManager.emptyString
+                    RowLayout {
+                        id: amountLabel
+                        spacing: 6
+                        Layout.preferredWidth: 125
+                        Layout.maximumWidth: recipientLayout.secondRowWidth
+
+                        MoneroComponents.TextPlain {
+                            font.family: MoneroComponents.Style.fontRegular.name
+                            font.pixelSize: 16
+                            color: MoneroComponents.Style.defaultFontColor
+                            text: qsTr("Amount") + translationManager.emptyString
+                        }
+
+                        MoneroComponents.InlineButton {
+                            fontFamily: FontAwesome.fontFamilySolid
+                            fontStyleName: "Solid"
+                            fontPixelSize: 16
+                            text: FontAwesome.infinity
+                            visible: recipientModel.count == 1
+                            tooltip: qsTr("Send all unlocked balance of this account") + translationManager.emptyString
+                            onClicked: recipientRepeater.itemAt(0).children[1].children[2].text = "(all)";
+                        }
+
+                        Item {
+                            Layout.fillWidth: true
+                        }
                     }
 
                     Item {
@@ -485,9 +505,10 @@ Rectangle {
                                 font.styleName: "Solid"
                                 horizontalAlignment: Text.AlignHCenter
                                 opacity: mouseArea.containsMouse ? 1 : 0.85
-                                text: recipientModel.count == 1 ? FontAwesome.infinity : FontAwesome.times
-                                tooltip: recipientModel.count == 1 ? qsTr("Send all unlocked balance of this account") : qsTr("Remove recipient")  + translationManager.emptyString
+                                text: FontAwesome.times
+                                tooltip: qsTr("Remove recipient")  + translationManager.emptyString
                                 tooltipLeft: true
+                                visible: recipientModel.count > 1
 
                                 MouseArea {
                                     id: mouseArea
@@ -496,14 +517,17 @@ Rectangle {
                                     hoverEnabled: true
                                     onEntered: parent.tooltipPopup.open()
                                     onExited: parent.tooltipPopup.close()
-                                    onClicked: {
-                                        if (recipientModel.count == 1) {
-                                            parent.parent.children[2].text = "(all)";
-                                        } else {
-                                            recipientModel.remove(index);
-                                        }
-                                    }
+                                    onClicked: recipientModel.remove(index);
                                 }
+                            }
+
+                            MoneroComponents.TextPlain {
+                                Layout.leftMargin: recipientLayout.colSpacing / 2
+                                Layout.preferredWidth: recipientLayout.thirdRowWidth
+                                horizontalAlignment: Text.AlignHCenter
+                                font.family: MoneroComponents.Style.fontRegular.name
+                                text: "XMR"
+                                visible: recipientModel.count == 1
                             }
                         }
                     }


### PR DESCRIPTION
Changes:
- Display "XMR" unit at the right side of amount field when transaction has a single recipient. This is the most common type of transaction and the "XMR" unit should definitely be displayed somewhere on this page.
- Send all button: moved it next to the Amount label, in a position consistent with the buttons of Address label.
- Send all button: hide tooltip when clicking, so the user can see that amount field was filled with `(all)`.

![new XMR](https://user-images.githubusercontent.com/45968869/120833573-3a450200-c562-11eb-9bcc-6da923875cbd.gif)
