### PR TITLE
WizardRestoreWallet1: disable Enter/Return and double space on seed text input area

### DIFF
--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -199,6 +199,15 @@ Rectangle {
                         wrapMode: TextInput.Wrap
 
                         selectByMouse: true
+                        Keys.onEnterPressed: void(0)
+                        Keys.onReturnPressed: void(0)
+                        Keys.onSpacePressed: {
+                            if (seedInput.text.substring(0, cursorPosition).slice(-1) == " ") {
+                                event.accepted = true;
+                            } else {
+                                event.accepted = false;
+                            }
+                        }
 
                         MoneroComponents.TextPlain {
                             id: memoTextPlaceholder


### PR DESCRIPTION
Recently an user on reddit reported that he/she wasn't able to restore a wallet using mnemonic seed because he/she was inadvertently typing Enter at the end of each line. 

This PR disables Enter and Return keys as well as double space on the seed text input area.