### PR TITLE
Advanced: ReserveProof: Add support for reserve proof

### DIFF
--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -66,7 +66,7 @@ Rectangle {
     signal paymentClicked(var recipients, string paymentId, int mixinCount, int priority, string description)
     signal sweepUnmixableClicked()
     signal generatePaymentIdInvoked()
-    signal getProofClicked(string txid, string address, string message);
+    signal getProofClicked(string txid, string address, string message, string amount);
     signal checkProofClicked(string txid, string address, string message, string signature);
 
     Rectangle {

--- a/js/TxUtils.js
+++ b/js/TxUtils.js
@@ -61,6 +61,10 @@ function checkSignature(signature) {
         if ((signature.length - 12) % 88 != 0)
             return false;
         return check256(signature, signature.length);
+    } else if (signature.indexOf("ReserveProofV") === 0) {
+        if ((signature.length - 14) % 447 != 0)
+            return false;
+        return check256(signature, signature.length);
     }
     return false;
 }

--- a/main.qml
+++ b/main.qml
@@ -985,24 +985,28 @@ ApplicationWindow {
     }
 
     // called on "getProof"
-    function handleGetProof(txid, address, message) {
-        console.log("Getting payment proof: ")
-        console.log("\ttxid: ", txid,
-                    ", address: ", address,
-                    ", message: ", message);
-
-        function spendProofFallback(txid, result){
-            if (!result || result.indexOf("error|") === 0) {
-                currentWallet.getSpendProofAsync(txid, message, txProofComputed);
-            } else {
-                txProofComputed(txid, result);
+    function handleGetProof(txid, address, message, amount) {
+        if (amount.length > 0) {
+            var result = currentWallet.getReserveProof(false, currentWallet.currentSubaddressAccount, walletManager.amountFromString(amount), message)
+            txProofComputed(null, result)
+        } else {
+            console.log("Getting payment proof: ")
+            console.log("\ttxid: ", txid,
+                        ", address: ", address,
+                        ", message: ", message);
+            function spendProofFallback(txid, result){
+                if (!result || result.indexOf("error|") === 0) {
+                    currentWallet.getSpendProofAsync(txid, message, txProofComputed);
+                } else {
+                    txProofComputed(txid, result);
+                }
             }
+            if (address.length > 0)
+                currentWallet.getTxProofAsync(txid, address, message, spendProofFallback);
+            else
+                spendProofFallback(txid, null);
         }
-
-        if (address.length > 0)
-            currentWallet.getTxProofAsync(txid, address, message, spendProofFallback);
-        else
-            spendProofFallback(txid, null);
+        informationPopup.open()
     }
 
     function txProofComputed(txid, result){
@@ -1025,12 +1029,18 @@ ApplicationWindow {
                     ", signature: ", signature);
 
         var result;
-        if (address.length > 0)
+        var isReserveProof = signature.indexOf("ReserveProofV") === 0;
+        if (address.length > 0 && !isReserveProof) {
             result = currentWallet.checkTxProof(txid, address, message, signature);
-        else
+        } 
+        else if (isReserveProof) {
+            result = currentWallet.checkReserveProof(address, message, signature);
+        } 
+        else {
             result = currentWallet.checkSpendProof(txid, message, signature);
+        }
         var results = result.split("|");
-        if (address.length > 0 && results.length == 5 && results[0] === "true") {
+        if (address.length > 0 && results.length == 5 && results[0] === "true" && !isReserveProof) {
             var good = results[1] === "true";
             var received = results[2];
             var in_pool = results[3] === "true";
@@ -1058,6 +1068,12 @@ ApplicationWindow {
             informationPopup.title = qsTr("Payment proof check") + translationManager.emptyString;
             informationPopup.icon = good ? StandardIcon.Information : StandardIcon.Critical;
             informationPopup.text = good ? qsTr("Good signature") : qsTr("Bad signature");
+        } 
+        else if (isReserveProof && results[0] === "true") {
+            var good = results[1] === "true";
+            informationPopup.title = qsTr("Reserve proof check") + translationManager.emptyString;
+            informationPopup.icon = good ? StandardIcon.Information : StandardIcon.Critical;
+            informationPopup.text = good ? qsTr("Good signature on ") + results[2] + qsTr(" total and ") + results[3] + qsTr(" spent.") : qsTr("Bad signature");
         }
         else {
             informationPopup.title  = qsTr("Error") + translationManager.emptyString;

--- a/main.qml
+++ b/main.qml
@@ -1073,7 +1073,7 @@ ApplicationWindow {
             var good = results[1] === "true";
             informationPopup.title = qsTr("Reserve proof check") + translationManager.emptyString;
             informationPopup.icon = good ? StandardIcon.Information : StandardIcon.Critical;
-            informationPopup.text = good ? qsTr("Good signature on ") + results[2] + qsTr(" total and ") + results[3] + qsTr(" spent.") : qsTr("Bad signature");
+            informationPopup.text = good ? qsTr("Good signature on %1 total and %2 spent.").arg(results[2]).arg(results[3]) : qsTr("Bad signature");
         }
         else {
             informationPopup.title  = qsTr("Error") + translationManager.emptyString;

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -60,13 +60,13 @@ Rectangle {
             MoneroComponents.Label {
                 id: soloTitleLabel
                 fontSize: 24
-                text: qsTr("Prove Transaction / Reserve") + translationManager.emptyString
+                text: qsTr("Prove Transaction") + " / " + qsTr("Reserve") + translationManager.emptyString
             }
 
             MoneroComponents.TextPlain {
                 Layout.fillWidth: true
                 text: qsTr("Generate a proof of your incoming/outgoing payment by supplying the transaction ID, the recipient address and an optional message. \n" +
-                           "For the case of outgoing payments, you can get a 'Spend Proof' that proves the authorship of a transaction. In this case, you don't need to specify the recipient address. \nFor reserve proofs you don't need to specify tx id or address.") + translationManager.emptyString
+                           "For the case of outgoing payments, you can get a 'Spend Proof' that proves the authorship of a transaction. In this case, you don't need to specify the recipient address.") + qsTr("\nFor reserve proofs you don't need to specify tx id or address.") + translationManager.emptyString
                 wrapMode: Text.Wrap
                 font.family: MoneroComponents.Style.fontRegular.name
                 font.pixelSize: 14
@@ -166,12 +166,12 @@ Rectangle {
             MoneroComponents.Label {
                 id: soloTitleLabel2
                 fontSize: 24
-                text: qsTr("Check Transaction / Reserve") + translationManager.emptyString
+                text: qsTr("Check Transaction") + " / " + qsTr("Reserve") + translationManager.emptyString
             }
 
             MoneroComponents.TextPlain {
                 text: qsTr("Verify that funds were paid to an address by supplying the transaction ID, the recipient address, the message used for signing and the signature.\n" +
-                           "For the case with Spend Proof, you don't need to specify the recipient address.\nTransaction is not needed for reserve proof.") + translationManager.emptyString
+                           "For the case with Spend Proof, you don't need to specify the recipient address.") + "\n" + qsTr("Transaction is not needed for reserve proof.") + translationManager.emptyString
                 wrapMode: Text.Wrap
                 Layout.fillWidth: true
                 font.family: MoneroComponents.Style.fontRegular.name
@@ -222,7 +222,7 @@ Rectangle {
                 labelFontSize: 14
                 labelText: qsTr("Signature") + translationManager.emptyString
                 placeholderFontSize: 16
-                placeholderText: qsTr("Paste tx / reserve proof") + translationManager.emptyString;
+                placeholderText: qsTr("Paste tx proof") + " / " + qsTr("reserve proof") + translationManager.emptyString;
                 readOnly: false
                 copyButton: true
             }
@@ -255,7 +255,7 @@ Rectangle {
                 font.family: MoneroComponents.Style.fontRegular.name
                 font.pixelSize: 14
                 color: MoneroComponents.Style.defaultFontColor
-            }            
+            }
         }
     }
 

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -844,6 +844,25 @@ Q_INVOKABLE QString Wallet::checkSpendProof(const QString &txid, const QString &
     return QString::fromStdString(result);
 }
 
+Q_INVOKABLE QString Wallet::getReserveProof(bool all, quint32 account_index, quint64 amount, const QString &message) const
+{
+    qDebug("Generating reserve proof");
+    std::string result = m_walletImpl->getReserveProof(all, account_index, amount, message.toStdString());
+    if (result.empty())
+        result = "error|" + m_walletImpl->errorString();
+    return QString::fromStdString(result);
+}
+
+Q_INVOKABLE QString Wallet::checkReserveProof(const QString &address, const QString &message, const QString &signature) const
+{
+    bool good;
+    u_int64_t total;
+    u_int64_t spent;
+    bool success = m_walletImpl->checkReserveProof(address.toStdString(), message.toStdString(), signature.toStdString(), good, total, spent);
+    std::string result = std::string(success ? "true" : "false") + "|" + std::string(good ? "true" : "false") + "|" + QString::number(total).toStdString() + "|" + QString::number(spent).toStdString();
+    return QString::fromStdString(result);
+}
+
 QString Wallet::signMessage(const QString &message, bool filename) const
 {
   if (filename) {

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -318,6 +318,8 @@ public:
     Q_INVOKABLE QString getSpendProof(const QString &txid, const QString &message) const;
     Q_INVOKABLE void getSpendProofAsync(const QString &txid, const QString &message, const QJSValue &callback);
     Q_INVOKABLE QString checkSpendProof(const QString &txid, const QString &message, const QString &signature) const;
+    Q_INVOKABLE QString getReserveProof(bool all, quint32 account_index, quint64 amount, const QString &message) const;
+    Q_INVOKABLE QString checkReserveProof(const QString &address, const QString &message, const QString &signature) const;
     // Rescan spent outputs
     Q_INVOKABLE bool rescanSpent();
 


### PR DESCRIPTION
Closes #3826 

This change adds the ability to prove and check a reserve proof
to this existing "Prove/check" advanced menu. If the amount line has
a valid amount less than that of the current account index this input
will drive the logic for generating a reserve proof. Checking a reserve
proof is accomplished by validating the address and verifying that
signature.indexOf("ReserveProofV") === 0. The result displays the total
and spent amount of the proof.

![reserve_proof_layout](https://user-images.githubusercontent.com/13033037/150448774-2fbe8d5f-bee7-43ea-8a39-1d02871218d6.png)

![reserve_proof_test](https://user-images.githubusercontent.com/13033037/150448785-2f823852-bad2-4ebb-95db-cc200f491507.png)

![check_reserve_proof_layout](https://user-images.githubusercontent.com/13033037/150451335-c1892575-9c95-49aa-b960-435827ed324c.png)

![check_reserve_proof](https://user-images.githubusercontent.com/13033037/150449863-9f75816f-8566-49d9-880b-78c37b9b9da4.png)
