### PR TITLE
TxUtils: don't show resolve for float

### DIFF
--- a/js/TxUtils.js
+++ b/js/TxUtils.js
@@ -71,9 +71,8 @@ function checkSignature(signature) {
 
 function isValidOpenAliasAddress(address) {
     address = address.trim()
-    var dot = address.indexOf('.')
-    if (dot < 0)
-        return false
     // we can get an awful lot of valid domains, including non ASCII chars... accept anything
-    return true
+    // there should be something after the .
+    // make sure it is not some kind of floating number
+    return address.length > 2 && isNaN(parseFloat(address)) && address.indexOf('.') >= 0
 }


### PR DESCRIPTION
Closes #3975

Add parseFloat() checks so that the 'Resolve' button
for OpenAlias remains hidden. Also add a length check
for one character with a dot. IP addresses will not be
respected, but the whole point of domain names and OA is
for facilitating human readable / user friendly information.