### PR TITLE
main: add --no-igd to simple mode flags

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -2034,7 +2034,7 @@ ApplicationWindow {
             return;
         }
 
-        const simpleModeFlags = "--enable-dns-blocklist --out-peers 16";
+        const simpleModeFlags = "--enable-dns-blocklist --out-peers 16 --no-igd";
         if (appWindow.daemonRunning) {
             appWindow.stopDaemon(function() {
                 appWindow.startDaemon(simpleModeFlags)


### PR DESCRIPTION
Should solve issues with monerod taking a while to exit. Simple mode nodes aren't beneficial to the network anyway, so having no incoming connections in some cases should be fine.