### PR TITLE
SettingsInfo, WizardRestoreWallet1, WizardCreateDevice1: Correct date typed in a wrong format

### DIFF
--- a/js/Utils.js
+++ b/js/Utils.js
@@ -115,3 +115,18 @@ function capitalize(s){
 function removeTrailingZeros(value) {
     return (value + '').replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
 }
+
+function parseDateStringOrRestoreHeightAsInteger(value) {
+    // Parse date string or restore height as integer
+    var restoreHeight = 0;
+    if (value.indexOf('-') === 4 && value.length === 10) {
+        restoreHeight = Wizard.getApproximateBlockchainHeight(value, Utils.netTypeToString());
+    } else if (parseInt(value.substring(0, 4)) >= 2014 && parseInt(value.substring(0, 4)) <= 2025 && value.length === 8) {
+        // Correct date typed in a wrong format (20201225 instead of 2020-12-25)
+        var restoreHeightHyphenated = value.substring(0, 4) + "-" + value.substring(4, 6) + "-" + value.substring(6, 8);
+        restoreHeight = Wizard.getApproximateBlockchainHeight(restoreHeightHyphenated, Utils.netTypeToString());
+    } else {
+        restoreHeight = parseInt(value);
+    }
+    return restoreHeight;
+}

--- a/pages/settings/SettingsInfo.qml
+++ b/pages/settings/SettingsInfo.qml
@@ -189,13 +189,7 @@ Rectangle {
                     inputDialog.onAcceptedCallback = function() {
                         var _restoreHeight;
                         if (inputDialog.inputText) {
-                            var restoreHeightText = inputDialog.inputText;
-                            // Parse date string or restore height as integer
-                            if(restoreHeightText.indexOf('-') === 4 && restoreHeightText.length === 10) {
-                                _restoreHeight = Wizard.getApproximateBlockchainHeight(restoreHeightText, Utils.netTypeToString());
-                            } else {
-                                _restoreHeight = parseInt(restoreHeightText)
-                            }
+                            _restoreHeight = Utils.parseDateStringOrRestoreHeightAsInteger(inputDialog.inputText);
                         }
                         if (!isNaN(_restoreHeight)) {
                             if(_restoreHeight >= 0) {

--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -183,15 +183,8 @@ Rectangle {
                     wizardController.walletOptionsDeviceName = wizardCreateDevice1.deviceName;
                     if(lookahead.text)
                         wizardController.walletOptionsSubaddressLookahead = lookahead.text;
-                    var _restoreHeight = 0;
                     if(restoreHeight.text){
-                        // Parse date string or restore height as integer
-                        if(restoreHeight.text.indexOf('-') === 4 && restoreHeight.text.length === 10){
-                            _restoreHeight = Wizard.getApproximateBlockchainHeight(restoreHeight.text, Utils.netTypeToString());
-                        } else {
-                            _restoreHeight = parseInt(restoreHeight.text)
-                        }
-                        wizardController.walletOptionsRestoreHeight = _restoreHeight;
+                        wizardController.walletOptionsRestoreHeight = Utils.parseDateStringOrRestoreHeightAsInteger(restoreHeight.text);
                     }
 
                     wizardController.walletCreatedFromDevice.connect(onCreateWalletFromDeviceCompleted);

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -314,16 +314,8 @@ Rectangle {
                             break;
                     }
 
-                    var _restoreHeight = 0;
                     if(restoreHeight.text){
-                        // Parse date string or restore height as integer
-                        if(restoreHeight.text.indexOf('-') === 4 && restoreHeight.text.length === 10){
-                            _restoreHeight = Wizard.getApproximateBlockchainHeight(restoreHeight.text, Utils.netTypeToString());
-                        } else {
-                            _restoreHeight = parseInt(restoreHeight.text)
-                        }
-
-                        wizardController.walletOptionsRestoreHeight = _restoreHeight;
+                        wizardController.walletOptionsRestoreHeight = Utils.parseDateStringOrRestoreHeightAsInteger(restoreHeight.text);
                     }
 
                     wizardStateView.state = "wizardRestoreWallet2";


### PR DESCRIPTION
Fixes #3207

Probably the best solution is to use two fields, one for date and another for restore height, but let's use this PR as a temporary fix.