### PR TITLE
StandardDropdown: use ArrowCursor; remove rotation of dropdownIcon; change background color on mouse hover; smaller text

### DIFF
--- a/components/StandardDropdown.qml
+++ b/components/StandardDropdown.qml
@@ -54,10 +54,10 @@ ColumnLayout {
     property alias labelWrapMode: dropdownLabel.wrapMode
     property alias labelHorizontalAlignment: dropdownLabel.horizontalAlignment
     property bool showingHeader: dropdownLabel.text !== ""
-    property int labelFontSize: 16
+    property int labelFontSize: 14
     property bool labelFontBold: false
     property int dropdownHeight: 39
-    property int fontSize: 16
+    property int fontSize: 14
     property int fontItemSize: 14
     property string colorBorder: MoneroComponents.Style.inputBorderColorInActive
     property string colorHeaderBackground: "transparent"
@@ -90,7 +90,7 @@ ColumnLayout {
 
     Rectangle {
         id: head
-        color: "transparent"
+        color: dropArea.containsMouse ? MoneroComponents.Style.titleBarButtonHoverColor : "transparent"
         border.width: dropdown.headerBorder ? 1 : 0
         border.color: dropdown.colorBorder
         radius: 4
@@ -129,7 +129,6 @@ ColumnLayout {
                 fontAwesomeFallbackIcon: FontAwesome.arrowDown
                 fontAwesomeFallbackSize: 14
                 color: MoneroComponents.Style.defaultFontColor
-                rotation: dropdown.expanded ? 180  : 0
             }
         }
 
@@ -138,7 +137,7 @@ ColumnLayout {
             anchors.fill: parent
             onClicked: dropdown.expanded ? popup.close() : popup.open()
             hoverEnabled: true
-            cursorShape: Qt.PointingHandCursor
+            cursorShape: Qt.ArrowCursor
         }
     }
 
@@ -227,7 +226,7 @@ ColumnLayout {
                             id: itemArea
                             anchors.fill: parent
                             hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
+                            cursorShape: Qt.ArrowCursor
 
                             onClicked: {
                                 popup.close()

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -700,6 +700,7 @@ Rectangle {
                     currentIndex: 0
                     dataModel: priorityModelV5
                     labelText: qsTr("Transaction priority") + translationManager.emptyString
+                    labelFontSize: 16
                 }
 
                 MoneroComponents.TextPlain {


### PR DESCRIPTION
- use ArrowCursor (default mouse cursor for dropdowns on Windows, Mac, and Linux)
- remove rotation of dropdownIcon (default behavior of dropdown icon on Windows, Mac, and Linux)
- change background color on mouse hover
- smaller text (from 16 to 14)