### PR TITLE
SettingsLog: new placeholder text in command field

### DIFF
--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -217,7 +217,7 @@ Rectangle {
             property int currentCommandIndex
             enabled: !persistentSettings.useRemoteNode
             fontBold: false
-            placeholderText: qsTr("command + enter (e.g 'help' or 'status')") + translationManager.emptyString
+            placeholderText: qsTr("Type a command (e.g '%1' or '%2') and press Enter").arg("help").arg("status") + translationManager.emptyString
             placeholderFontSize: 16
             Keys.onUpPressed: {
                 if (currentCommandIndex != 0) {


### PR DESCRIPTION
Changes:
- Remove command examples from translation string. Many translators have translated the "help" and "status" commands, but they should be in entered in English.
- Better wording