### PR TITLE
LeftPanel: auto refresh Transactions page during wallet scan

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -63,6 +63,13 @@ Rectangle {
     signal addressBookClicked()
     signal accountClicked()
 
+    onBalanceStringChanged: {
+        if (middlePanel.state == "History") {
+            middlePanel.historyView.onPageClosed()
+            middlePanel.historyView.onPageCompleted()
+        }
+    }
+
     function selectItem(pos) {
         menuColumn.previousButton.checked = false
         if(pos === "History") menuColumn.previousButton = historyButton


### PR DESCRIPTION
Closes #3134

Transactions page will auto refresh every time balance is updated.