### PR TITLE
History: advanced options hidden when transaction count = 0

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1363,6 +1363,7 @@ Rectangle {
             Layout.bottomMargin: 20
             Layout.leftMargin: sideMargin
             Layout.rightMargin: sideMargin
+            visible: root.txCount > 0
             checked: persistentSettings.historyShowAdvanced
             onClicked: persistentSettings.historyShowAdvanced = !persistentSettings.historyShowAdvanced
             text: qsTr("Advanced options") + translationManager.emptyString


### PR DESCRIPTION
Both advanced options  ("Human readable date format" and "Export all history") are useful only when transaction count >0. 