### PR TITLE
History: collapse "Sort & Filter" when user types

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -160,6 +160,9 @@ Rectangle {
                 placeholderFontSize: 15
                 inputHeight: 34
                 onTextUpdated: {
+                    if (!sortAndFilter.collapsed) {
+                        sortAndFilter.collapsed = true;
+                    }
                     if(searchInput.text != null && searchInput.text.length >= 3){
                         root.sortSearchString = searchInput.text;
                         root.reset();


### PR DESCRIPTION
Currently it's possible to type on Search text field when Sort & Filter section isn't collapsed.

With this PR, if the user starts typing when "Sort & Filter" section isn't collapsed, it will collapse automatically.