### PR TITLE
History: close sortAndFilter when exiting Transactions page

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1783,6 +1783,7 @@ Rectangle {
     }
 
     function clearFields() {
+        sortAndFilter.collapsed = false;
         searchInput.text = "";
         root.txDataCollapsed = [];
     }


### PR DESCRIPTION
This PR fixes this bug: 
1) Open sortAndFilter on a wallet with txCount > 0
2) Close this wallet and return to main menu
3) Open another wallet with txCount = 0
4) sortAndFilter is still being displayed, when it shouldn't