### PR TITLE
main: disable setting -platformpluginpath

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -206,6 +206,13 @@ int main(int argc, char *argv[])
 
     qputenv("QML_DISABLE_DISK_CACHE", "1");
 
+    for (int i = 0; i < argc; i++) {
+        if (QString(argv[i]).contains("platformpluginpath")) {
+            qCritical() << "Setting -platformpluginpath as an argument is disabled"; // CVE-2021-3401
+            return 1;
+        }
+    }
+
     MainApp app(argc, argv);
 
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
Not clear if this also applies to monero-gui but it doesn't hurt to disable this option.

- https://achow101.com/2021/02/0.18-uri-vuln
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3401