### PR TITLE
main: check if currentWallet is loaded before calling it

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -730,14 +730,18 @@ ApplicationWindow {
     function onDaemonStarted(){
         console.log("daemon started");
         daemonStartStopInProgress = 0;
-        currentWallet.connected(true);
-        // resume refresh
-        currentWallet.startRefresh();
+        if (currentWallet) {
+            currentWallet.connected(true);
+            // resume refresh
+            currentWallet.startRefresh();
+        }
         // resume simplemode connection timer
         appWindow.disconnectedEpoch = Utils.epoch();
     }
     function onDaemonStopped(){
-        currentWallet.connected(true);
+        if (currentWallet) {
+            currentWallet.connected(true);
+        }
     }
 
     function onDaemonStartFailure(error) {


### PR DESCRIPTION
When daemon is started/stopped while the wallet is being closed, the following error appears:
`W qrc:/main.qml:733: TypeError: Cannot call method 'connected' of undefined`