### PR TITLE
RemoteNodeList: reconnect after editing remote node

### DIFF
--- a/components/RemoteNodeList.qml
+++ b/components/RemoteNodeList.qml
@@ -144,6 +144,9 @@ ColumnLayout {
                         tooltipLeft: true
                         onClicked: remoteNodeDialog.edit(remoteNodesModel.get(index), function (remoteNode) {
                             remoteNodesModel.set(index, remoteNode)
+                            if (index === remoteNodesModel.selected) {
+                                remoteNodesModel.applyRemoteNode(index)
+                            }
                         })
                     }
 


### PR DESCRIPTION
A reconnect is necessary to apply changes after editing a remote node that is currently connected.