### PR TITLE
Add note about GUI releases to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Packaging for your favorite distribution would be a welcome contribution!
 
 *Note*: Qt 5.9.7 is the minimum version required to build the GUI.
 
+*Note*: Official GUI releases use monero-wallet-gui from this process alongside the supporting binaries (monerod, etc) from the [CLI deterministic builds](https://github.com/monero-project/monero/blob/master/contrib/gitian/README.md).
+
 ### Building Reproducible Windows static binaries with Docker (any OS)
 
 1. Install Docker [https://docs.docker.com/engine/install/](https://docs.docker.com/engine/install/)


### PR DESCRIPTION
Official GUI releases use monero-wallet-gui from the docker build process documented in the monero-gui README, alongisde the supporting binaries from the deterministic CLI builds. This should be noted for users looking for verify GUI builds against official releases.