### PR TITLE
Receive: remove highlight of QR code menu if no item is hovered

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -152,13 +152,16 @@ Rectangle {
                 Menu {
                     id: qrMenu
                     title: "QrCode"
+                    currentIndex: menuItem1.hovered ? 0 : menuItem2.hovered ? 1 : -1
 
                     MenuItem {
+                        id: menuItem1
                         text: qsTr("Copy to clipboard") + translationManager.emptyString;
                         onTriggered: walletManager.saveQrCodeToClipboard(generateQRCodeString())
                     }
 
                     MenuItem {
+                        id: menuItem2
                         text: qsTr("Save as Image") + translationManager.emptyString;
                         onTriggered: qrFileDialog.open()
                     }


### PR DESCRIPTION
Before:
![menuitembefore](https://user-images.githubusercontent.com/45968869/131900360-d9c6d3a2-68b8-40fe-b1de-5da0f8595742.gif)

After:
![menuitem](https://user-images.githubusercontent.com/45968869/131900008-483f3fc1-5306-4a86-ab46-be2f4d9d39ba.gif)