### PR TITLE
DatePicker: date input with fixed width; longer animation; move up calendar

### DIFF
--- a/components/DatePicker.qml
+++ b/components/DatePicker.qml
@@ -91,8 +91,8 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             height: parent.height - 1
-            anchors.leftMargin: datePicker.expanded ? 1 : 0
-            anchors.rightMargin: datePicker.expanded ? 1 : 0
+            anchors.leftMargin: 0
+            anchors.rightMargin: 0
             radius: 4
             y: 1
             color: datePicker.backgroundColor
@@ -257,7 +257,7 @@ Item {
             id: calendarRect
             width: head.width
             x: head.x
-            y: head.y + head.height + 10
+            y: head.y + head.height - 2
 
             color: MoneroComponents.Style.middlePanelBackgroundColor
             border.width: 1
@@ -266,7 +266,7 @@ Item {
             clip: true
 
             Behavior on height {
-                NumberAnimation { duration: 100; easing.type: Easing.InQuad }
+                NumberAnimation { duration: 150; easing.type: Easing.InQuad }
             }
 
             MouseArea {


### PR DESCRIPTION
Changes:
- Date input doesn't change width anymore when calendar pop up is open
- Add +50 ms to duration of calendar pop up animation
- Move up calendar rectangle, so that it looks like a dropdown (consistent with StandardDropdown component)