### PR TITLE
workflows: add caching for docker android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,13 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - uses: satackey/action-docker-layer-caching@v0.0.11
+      if: "!startsWith(github.ref, 'refs/tags/v')"
+      continue-on-error: true
+      with:
+        key: docker-android-static-{hash}
+        restore-keys: |
+          docker-android-static-
     - name: prepare build environment
       run: docker build --tag monero:build-env-android --build-arg THREADS=3 --file Dockerfile.android .
     - name: build


### PR DESCRIPTION
Github has increased the cache to 10GB per repo.