### PR TITLE
workflows: fix windows build error

### DIFF
--- a/src/qt/updater.cpp
+++ b/src/qt/updater.cpp
@@ -26,6 +26,10 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#if defined(_WIN32) && !defined(MONERO_GUI_STATIC)
+    #include <Winsock2.h>
+#endif
+
 #include "updater.h"
 
 #include <common/util.h>


### PR DESCRIPTION
Don't have much knowledge about this error but it seems to have occurred before in [PR #2294](https://github.com/monero-project/monero/pull/2994). Logs show to include winsock2.h and the build fails at the updater.cpp file.

<details>
<summary>
logs
</summary>
<code>
from D:/a/monero-gui/monero-gui/src/qt/updater.cpp:35:
</code>
<br />
<code>
D:/a/_temp/msys64/mingw64/include/winsock2.h:15:2:
</code>
<br />
<code>
warning: #warning Please include winsock2.h before windows.h
</code>
<br />
<code>
[-Wcpp] 15 | #warning Please include winsock2.h before windows.h
</code
</details>
