### PR TITLE
LineEdit: use ColumnLayout instead of Item

### DIFF
--- a/components/RemoteNodeEdit.qml
+++ b/components/RemoteNodeEdit.qml
@@ -82,9 +82,9 @@ GridLayout {
         return addr + ":" + port;
     }
 
-    LineEdit {
+    MoneroComponents.LineEdit {
         id: daemonAddr
-        Layout.fillWidth: true
+        Layout.preferredWidth: root.width/3
         placeholderText: qsTr("Remote Node Hostname / IP") + translationManager.emptyString
         placeholderFontFamily: root.placeholderFontFamily
         placeholderFontBold: root.placeholderFontBold
@@ -104,9 +104,9 @@ GridLayout {
         text: initialHostPort[1]
     }
 
-    LineEdit {
+    MoneroComponents.LineEdit {
         id: daemonPort
-        Layout.fillWidth: true
+        Layout.preferredWidth: root.width/3
         placeholderText: qsTr("Port") + translationManager.emptyString
         placeholderFontFamily: root.placeholderFontFamily
         placeholderFontBold: root.placeholderFontBold

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -171,19 +171,25 @@ Rectangle {
                     }
                 }
 
-                MoneroComponents.InlineButton {
-                    Layout.topMargin: -8
+                Rectangle {
+                    color: "transparent"
+                    height: cleanButton.height
+                    width: cleanButton.width
                     Layout.rightMargin: -8
                     Layout.leftMargin: -2
-                    buttonColor: "transparent"
-                    fontFamily: FontAwesome.fontFamilySolid
-                    fontStyleName: "Solid"
-                    fontPixelSize: 18
-                    text: FontAwesome.times
-                    tooltip: qsTr("Clean") + translationManager.emptyString
-                    tooltipLeft: true
-                    visible: searchInput.text != ""
-                    onClicked: searchInput.text = ""
+
+                    MoneroComponents.InlineButton {
+                        id: cleanButton
+                        buttonColor: "transparent"
+                        fontFamily: FontAwesome.fontFamilySolid
+                        fontStyleName: "Solid"
+                        fontPixelSize: 18
+                        text: FontAwesome.times
+                        tooltip: qsTr("Clean") + translationManager.emptyString
+                        tooltipLeft: true
+                        visible: searchInput.text != ""
+                        onClicked: searchInput.text = ""
+                    }
                 }
             }
         }

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -468,10 +468,14 @@ Rectangle {
                                 Layout.bottomMargin: recipientLayout.rowSpacing / 2
                                 Layout.rightMargin: recipientLayout.colSpacing / 2
                                 Layout.preferredWidth: 125
+                                Layout.maximumWidth: 125
                                 borderDisabled: true
                                 fontFamily: MoneroComponents.Style.fontMonoRegular.name
                                 fontSize: 14
-                                inputPadding: 0
+                                inputPaddingLeft: 0
+                                inputPaddingRight: 0
+                                inputPaddingTop: 0
+                                inputPaddingBottom: 0
                                 placeholderFontFamily: MoneroComponents.Style.fontMonoRegular.name
                                 placeholderFontSize: 14
                                 placeholderLeftMargin: 0
@@ -586,11 +590,15 @@ Rectangle {
                         Layout.column: 1
                         Layout.row: 0
                         Layout.preferredWidth: recipientLayout.secondRowWidth
+                        Layout.maximumWidth: recipientLayout.secondRowWidth
                         borderDisabled: true
                         fontFamily: MoneroComponents.Style.fontMonoRegular.name
                         fontSize: 14
                         inputHeight: 30
-                        inputPadding: 0
+                        inputPaddingLeft: 0
+                        inputPaddingRight: 0
+                        inputPaddingTop: 0
+                        inputPaddingBottom: 0
                         readOnly: true
                         text: Utils.removeTrailingZeros(walletManager.displayAmount(recipientModel.getAmountTotal()))
                         visible: recipientModel.count > 1
@@ -600,6 +608,7 @@ Rectangle {
                         Layout.column: 2
                         Layout.row: 0
                         Layout.preferredWidth: recipientLayout.thirdRowWidth
+                        Layout.maximumWidth: recipientLayout.thirdRowWidth
                         horizontalAlignment: Text.AlignHCenter
                         font.family: MoneroComponents.Style.fontRegular.name
                         text: "XMR"
@@ -611,11 +620,15 @@ Rectangle {
                         Layout.row: recipientModel.count > 1 ? 1 : 0
                         Layout.preferredWidth: recipientLayout.secondRowWidth
                         Layout.topMargin: recipientModel.count > 1 ? 0 : 5
+                        Layout.maximumWidth: recipientLayout.secondRowWidth
                         borderDisabled: true
                         fontFamily: MoneroComponents.Style.fontMonoRegular.name
                         fontSize: 14
                         inputHeight: 30
-                        inputPadding: 0
+                        inputPaddingLeft: 0
+                        inputPaddingRight: 0
+                        inputPaddingTop: 0
+                        inputPaddingBottom: 0
                         opacity: 0.7
                         readOnly: true
                         text: fiatApiConvertToFiat(walletManager.displayAmount(recipientModel.getAmountTotal()))
@@ -627,6 +640,7 @@ Rectangle {
                         Layout.row: recipientModel.count > 1 ? 1 : 0
                         Layout.preferredWidth: recipientLayout.thirdRowWidth
                         Layout.topMargin: recipientModel.count > 1 ? 0 : 5
+                        Layout.maximumWidth: recipientLayout.thirdRowWidth
                         font.family: MoneroComponents.Style.fontRegular.name
                         horizontalAlignment: Text.AlignHCenter
                         opacity: 0.7

--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -226,10 +226,13 @@ Rectangle {
         MoneroComponents.LineEdit {
             id: sendCommandText
             Layout.fillWidth: true
+            inputPaddingTop: 0
+            inputPaddingBottom: 0
             property var lastCommands: []
             property int currentCommandIndex
             enabled: !persistentSettings.useRemoteNode
             fontBold: false
+            fontSize: 16
             placeholderText: qsTr("Type a command (e.g '%1' or '%2') and press Enter").arg("help").arg("status") + translationManager.emptyString
             placeholderFontSize: 16
             Keys.onUpPressed: {

--- a/wizard/WizardWalletInput.qml
+++ b/wizard/WizardWalletInput.qml
@@ -36,6 +36,7 @@ import "../components"
 import "../components" as MoneroComponents
 
 GridLayout {
+    id: grid
     Layout.fillWidth: true
     property alias walletName: walletName
     property alias walletLocation: walletLocation
@@ -61,7 +62,7 @@ GridLayout {
 
     MoneroComponents.LineEdit {
         id: walletName
-        Layout.fillWidth: true
+        Layout.preferredWidth: grid.width/3
 
         function verify(){
             if(walletLocation === "" || /[\\\/]/.test(walletName.text)) return false;
@@ -82,7 +83,7 @@ GridLayout {
 
     MoneroComponents.LineEdit {
         id: walletLocation
-        Layout.fillWidth: true
+        Layout.preferredWidth: grid.width/3
 
         labelText: qsTr("Wallet location") + translationManager.emptyString
         labelFontSize: 14


### PR DESCRIPTION
Required for #2637

Currently LineEdit uses an Item{} component while LineEditMulti uses a ColumnLayout{}. 

This PR modifies LineEdit component to use ColumnLayout{}. This is useful because we can set its properties (like margins) with the same values of a neighbor LineEditMulti component.

This modification requires some changes to LineEdit components in Transfer and WizardWalletInput.

Other changes:
- Removing unused inlineIcon
- inputHeight changed to 39 (the same as LineEditMulti)
- Add paste button