### PR TITLE
History: fix payment proof button

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -999,7 +999,7 @@ ApplicationWindow {
 
     // called on "getProof"
     function handleGetProof(txid, address, message, amount) {
-        if (amount.length > 0) {
+        if (amount !== null && amount.length > 0) {
             var result = currentWallet.getReserveProof(false, currentWallet.currentSubaddressAccount, walletManager.amountFromString(amount), message)
             txProofComputed(null, result)
         } else {

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1720,7 +1720,7 @@ Rectangle {
         }
 
         console.log("getProof: Generate clicked: txid " + hash + ", address " + address);
-        middlePanel.getProofClicked(hash, address, '');
+        middlePanel.getProofClicked(hash, address, '', null);
         informationPopup.title  = qsTr("Payment proof") + translationManager.emptyString;
         informationPopup.text = qsTr("Generating payment proof") + "..." + translationManager.emptyString;
         informationPopup.onCloseCallback = null


### PR DESCRIPTION
Closes #3909 

Adding support for reserve proof added an additional
argument to the getProofClicked signal. The payment
proof button on the transaction list from history.qml
does not pass this argument and fails with insufficient
argument error.

Fixes: 0f67580e ("Advanced: ReserveProof: Add support for reserve proof")

Temporary fix: Use Advanced tab on the GUI or use CLI to generate tx proof (`OutProof`)
Edit: tested locally using docker reproducible build against master branch