### PR TITLE
History: fix filtering of transactions by date/time

### DIFF
--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1439,9 +1439,8 @@ Rectangle {
         // applying filters
         root.txData = JSON.parse(JSON.stringify(root.txModelData)); // deepcopy
 
-        const timezoneOffset = new Date().getTimezoneOffset() * 60;
-        var fromDate = Math.floor(fromDatePicker.currentDate.getTime() / 86400000) * 86400 + timezoneOffset;
-        var toDate = (Math.floor(toDatePicker.currentDate.getTime() / 86400000) + 1) * 86400 + timezoneOffset;
+        var fromDate = fromDatePicker.currentDate.setHours(0, 0, 0, 0);
+        var toDate = toDatePicker.currentDate.setHours(23, 59, 59, 999);
 
         var txs = [];
         for (var i = 0; i < root.txData.length; i++){
@@ -1449,7 +1448,7 @@ Rectangle {
             var matched = "";
 
             // daterange filtering
-            if(item.timestamp < fromDate || item.timestamp > toDate){
+            if(item.timestamp * 1000 < fromDate || item.timestamp * 1000 > toDate){
                 continue;
             }
 


### PR DESCRIPTION
Some recent transactions were not being displayed in Transactions page, specially transactions done near the beginning of the day (for example, at 1:25).

This occured because we were not multiplying `item.timestamp` * 1000, and the toDate value was also incorrect. Both item.timestamp and toDate resulted in dates in 1970, which sometimes results in a incorrect filtering

This PR simplifies how we set these values, and it also sets the fromDate hour to the beginning of the day (0:00) and the toDate hour to the end of the day (23:59:59).

To test this PR, I suggest changing the clock to 1:25, sending a transaction and then checking if it appears on Transactions page.