### PR TITLE
display wallet files with "." in name

### DIFF
--- a/src/qt/KeysFiles.cpp
+++ b/src/qt/KeysFiles.cpp
@@ -115,12 +115,12 @@ void WalletKeysFilesModel::findWallets(const QString &moneroAccountsDir)
         QFileInfo keysFileinfo = it.fileInfo();
 
         constexpr const char keysFileExtension[] = "keys";
-        if (!keysFileinfo.isFile() || keysFileinfo.completeSuffix() != keysFileExtension)
+        if (!keysFileinfo.isFile() || keysFileinfo.suffix() != keysFileExtension)
         {
             continue;
         }
 
-        QString wallet(keysFileinfo.path() + QDir::separator() + keysFileinfo.baseName());
+        QString wallet(keysFileinfo.path() + QDir::separator() + keysFileinfo.completeBaseName());
         quint8 networkType = NetworkType::MAINNET;
         QString address = QString("");
 


### PR DESCRIPTION
in #3774 wallet files containing a dot not being visible was reported. @rbrunner7 also mentions that their wallet files contain ".wallet" at the end. 
![dot](https://user-images.githubusercontent.com/77655812/178628278-4e4e3012-51a0-4bed-a11e-cba3da951cf4.png)
after i found the relevant place in the source where this is handled, selsta suggested "suffix" rather then "completeSuffix". I then noticed the full filename was still missing in the menu - using "completeBaseName" solved this 

I also tested naming a wallet .keys but this is handled correctly by (assuming) wallet2 somewhere (the .keys is stripped from the cache file)