### PR TITLE
qt: replace QRegExp with QRegularExpression

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -36,7 +36,6 @@
 #include <QObject>
 #include <QDesktopWidget>
 #include <QScreen>
-#include <QRegExp>
 #include <QThread>
 
 #include <version.h>

--- a/src/qt/TailsOS.cpp
+++ b/src/qt/TailsOS.cpp
@@ -1,4 +1,3 @@
-#include <QRegExp>
 #include <QMessageBox>
 #include <QPixmap>
 #include <QTranslator>

--- a/src/qt/utils.h
+++ b/src/qt/utils.h
@@ -30,7 +30,7 @@
 #define UTILS_H
 
 #include <QtCore>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QApplication>
 
 bool fileExists(QString path);
@@ -42,7 +42,7 @@ QString getAccountName();
 QString xdgMime();
 void registerXdgMime();
 #endif
-const static QRegExp reURI = QRegExp("^\\w+:\\/\\/([\\w+\\-?\\-_\\-=\\-&]+)");
+const static QRegularExpression reURI = QRegularExpression("^\\w+:\\/\\/([\\w+\\-?\\-_\\-=\\-&]+)");
 QString randomUserAgent();
 
 #endif // UTILS_H


### PR DESCRIPTION
`QRegExp` is removed in Qt6