### PR TITLE
SettingsWallet: lock wallet on demand

### DIFF
--- a/components/SettingsListItem.qml
+++ b/components/SettingsListItem.qml
@@ -7,6 +7,7 @@ import "../components" as MoneroComponents
 ColumnLayout {
     id: settingsListItem
     property alias iconText: iconLabel.text
+    property alias symbol: symbolText.text
     property alias description: area.text
     property alias title: header.text
     property bool isLast: false
@@ -113,6 +114,18 @@ ColumnLayout {
             onClicked: {
                 settingsListItem.clicked()
             }
+        }
+
+        MoneroComponents.TextPlain {
+            id: symbolText
+            anchors.right: parent.right
+            anchors.rightMargin: 44
+            anchors.verticalCenter: parent.verticalCenter
+            font.pixelSize: 12
+            font.bold: true
+            color: MoneroComponents.Style.menuButtonTextColor
+            visible: appWindow.ctrlPressed
+            themeTransition: false
         }
     }
 }

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -57,6 +57,7 @@ Rectangle {
     signal minimizeClicked
     signal languageClicked
     signal closeWalletClicked
+    signal lockWalletClicked
 
     state: "default"
     states: [
@@ -90,6 +91,46 @@ Rectangle {
         z: parent.z + 2
         spacing: 0
         anchors.fill: parent
+
+        // lock wallet
+        Rectangle {
+            id: btnLockWallet
+            color: "transparent"
+            Layout.preferredWidth: parent.height
+            Layout.preferredHeight: parent.height
+
+            Text {
+                text: FontAwesome.lock
+                font.family: FontAwesome.fontFamilySolid
+                font.pixelSize: 16
+                color: MoneroComponents.Style.defaultFontColor
+                font.styleName: "Solid"
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+                opacity: 0.75
+            }
+
+            MoneroComponents.Tooltip {
+                id: btnLockWalletTooltip
+                anchors.fill: parent
+                text: qsTr("Lock this wallet") + translationManager.emptyString
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onEntered: {
+                    parent.color = MoneroComponents.Style.titleBarButtonHoverColor
+                    btnLockWalletTooltip.tooltipPopup.open()
+                }
+                onExited: {
+                    parent.color = "transparent"
+                    btnLockWalletTooltip.tooltipPopup.close()
+                }
+                onClicked: root.lockWalletClicked(leftPanel.visible)
+            }
+        }
 
         // collapse sidebar
         Rectangle {

--- a/fonts/FontAwesome/FontAwesome.qml
+++ b/fonts/FontAwesome/FontAwesome.qml
@@ -53,6 +53,7 @@ Object {
     property string info : "\uf129"
     property string key : "\uf084"
     property string language : "\uf1ab"
+    property string lock : "\uf023"
     property string minus : "\uf068"
     property string minusCircle : "\uf056"
     property string moonO : "\uf186"

--- a/main.qml
+++ b/main.qml
@@ -131,6 +131,17 @@ ApplicationWindow {
         leftPanel.selectItem(page)
     }
 
+    function lock() {
+        passwordDialog.onRejectedCallback = function() { appWindow.showWizard(); }
+        passwordDialog.onAcceptedCallback = function() {
+            if(walletPassword === passwordDialog.password)
+                passwordDialog.close();
+            else 
+                passwordDialog.showError(qsTr("Wrong password") + translationManager.emptyString);
+        }
+        passwordDialog.open(usefulName(persistentSettings.wallet_path));
+    }
+
     function sequencePressed(obj, seq) {
         if(seq === undefined || !leftPanel.enabled)
             return
@@ -139,6 +150,8 @@ ApplicationWindow {
             return
         }
 
+        // lock wallet on demand
+        if(seq === "Ctrl+L" && !passwordDialog.visible) lock()
         if(seq === "Ctrl+S") middlePanel.state = "Transfer"
         else if(seq === "Ctrl+R") middlePanel.state = "Receive"
         else if(seq === "Ctrl+H") middlePanel.state = "History"
@@ -1923,6 +1936,7 @@ ApplicationWindow {
             anchors.left: parent.left
             anchors.right: parent.right
             onCloseClicked: appWindow.close();
+            onLockWalletClicked: appWindow.lock();
             onLanguageClicked: appWindow.toggleLanguageView();
             onCloseWalletClicked: appWindow.showWizard();
             onMaximizeClicked: appWindow.visibility = appWindow.visibility !== Window.Maximized ? Window.Maximized : Window.Windowed

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -51,6 +51,14 @@ Rectangle {
         spacing: 0
 
         MoneroComponents.SettingsListItem {
+            iconText: FontAwesome.lock
+            description: qsTr("Locks the wallet on demand.") + translationManager.emptyString
+            title: qsTr("Lock this wallet") + translationManager.emptyString
+            symbol: (isMac ? "⌃" : qsTr("Ctrl+")) + "L" + translationManager.emptyString
+            onClicked: appWindow.lock();
+        }
+
+        MoneroComponents.SettingsListItem {
             iconText: FontAwesome.signOutAlt
             description: qsTr("Logs out of this wallet.") + translationManager.emptyString
             title: qsTr("Close this wallet") + translationManager.emptyString


### PR DESCRIPTION
Closes #3857 
This commit adds the ability to lock the wallet on demand instead
of waiting for the user inactivity time out. It is binded to the
hot keys Ctrl+L. Pressing cancel or the esc key will send the user
back to the wizard home for wallet selection. Incorrect password
returns the error message. Correct password will remove the
PasswordDialog allowing access. Add lock functionality in the
wallet settings section and title bar.

![fix-3857](https://user-images.githubusercontent.com/13033037/158070462-e5315b64-5a4f-4cbd-bebe-00c8e60916ae.png)
