### PR TITLE
cmake: remove including non-existent directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,10 +373,7 @@ endif()
 list(APPEND EXTRA_LIBRARIES ${CMAKE_DL_LIBS})
 
 if(APPLE)
-  include_directories(SYSTEM /usr/include/malloc)
-  if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 NEW)
-  endif()
+  cmake_policy(SET CMP0042 NEW)
 endif()
 
 if (APPLE AND NOT IOS)


### PR DESCRIPTION
There is no `/usr/include/malloc` on macOS and it builds fine without.

Also CMP0042 always exists with out minimum version, no need to check for it explicitly.