### PR TITLE
PasswordDialog: display wizard title bar when returning to wizard after canceling password dialog

### DIFF
--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -108,7 +108,11 @@ Item {
         leftPanel.enabled = true
         middlePanel.enabled = true
         wizard.enabled = true
-        titleBar.state = "default"
+        if (rootItem.state == "wizard") {
+            titleBar.state = "essentials"
+        } else {
+            titleBar.state = "default"
+        }
 
         root.visible = false;
         appWindow.hideBalanceForced = false;


### PR DESCRIPTION
Steps to reproduce the bug:
- Open the main menu
- Open a wallet from file
- Click on Cancel button in password dialog
- Title bar will change to the wrong state ("default") instead of the correct one ("wizard")