### PR TITLE
TitleBar: Remove lock icon on essentials display

### DIFF
--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -64,11 +64,13 @@ Rectangle {
         State {
             name: "default";
             PropertyChanges { target: btnCloseWallet; visible: true}
+            PropertyChanges { target: btnLockWallet; visible: true}
             PropertyChanges { target: btnLanguageToggle; visible: true}
         }, State {
             // show only theme switcher and window controls
             name: "essentials";
             PropertyChanges { target: btnCloseWallet; visible: false}
+            PropertyChanges { target: btnLockWallet; visible: false}
             PropertyChanges { target: btnLanguageToggle; visible: false}
         }
     ]


### PR DESCRIPTION
The lock functionality is shown on the initial welcome screen
and the WizardHome. Remove the lock icon until the wallet is
actually open, similar to the "Close this wallet" logic.

Fixes 346913f: ("SettingsWallet: lock wallet on demand")

![lock-wallet-welcome](https://user-images.githubusercontent.com/13033037/159159447-b0d6bc7f-768c-4add-b362-d10143125f39.png)

I don't open this screen often so just noticed lock icon is there.

