### PR TITLE
settings: bind return key after password change

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1692,6 +1692,9 @@ ApplicationWindow {
             informationPopup.open();
         }
         onRejectedNewPassword: {}
+        Keys.enabled: !passwordDialog.visible && informationPopup.visible
+        Keys.onEnterPressed: informationPopup.close()
+        Keys.onReturnPressed: informationPopup.close()
     }
 
     DevicePassphraseDialog {


### PR DESCRIPTION
Closes #3836 

The enter / return key is not bound to the information
popup that appears after a successful password change.
The functionality exists on the previous menu. Make it
possible to use the return key on this popup as well.