### PR TITLE
RemoteNodeList: reduce spacing between icons

### DIFF
--- a/components/RemoteNodeList.qml
+++ b/components/RemoteNodeList.qml
@@ -121,9 +121,8 @@ ColumnLayout {
                 RowLayout {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
-                    anchors.rightMargin: 6
                     height: 30
-                    spacing: 10
+                    spacing: 2
 
                     MoneroComponents.InlineButton {
                         buttonColor: "transparent"


### PR DESCRIPTION
Before:
<img width="614" alt="Screenshot 2021-06-25 at 01 59 02" src="https://user-images.githubusercontent.com/7697454/123346576-ecb42780-d558-11eb-8485-34953b5b8d79.png">


After: 
<img width="624" alt="Screenshot 2021-06-25 at 01 57 53" src="https://user-images.githubusercontent.com/7697454/123346547-e2922900-d558-11eb-94a7-c21db3485f93.png">
