### PR TITLE
Mining: only update mining status when page is open

### DIFF
--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -575,18 +575,10 @@ Rectangle {
 
     Timer {
         id: timer
-        interval: 2000; running: false; repeat: true
+        interval: 2000
+        running: middlePanel.advancedView.state === "Mining" && middlePanel.state === "Advanced" && currentWallet !== undefined && (!persistentSettings.useRemoteNode || persistentSettings.allowRemoteNodeMining)
+        repeat: true
         onTriggered: update()
-    }
-
-    function onPageCompleted() {
-        console.log("Mining page loaded");
-        update()
-        timer.running = !persistentSettings.useRemoteNode || persistentSettings.allowRemoteNodeMining
-    }
-
-    function onPageClosed() {
-        timer.running = false
     }
 
     function startP2PoolLocal() {


### PR DESCRIPTION
Due to a bug the GUI was constantly checking the mining status every two seconds, no matter if the mining page is open or not.