### PR TITLE
cmake: don't print verbose make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 include(CheckLinkerFlag)
 
-if(DEBUG)
-	set(CMAKE_VERBOSE_MAKEFILE ON)
-endif()
-
 set(BUILD_GUI_DEPS ON)
 set(ARCH "x86-64" CACHE STRING "Target architecture")
 set(BUILD_64 ON CACHE BOOL "Build 64-bit binaries")


### PR DESCRIPTION
If someone wants verbose make they can set the env var.
This is now in line with monero's behaviour.