### PR TITLE
Fix behavior when switching nodes

### DIFF
--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -461,6 +461,7 @@ private:
     mutable QElapsedTimer m_connectionStatusTime;
     bool m_disconnected;
     std::atomic<bool> m_initialized;
+    std::atomic<bool> m_initializing;
     uint32_t m_currentSubaddressAccount;
     Subaddress * m_subaddress;
     mutable SubaddressModel * m_subaddressModel;


### PR DESCRIPTION
Works together with the fixes in Monero PR https://github.com/monero-project/monero/pull/8585.

The most significant fix in this PR is that it prevents the GUI from getting stuck in an infinite "Connecting" loop when connecting to a non-existent (or sometimes offline) daemon.

It also fixes some jank (and *some* of the incorrect underlying behavior) when switching nodes. The underlying async behavior still isn't perfect, but it's a move in a better direction. See the demos below.

## GUI v0.18.1.1 + this PR + Monero PR 8585

*Not shown: connecting to `1.2.3.4:18081` takes 20 seconds to time out and display "Disconnected"*

![PR behavior](https://user-images.githubusercontent.com/26468430/191656682-3c07c818-446c-46a6-af6f-ba7e0f9bbf74.gif)

## GUI v0.18.1.1 + Monero PR 8585 (this PR is excluded)

*Not shown: connecting to `1.2.3.4:18081` gets stuck infinite "Connecting"*

![Only Monero repo PR behavior](https://user-images.githubusercontent.com/26468430/191656828-a455b187-df35-40bd-972d-1ea58a3d253f.gif)

