### PR TITLE
Transfer: use defaultFontColor for text cursor when address field is blank

### DIFF
--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -382,7 +382,7 @@ Rectangle {
                                 Layout.fillWidth: true
                                 addressValidation: true
                                 borderDisabled: true
-                                fontColor: error ? MoneroComponents.Style.errorColor : MoneroComponents.Style.defaultFontColor
+                                fontColor: error && text != "" ? MoneroComponents.Style.errorColor : MoneroComponents.Style.defaultFontColor
                                 fontFamily: MoneroComponents.Style.fontMonoRegular.name
                                 fontSize: 14
                                 inputPaddingBottom: 0


### PR DESCRIPTION
Currently text cursor is orange when address field is blank, but this color should only be used when there is an invalid input.