### PR TITLE
WizardCreateWallet2, WizardRestoreWallet2: clean password fields when clicking on back button

### DIFF
--- a/wizard/WizardCreateWallet2.qml
+++ b/wizard/WizardCreateWallet2.qml
@@ -39,6 +39,11 @@ Rectangle {
     property alias pageHeight: pageRoot.height
     property string viewName: "wizardCreateWallet2"
 
+    function onPageCompleted() {
+        passwordFields.password = Qt.binding(function() { return wizardController.walletOptionsPassword })
+        passwordFields.passwordConfirm = Qt.binding(function() { return wizardController.walletOptionsPassword })
+    }
+
     ColumnLayout {
         id: pageRoot
         Layout.alignment: Qt.AlignHCenter;
@@ -64,8 +69,7 @@ Rectangle {
                 progress: 1
                 btnNext.enabled: passwordFields.calcStrengthAndVerify();
                 onPrevClicked: {
-                    passwordFields.password = "";
-                    passwordFields.passwordConfirm = "";
+                    wizardController.walletOptionsPassword = '';
 
                     if(wizardController.walletOptionsIsRecoveringFromDevice){
                         wizardStateView.state = "wizardCreateDevice1";

--- a/wizard/WizardRestoreWallet2.qml
+++ b/wizard/WizardRestoreWallet2.qml
@@ -42,6 +42,11 @@ Rectangle {
     property string viewName: "wizardRestoreWallet2"
     property int recoveryMode: 1
 
+    function onPageCompleted() {
+        passwordFields.password = Qt.binding(function() { return wizardController.walletOptionsPassword })
+        passwordFields.passwordConfirm = Qt.binding(function() { return wizardController.walletOptionsPassword })
+    }
+
     ColumnLayout {
         id: pageRoot
         Layout.alignment: Qt.AlignHCenter;
@@ -67,9 +72,7 @@ Rectangle {
                 progress: 1
                 btnNext.enabled: passwordFields.calcStrengthAndVerify();
                 onPrevClicked: {
-                    passwordFields.password = "";
-                    passwordFields.passwordConfirm = "";
-
+                    wizardController.walletOptionsPassword = '';
                     wizardStateView.state = "wizardRestoreWallet1";
                 }
                 onNextClicked: {


### PR DESCRIPTION
Closes #3794

This bug was introduced in #3755 (property binding was lost when setting password fields to blank).