### PR TITLE
convert nettype to int to return correct rpc port

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -2253,7 +2253,7 @@ ApplicationWindow {
     }
 
     function getDefaultDaemonRpcPort(networkType) {
-        switch (networkType) {
+        switch (parseInt(networkType)) {
             case NetworkType.STAGENET:
                 return 38081;
             case NetworkType.TESTNET:


### PR DESCRIPTION
closes #3962 , title could use a little work, its for the local daemon running in the background as `./monerod --stagenet`
selsta suggested a better 1 liner instead of a new line: thanks   
```C++
switch (parseInt(networkType))
```
solution # 2 is to change `var` to `int` but the root cause of this problem remains unknown 
https://github.com/monero-project/monero-gui/blob/b26f38d37ed81e84e51199425a633bc517f7bec2/main.qml#L1378