### PR TITLE
main: hide TitleBar when MerchantTitleBar is visible

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -259,9 +259,6 @@ ApplicationWindow {
             walletPassword,
             persistentSettings.nettype,
             persistentSettings.kdfRounds);
-
-        // Hide titlebar based on persistentSettings.customDecorations
-        titleBar.visible = persistentSettings.customDecorations;
     }
 
     function closeWallet(callback) {


### PR DESCRIPTION
hide TitleBar when MerchantTitleBar is visible (while in Merchant mode, the buttons on the left were clickable and opening tooltips)

"visible" property is already set for titleBar component in line 1900 of main.qml