### PR TITLE
WizardRestoreWallet4, WizardCreateWallet4: disable double-click on "Create wallet" button

### DIFF
--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -349,6 +349,8 @@ Rectangle {
         const handler = function(success) {
             if (!success) {
                 appWindow.showStatusMessage(qsTr("Failed to store the wallet"), 3);
+                wizardStateView.wizardRestoreWallet4View.wizardNav.btnNext.enabled = true;
+                wizardStateView.wizardCreateWallet4View.wizardNav.btnNext.enabled = true;
                 return;
             }
 

--- a/wizard/WizardCreateWallet4.qml
+++ b/wizard/WizardCreateWallet4.qml
@@ -38,6 +38,7 @@ Rectangle {
 
     color: "transparent"
     property alias pageHeight: pageRoot.height
+    property alias wizardNav: wizardNav
     property string viewName: "wizardCreateWallet4"
 
     ColumnLayout {
@@ -64,6 +65,7 @@ Rectangle {
             WizardSummary {}
 
             WizardNav {
+                id: wizardNav
                 Layout.topMargin: 24
                 btnNextText: qsTr("Create wallet") + translationManager.emptyString
                 progressSteps: appWindow.walletMode <= 1 ? 3 : 4
@@ -77,11 +79,13 @@ Rectangle {
                     }
                 }
                 onNextClicked: {
+                    btnNext.enabled = false;
                     wizardController.wizardStateView.wizardCreateWallet2View.pwField = "";
                     wizardController.wizardStateView.wizardCreateWallet2View.pwConfirmField = "";
                     wizardController.writeWallet(function() {
                         wizardController.useMoneroClicked();
                         wizardController.walletOptionsIsRecoveringFromDevice = false;
+                        btnNext.enabled = true;
                     });
                 }
             }

--- a/wizard/WizardRestoreWallet4.qml
+++ b/wizard/WizardRestoreWallet4.qml
@@ -38,6 +38,7 @@ Rectangle {
 
     color: "transparent"
     property alias pageHeight: pageRoot.height
+    property alias wizardNav: wizardNav
     property string viewName: "wizardRestoreWallet4"
 
     ColumnLayout {
@@ -64,6 +65,7 @@ Rectangle {
             WizardSummary {}
 
             WizardNav {
+                id: wizardNav
                 Layout.topMargin: 24
                 btnNextText: qsTr("Create wallet") + translationManager.emptyString
                 progressSteps: appWindow.walletMode <= 1 ? 3 : 4
@@ -77,11 +79,13 @@ Rectangle {
                     }
                 }
                 onNextClicked: {
+                    btnNext.enabled = false;
                     wizardController.wizardStateView.wizardRestoreWallet2View.pwField = "";
                     wizardController.wizardStateView.wizardRestoreWallet2View.pwConfirmField = "";
                     wizardController.recoveryWallet();
                     wizardController.writeWallet(function() {
                         wizardController.useMoneroClicked();
+                        btnNext.enabled = true;
                     });
                 }
             }


### PR DESCRIPTION
If the user double-clicks the "Create wallet" button on the last page of "Restore wallet from keys or mnemonic seed", the wallet is created, but Monero GUI will display an error and the temporary wallet name will be displayed:

![image](https://user-images.githubusercontent.com/45968869/149832282-22d4f63f-3218-4f79-bb91-9f00405c93d3.png)

An error will also be displayed when double-clicking "Create wallet" button on the last page of "Create new wallet from hardware", but in this case Monero GUI will not display the temporary wallet name.

"Create new wallet" page doesn't have this problem.

This PR disables double-clicking on the "Create wallet" button on WizardRestoreWallet4.qml and WizardCreateWallet4.qml.