### PR TITLE
RemoteNodeList: fix qml warning

### DIFF
--- a/components/RemoteNodeList.qml
+++ b/components/RemoteNodeList.qml
@@ -89,7 +89,7 @@ ColumnLayout {
                     anchors.fill: parent
                     anchors.rightMargin: 80
                     color: "transparent"
-                    property var trusted: remoteNodesModel.get(index).trusted
+                    property var trusted: remoteNodesModel.get(index) ? remoteNodesModel.get(index).trusted : false
 
                     MoneroComponents.TextPlain {
                         id: addressText


### PR DESCRIPTION
```
2021-12-13 03:26:11.850	W qrc:/components/RemoteNodeList.qml:92: TypeError: Cannot read property 'trusted' of undefined
```