### PR TITLE
DatePicker: support mouse wheel to navigate months

### DIFF
--- a/components/DatePicker.qml
+++ b/components/DatePicker.qml
@@ -271,6 +271,11 @@ Item {
 
             MouseArea {
                 anchors.fill: parent
+                scrollGestureEnabled: false
+                onWheel: {
+                    if (wheel.angleDelta.y > 0) return calendar.showPreviousMonth();
+                    if (wheel.angleDelta.y < 0) return calendar.showNextMonth();
+                }
             }
 
             Rectangle {


### PR DESCRIPTION
Go to previous/next month with mouse wheel (a lot faster than clicking on left/right arrows)