### PR TITLE
History: add tooltips; locked funds/change indicator

### DIFF
--- a/components/TextPlain.qml
+++ b/components/TextPlain.qml
@@ -15,6 +15,7 @@ Text {
     property alias tooltip: tooltip.text
     property alias tooltipLeft: tooltip.tooltipLeft
     property alias tooltipIconVisible: tooltip.tooltipIconVisible
+    property alias tooltipIconColor: tooltip.tooltipIconColor
     property alias tooltipPopup: tooltip.tooltipPopup
     font.family: MoneroComponents.Style.fontMedium.name
     font.bold: false

--- a/components/Tooltip.qml
+++ b/components/Tooltip.qml
@@ -37,6 +37,7 @@ Rectangle {
     property alias text: tooltip.text
     property alias tooltipPopup: popup
     property bool tooltipIconVisible: false
+    property var tooltipIconColor: MoneroComponents.Style.defaultFontColor
     property bool tooltipLeft: false
     property bool tooltipBottom: tooltipIconVisible ? false : true
 
@@ -48,7 +49,7 @@ Rectangle {
     Text {
         id: icon
         visible: tooltipIconVisible
-        color: MoneroComponents.Style.orange
+        color: tooltipIconColor
         font.family: FontAwesome.fontFamily
         font.pixelSize: 10
         font.styleName: "Regular"
@@ -95,11 +96,10 @@ Rectangle {
         delay: 200
 
         RowLayout {
-            Layout.maximumWidth: 350
-
             Text {
                 id: tooltip
-                width: contentWidth
+                Layout.maximumWidth: 360
+                width: implicitWidth > 360 ? 360 : implicitWidth
                 color: MoneroComponents.Style.defaultFontColor
                 font.family: MoneroComponents.Style.fontRegular.name
                 font.pixelSize: 12

--- a/fonts/FontAwesome/FontAwesome.qml
+++ b/fonts/FontAwesome/FontAwesome.qml
@@ -52,6 +52,7 @@ Object {
     property string info : "\uf129"
     property string key : "\uf084"
     property string language : "\uf1ab"
+    property string lock : "\uf023"
     property string minus : "\uf068"
     property string minusCircle : "\uf056"
     property string moonO : "\uf186"


### PR DESCRIPTION
Main changes:
- Add tooltips for most items
- Add indicator for locked funds/change indicator (lock icon + text)
- Add time remaining to unlock funds/change
- Fix tooltip maximum width (#3627 was not setting a maximum width)

Sender wallet: tooltips in a pending transaction (transaction with 0 confirmations):
![image](https://user-images.githubusercontent.com/45968869/131726033-787ecfca-53e6-48ed-8fa1-36c086486869.png)

Receiver wallet: "Funds locked" indicator + time remaining to unlock (transaction with 1-9 confirmations):
![image](https://user-images.githubusercontent.com/45968869/131727153-9fce8271-4477-4960-8300-1a7ffb8a9be7.png)

Sender wallet: "Change locked" indicator + time remaining to unlock (transaction with 1-9 confirmations):
![image](https://user-images.githubusercontent.com/45968869/131726410-7a36a5b1-f853-4b95-9e90-2f791c425bd6.png)

Finished transaction (>10 confirmations) remains unchanged (no tooltip is displayed, circle icon is used):
![image](https://user-images.githubusercontent.com/45968869/131726636-483c5e00-ae40-40e0-891b-17d6a0c735f3.png)
![image](https://user-images.githubusercontent.com/45968869/131726773-63a22f80-b3c7-45ee-9310-41ceffa09396.png)
