### PR TITLE
libwalletqt: refresh once on wallet opening

### DIFF
--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -545,6 +545,7 @@ bool Wallet::refresh(bool historyAndSubaddresses /* = true */)
 void Wallet::startRefresh()
 {
     m_refreshEnabled = true;
+    m_refreshNow = true;
 }
 
 void Wallet::pauseRefresh()
@@ -1142,6 +1143,7 @@ Wallet::Wallet(Monero::Wallet *w, QObject *parent)
     , m_subaddressModel(nullptr)
     , m_subaddressAccount(new SubaddressAccount(m_walletImpl->subaddressAccount(), this))
     , m_subaddressAccountModel(nullptr)
+    , m_refreshNow(false)
     , m_refreshEnabled(false)
     , m_refreshing(false)
     , m_scheduler(this)
@@ -1195,10 +1197,11 @@ void Wallet::startRefreshThread()
             {
                 const auto now = std::chrono::steady_clock::now();
                 const auto elapsed = now - last;
-                if (elapsed >= refreshInterval)
+                if (elapsed >= refreshInterval || m_refreshNow)
                 {
                     refresh(false);
                     last = std::chrono::steady_clock::now();
+                    m_refreshNow = false;
                 }
             }
 

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -473,6 +473,7 @@ private:
     QString m_daemonPassword;
     QString m_proxyAddress;
     mutable QMutex m_proxyMutex;
+    std::atomic<bool> m_refreshNow;
     std::atomic<bool> m_refreshEnabled;
     std::atomic<bool> m_refreshing;
     WalletListenerImpl *m_walletListener;


### PR DESCRIPTION
Found and fixed an issue that the wallet first waits 10 seconds before starting a refresh, turns out Feather fixed it 2 years ago. Added tobtoht as co-author for this reason and copied their variable naming.