### PR TITLE
SettingsWallet, SettingsListItem: disable "Rescan wallet balance" button if wallet is not synced

### DIFF
--- a/components/SettingsListItem.qml
+++ b/components/SettingsListItem.qml
@@ -10,6 +10,7 @@ ColumnLayout {
     property alias description: area.text
     property alias title: header.text
     property bool isLast: false
+    property bool enabled: true
     signal clicked()
 
     Layout.fillWidth: true
@@ -37,6 +38,7 @@ ColumnLayout {
             width: parent.width
             height: header.height + area.contentHeight
             color: "transparent";
+            opacity: settingsListItem.enabled ? 1 : 0.25
             anchors.left: parent.left
             anchors.bottomMargin: 4
             anchors.topMargin: 4
@@ -102,6 +104,7 @@ ColumnLayout {
         }
 
         MouseArea {
+            visible: settingsListItem.enabled
             cursorShape: Qt.PointingHandCursor
             anchors.fill: parent
             hoverEnabled: true

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -91,6 +91,7 @@ Rectangle {
         }
 
         MoneroComponents.SettingsListItem {
+            enabled: leftPanel.progressBar.fillLevel == 100
             iconText: FontAwesome.repeat
             description: qsTr("Use this feature if you think the shown balance is not accurate.") + translationManager.emptyString
             title: qsTr("Rescan wallet balance") + translationManager.emptyString


### PR DESCRIPTION
Monero GUI freezes if "Rescan wallet balance" button is clicked while wallet is being synced.