### PR TITLE
WizardHome: restore binding of networkTypeDropdown.currentIndex when selecting an item; display networkTypeDropdown if stagenet or testnet is selected

### DIFF
--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -202,6 +202,7 @@ Rectangle {
                             persistentSettings.nettype = NetworkType.TESTNET
                         }
                         appWindow.disconnectRemoteNode()
+                        networkTypeDropdown.currentIndex = Qt.binding(function() { return persistentSettings.nettype });
                     }
                 }
 
@@ -241,5 +242,8 @@ Rectangle {
 
     function onPageCompleted(){
         wizardController.walletOptionsIsRecoveringFromDevice = false;
+        if (networkTypeDropdown.currentIndex != 0) {
+            showAdvancedCheckbox.checked = true;
+        }
     }
 }


### PR DESCRIPTION
closes #3816