### PR TITLE
Makefile: set CMAKE_BUILD_TYPE to debug for debug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ debug-static-win64:
 
 debug-static-mac64:
 	mkdir -p $(builddir)/debug
-	cd $(builddir)/debug && cmake -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},ON) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="mac-x64" $(topdir) && $(MAKE)
+	cd $(builddir)/debug && cmake -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},ON) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Debug -D BUILD_TAG="mac-x64" $(topdir) && $(MAKE)
 
 release-static-win64:
 	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -D STATIC=ON -G "MSYS Makefiles" -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=$(topdir)/cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) -D MINGW=ON $(topdir) && $(MAKE)


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

> Typical values include Debug, **Release**, RelWithDebInfo and MinSizeRel, but custom build types can also be defined.

> Depending on the situation, the value of this variable may be treated **case-sensitively** or case-insensitively.