### PR TITLE
Transfer: UI changes to description field (use LineEdit, decrease font size, new placeholder)

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -789,9 +789,11 @@ Rectangle {
                   }
               }
 
-              LineEditMulti {
+              LineEdit {
                   id: descriptionLine
-                  placeholderText: qsTr("Saved to local wallet history") + translationManager.emptyString
+                  placeholderFontSize: 16
+                  fontSize: 16
+                  placeholderText: qsTr("Saved to local wallet history") + " (" + qsTr("only visible to you") + ")" + translationManager.emptyString
                   Layout.fillWidth: true
                   visible: descriptionCheckbox.checked
               }


### PR DESCRIPTION
closes #2613

Changes:
- use LineEdit instead of LineEditMulti (fixes #2613)
- decrease fontsize from input and placeholder from 18 to 16
- Add "(only visible to you)" to placeholder