### PR TITLE
WizardCreateDevice1: set default restore height to 1

### DIFF
--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -185,7 +185,7 @@ Rectangle {
                     validator: RegExpValidator {
                         regExp: /^(\d+|\d{4}-\d{2}-\d{2})$/
                     }
-                    text: "0"
+                    text: "1"
                 }
 
                 CheckBox2 {
@@ -237,7 +237,7 @@ Rectangle {
                     wizardController.walletOptionsDeviceName = wizardCreateDevice1.deviceName;
                     if(lookahead.text)
                         wizardController.walletOptionsSubaddressLookahead = lookahead.text;
-                    if(restoreHeight.text){
+                    if (restoreHeight.text && wizardController.walletOptionsDeviceIsRestore) {
                         wizardController.walletOptionsRestoreHeight = Utils.parseDateStringOrRestoreHeightAsInteger(restoreHeight.text);
                     }
 
@@ -259,7 +259,7 @@ Rectangle {
             newDeviceWallet.checked = true;
             restoreDeviceWallet.checked = false;
             wizardController.walletOptionsDeviceIsRestore = false;
-            restoreHeight.text = "";
+            restoreHeight.text = "1";
             lookahead.text = "";
             errorMsg.text = "";
         }


### PR DESCRIPTION
Due to API reasons height 0 means to approximate the current block height during hardware device restore. That's not what we want by default. Until this gets changed upstream we will set the default to 1.

https://github.com/monero-project/monero/blob/v0.17.3.2/src/wallet/api/wallet_manager.cpp#L145-L149