### PR TITLE
Slider: use MoneroComponents.TextPlain instead of Text on label

### DIFF
--- a/components/Slider.qml
+++ b/components/Slider.qml
@@ -16,11 +16,11 @@ ColumnLayout {
 
     spacing: 0
 
-    Text {
+    MoneroComponents.TextPlain {
         id: label
         color: MoneroComponents.Style.defaultFontColor
         font.pixelSize: 14
-        Layout.fillWidth: true
+        font.family: MoneroComponents.Style.fontRegular.name
     }
 
     QtQuickControls.Slider {


### PR DESCRIPTION
Closes #3242
I tested on Android 11.