### PR TITLE
TxConfirmationDialog: fix displaying of "<" when using fontMonoRegular

### DIFF
--- a/components/TxConfirmationDialog.qml
+++ b/components/TxConfirmationDialog.qml
@@ -141,7 +141,7 @@ Rectangle {
 
     function showFiatConversion(valueXMR) {
         const fiatFee = fiatApiConvertToFiat(valueXMR);
-        return "%1 %2".arg(fiatFee < 0.01 ? "<0.01" : "~" + fiatFee).arg(fiatApiCurrencySymbol());
+        return "%1 %2".arg(fiatFee < 0.01 ? "&lt;0.01" : "~" + fiatFee).arg(fiatApiCurrencySymbol());
     }
 
     ColumnLayout {


### PR DESCRIPTION
closes #3597

Recipients text is using fontMonoRegular, and for some reason it is not displaying the string "<0.01" because it contains "<".