### PR TITLE
RemoteNodeDialog: bind ok to return key

### DIFF
--- a/components/RemoteNodeDialog.qml
+++ b/components/RemoteNodeDialog.qml
@@ -42,6 +42,13 @@ MoneroComponents.Dialog {
 
     onActiveFocusChanged: activeFocus && remoteNodeAddress.forceActiveFocus()
 
+    function onOk() {
+        root.success = true;
+        root.close();
+    }
+
+    function onCancel() { root.close(); }
+
     function add(callbackOnSuccess) {
         root.editMode = false;
         root.callbackOnSuccess = callbackOnSuccess;
@@ -89,6 +96,11 @@ MoneroComponents.Dialog {
 
         daemonAddrLabelText: qsTr("Address") + translationManager.emptyString
         daemonPortLabelText: qsTr("Port") + translationManager.emptyString
+
+        Keys.enabled: root.visible
+        Keys.onEnterPressed: root.onOk()
+        Keys.onReturnPressed: root.onOk()
+        Keys.onEscapePressed: root.onCancel()
     }
 
     RowLayout {
@@ -116,6 +128,11 @@ MoneroComponents.Dialog {
             placeholderFontSize: 15
             labelFontSize: 14
             fontSize: 15
+
+            Keys.enabled: root.visible
+            Keys.onEnterPressed: root.onOk()
+            Keys.onReturnPressed: root.onOk()
+            Keys.onEscapePressed: root.onCancel()
         }
     }
 


### PR DESCRIPTION
Closes #3842
This commit binds the enter / return key on the remote
node dialog. If cursor is in the host, port or password
input fields the keyboard can be used to continue. It is not
bound to the username field because ideally a user would
enter password or port last.