### PR TITLE
main: hide wallet name in wizard title bar

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1898,7 +1898,7 @@ ApplicationWindow {
         TitleBar {
             id: titleBar
             visible: persistentSettings.customDecorations && middlePanel.state !== "Merchant"
-            walletName: persistentSettings.displayWalletNameInTitleBar ? appWindow.walletName : ""
+            walletName: persistentSettings.displayWalletNameInTitleBar && rootItem.state != "wizard" ? appWindow.walletName : ""
             anchors.left: parent.left
             anchors.right: parent.right
             onCloseClicked: appWindow.close();


### PR DESCRIPTION
Steps to reproduce the bug:
- In Settings > Interface, enable "Display wallet name in title bar"
- Close the wallet and open the main menu
- Open a wallet from file
- Enter an incorrect password in password dialog and click on Ok button
- Wallet name will appear on title bar, and it will persist on wizard mode, even if you click on Cancel button