### PR TITLE
SettingsWallet: add scan transaction option

### DIFF
--- a/fonts/FontAwesome/FontAwesome.qml
+++ b/fonts/FontAwesome/FontAwesome.qml
@@ -54,6 +54,7 @@ Object {
     property string key : "\uf084"
     property string language : "\uf1ab"
     property string lock : "\uf023"
+    property string magnifyingGlass : "\uf002"
     property string minus : "\uf068"
     property string minusCircle : "\uf056"
     property string moonO : "\uf186"

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -128,6 +128,27 @@ Rectangle {
         }
 
         MoneroComponents.SettingsListItem {
+            enabled: leftPanel.progressBar.fillLevel == 100
+            iconText: FontAwesome.magnifyingGlass
+            description: qsTr("Use this feature if a transaction is missing in your wallet history. This will expose the transaction ID to the remote node, which can harm your privacy.") + translationManager.emptyString
+            title: qsTr("Scan transaction") + translationManager.emptyString
+
+            onClicked: {
+                inputDialog.labelText = qsTr("Enter a transaction ID:") + translationManager.emptyString;
+                inputDialog.onAcceptedCallback = function() {
+                    var txid = inputDialog.inputText.trim();
+                    if (currentWallet.scanTransactions([txid])) {
+                        appWindow.showStatusMessage(qsTr("Transaction successfully scanned"), 3);
+                    } else {
+                        appWindow.showStatusMessage(qsTr("Failed to scan transaction") + ": " + currentWallet.errorString, 5);
+                    }
+                }
+                inputDialog.onRejectedCallback = null;
+                inputDialog.open()
+            }
+        }
+
+        MoneroComponents.SettingsListItem {
             iconText: FontAwesome.ellipsisH
             description: qsTr("Change the password of your wallet.") + translationManager.emptyString
             title: qsTr("Change wallet password") + translationManager.emptyString

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -30,7 +30,9 @@
 
 #include <chrono>
 #include <stdexcept>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include "PendingTransaction.h"
 #include "UnsignedTransaction.h"
@@ -505,6 +507,16 @@ bool Wallet::exportOutputs(const QString& path, bool all) {
 
 bool Wallet::importOutputs(const QString& path) {
     return m_walletImpl->importOutputs(path.toStdString());
+}
+
+bool Wallet::scanTransactions(const QVector<QString> &txids)
+{
+    std::vector<std::string> c;
+    for (const auto &v : txids)
+    {
+        c.push_back(v.toStdString());
+    }
+    return m_walletImpl->scanTransactions(c);
 }
 
 bool Wallet::refresh(bool historyAndSubaddresses /* = true */)

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -212,6 +212,9 @@ public:
     Q_INVOKABLE bool exportOutputs(const QString& path, bool all = false);
     Q_INVOKABLE bool importOutputs(const QString& path);
 
+    //! scan transactions
+    Q_INVOKABLE bool scanTransactions(const QVector<QString> &txids);
+
     //! refreshes the wallet
     Q_INVOKABLE bool refresh(bool historyAndSubaddresses = true);
 


### PR DESCRIPTION
Requires https://github.com/monero-project/monero/pull/8356

So far only added the option to scan for a single transaction.