### PR TITLE
bug: reset wallet path on network change 

### DIFF
--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -213,6 +213,7 @@ Rectangle {
                         }
                         appWindow.disconnectRemoteNode()
                         networkTypeDropdown.currentIndex = Qt.binding(function() { return persistentSettings.nettype });
+                        persistentSettings.wallet_path = ""
                     }
                 }
 


### PR DESCRIPTION
Closes #3818

When changing network type without changing
wallet path the gui will attempt to open the
most recently used wallet path and network type
even if they don't match. This commit forces the
user back to wallet setup under this condition.
As long as network type and wallet path are both
updated before closing the issue will no longer occur.