### PR TITLE
trim restore height at info -> change height input

### DIFF
--- a/pages/settings/SettingsInfo.qml
+++ b/pages/settings/SettingsInfo.qml
@@ -191,7 +191,7 @@ Rectangle {
                     inputDialog.onAcceptedCallback = function() {
                         var _restoreHeight;
                         if (inputDialog.inputText) {
-                            _restoreHeight = Utils.parseDateStringOrRestoreHeightAsInteger(inputDialog.inputText);
+                            _restoreHeight = Utils.parseDateStringOrRestoreHeightAsInteger(inputDialog.inputText.trim());
                         }
                         if (!isNaN(_restoreHeight)) {
                             if(_restoreHeight >= 0) {


### PR DESCRIPTION
If you accidentally copy and paste a date with a new line character 
```
2022-01-01

```
The gui will restore from 2022. I ran into this problem when helping someone just now, after giving them the correct date to copy and paste so they can restore quicker xD caused some confusion.

the reg exp method used here https://github.com/monero-project/monero-gui/blob/064c145aa8dc68d28ac8b4aa04ae8b4dbad2e2ce/wizard/WizardRestoreWallet1.qml#L277 prevents you from copy and pasting the 'wrong' string which might be annoying - but may be the required 'real' fix for this input too? 