### PR TITLE
Mining: add compile time option to disable p2pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(STATIC "Link libraries statically, requires static Qt")
 option(USE_DEVICE_TREZOR "Trezor support compilation" ON)
 option(WITH_SCANNER "Enable webcam QR scanner" OFF)
 option(WITH_DESKTOP_ENTRY "Ask to install desktop entry on first startup" ON)
+option(WITH_P2POOL "Enable mining with P2Pool" ON)
 option(DEV_MODE "Checkout latest monero master on build" OFF)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
@@ -85,6 +86,10 @@ endif()
 
 if(WITH_DESKTOP_ENTRY)
     add_definitions(-DWITH_DESKTOP_ENTRY)
+endif()
+
+if(WITH_P2POOL)
+    add_definitions(-DWITH_P2POOL)
 endif()
 
 # Sodium

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -41,6 +41,7 @@ Rectangle {
     property alias miningHeight: mainLayout.height
     property double currentHashRate: 0
     property int threads: idealThreadCount / 2
+    property bool p2poolSelectedWithoutSupport: persistentSettings.allow_p2pool_mining && !builtWithP2Pool
 
     ColumnLayout {
         id: mainLayout
@@ -86,6 +87,11 @@ Rectangle {
             Layout.topMargin: 8
             Layout.bottomMargin: 8
             text: qsTr("Mining may reduce the performance of other running applications and processes.") + translationManager.emptyString
+        }
+
+        MoneroComponents.WarningBox {
+            text: qsTr("Monero GUI is compiled with P2Pool support disabled.") + translationManager.emptyString
+            visible: p2poolSelectedWithoutSupport
         }
 
         GridLayout {
@@ -544,8 +550,8 @@ Rectangle {
         }
         appWindow.isMining = isMining;
         updateStatusText(hashrate)
-        startSoloMinerButton.enabled = !appWindow.isMining && daemonReady
-        stopSoloMinerButton.enabled = !startSoloMinerButton.enabled && daemonReady
+        startSoloMinerButton.enabled = !appWindow.isMining && daemonReady && !p2poolSelectedWithoutSupport
+        stopSoloMinerButton.enabled = !startSoloMinerButton.enabled && daemonReady && !p2poolSelectedWithoutSupport
     }
 
     function update() {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -514,6 +514,12 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 #endif
     engine.rootContext()->setContextProperty("builtWithDesktopEntry", builtWithDesktopEntry);
 
+    bool builtWithP2Pool = false;
+#ifdef WITH_P2POOL
+    builtWithP2Pool = true;
+#endif
+    engine.rootContext()->setContextProperty("builtWithP2Pool", builtWithP2Pool);
+
     engine.rootContext()->setContextProperty("moneroVersion", MONERO_VERSION_FULL);
 
     // Load main window (context properties needs to be defined obove this line)


### PR DESCRIPTION
P2Pool doesn't work with all package manager setups, so it's best to add an option to disable it during compile time.

@devhyper @BigmenPixel0 @kpcyrd