### PR TITLE
Feature: sync in the background with just view key when locked

### DIFF
--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -50,6 +50,7 @@ Item {
     property bool passwordDialogMode
     property bool passphraseDialogMode
     property bool newPasswordDialogMode
+    property bool backgroundSyncing
 
     // same signals as Dialog has
     signal accepted()
@@ -77,10 +78,11 @@ Item {
         appWindow.updateBalance();
     }
 
-    function open(walletName, errorText, okButtonText, okButtonIcon) {
+    function open(walletName, errorText, okButtonText, okButtonIcon, backgroundSyncOn) {
         passwordDialogMode = true;
         passphraseDialogMode = false;
         newPasswordDialogMode = false;
+        backgroundSyncing = backgroundSyncOn || false;
         root.okButtonText = okButtonText;
         root.okButtonIcon = okButtonIcon ? okButtonIcon : "";
         _openInit(walletName, errorText);
@@ -90,6 +92,7 @@ Item {
         passwordDialogMode = false;
         passphraseDialogMode = true;
         newPasswordDialogMode = false;
+        backgroundSyncing = false;
         _openInit("", "");
     }
 
@@ -97,6 +100,7 @@ Item {
         passwordDialogMode = false;
         passphraseDialogMode = false;
         newPasswordDialogMode = true;
+        backgroundSyncing = false;
         _openInit("", "");
     }
 
@@ -299,6 +303,18 @@ Item {
                     enabled: (passwordDialogMode == true) ? true : passwordInput1.text === passwordInput2.text
                     onClicked: onOk()
                 }
+            }
+
+            Label {
+                visible: backgroundSyncing
+                text: qsTr("Syncing in the background...") + translationManager.emptyString;
+                Layout.fillWidth: true
+
+                font.pixelSize: 14
+                font.family: MoneroComponents.Style.fontLight.name
+                font.italic: true
+
+                color: MoneroComponents.Style.defaultFontColor
             }
         }
     }

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1542,6 +1542,7 @@ Rectangle {
     function updateTransactionsFromModel() {
         // This function copies the items of `appWindow.currentWallet.historyModel` to `root.txModelData`, as a list of javascript objects
         if(currentWallet == null || typeof currentWallet.history === "undefined" ) return;
+        if(currentWallet.isBackgroundSyncing()) return;
 
         var _model = root.model;
         var total = 0

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -31,6 +31,8 @@ import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.0
 import QtQuick.Dialogs 1.2
 
+import moneroComponents.Wallet 1.0
+
 import "../../js/Utils.js" as Utils
 import "../../js/Windows.js" as Windows
 import "../../components" as MoneroComponents
@@ -153,6 +155,28 @@ Rectangle {
                 return qsTr("After ") + value + " " + minutes + translationManager.emptyString;
             }
             onMoved: persistentSettings.lockOnUserInActivityInterval = value
+        }
+
+        MoneroComponents.CheckBox {
+            id: backgroundSyncCheckbox
+            visible: !!currentWallet && !currentWallet.isHwBacked() && !appWindow.viewOnly
+            checked: appWindow.backgroundSyncType != Wallet.BackgroundSync_Off
+            text: qsTr("Sync in the background when locked") + translationManager.emptyString
+            toggleOnClick: false
+            onClicked: {
+                if (currentWallet && appWindow) {
+                    appWindow.showProcessingSplash(qsTr("Updating settings..."))
+
+                    // TODO: add support for custom background password option
+                    var newBackgroundSyncType = Wallet.BackgroundSync_Off
+                    if (currentWallet.getBackgroundSyncType() === Wallet.BackgroundSync_Off)
+                        newBackgroundSyncType = Wallet.BackgroundSync_ReusePassword
+
+                    // TODO: don't keep the wallet password in memory on the appWindow
+                    // https://github.com/monero-project/monero-gui/issues/1537#issuecomment-410055329
+                    currentWallet.setupBackgroundSync(newBackgroundSyncType, appWindow.walletPassword)
+                }
+            }
         }
 
         MoneroComponents.CheckBox {

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -529,6 +529,69 @@ bool Wallet::scanTransactions(const QVector<QString> &txids)
     return m_walletImpl->scanTransactions(c);
 }
 
+void Wallet::setupBackgroundSync(const Wallet::BackgroundSyncType background_sync_type, const QString &wallet_password)
+{
+    qDebug() << "Setting up background sync";
+    bool refreshEnabled = m_refreshEnabled;
+    pauseRefresh();
+
+    // run inside scheduler because of lag when stopping/starting refresh
+    m_scheduler.run([this, refreshEnabled, background_sync_type, &wallet_password] {
+        m_walletImpl->setupBackgroundSync(
+            static_cast<Monero::Wallet::BackgroundSyncType>(background_sync_type),
+            wallet_password.toStdString(),
+            Monero::optional<std::string>());
+        if (refreshEnabled)
+            startRefresh();
+        emit backgroundSyncSetup();
+    });
+}
+
+Wallet::BackgroundSyncType Wallet::getBackgroundSyncType() const
+{
+    return static_cast<BackgroundSyncType>(m_walletImpl->getBackgroundSyncType());
+}
+
+bool Wallet::isBackgroundWallet() const
+{
+    return m_walletImpl->isBackgroundWallet();
+}
+
+bool Wallet::isBackgroundSyncing() const
+{
+    return m_walletImpl->isBackgroundSyncing();
+}
+
+void Wallet::startBackgroundSync()
+{
+    qDebug() << "Starting background sync";
+    bool refreshEnabled = m_refreshEnabled;
+    pauseRefresh();
+
+    // run inside scheduler because of lag when stopping/starting refresh
+    m_scheduler.run([this, refreshEnabled] {
+        m_walletImpl->startBackgroundSync();
+        if (refreshEnabled)
+            startRefresh();
+        emit backgroundSyncStarted();
+    });
+}
+
+void Wallet::stopBackgroundSync(const QString &password)
+{
+    qDebug() << "Stopping background sync";
+    bool refreshEnabled = m_refreshEnabled;
+    pauseRefresh();
+
+    // run inside scheduler because of lag when stopping/starting refresh
+    m_scheduler.run([this, password, refreshEnabled] {
+        m_walletImpl->stopBackgroundSync(password.toStdString());
+        if (refreshEnabled)
+            startRefresh();
+        emit backgroundSyncStopped();
+    });
+}
+
 bool Wallet::refresh(bool historyAndSubaddresses /* = true */)
 {
     refreshingSet(true);

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -112,6 +112,14 @@ public:
 
     Q_ENUM(ConnectionStatus)
 
+    enum BackgroundSyncType {
+        BackgroundSync_Off            = Monero::Wallet::BackgroundSync_Off,
+        BackgroundSync_ReusePassword  = Monero::Wallet::BackgroundSync_ReusePassword,
+        BackgroundSync_CustomPassword = Monero::Wallet::BackgroundSync_CustomPassword
+    };
+
+    Q_ENUM(BackgroundSyncType)
+
     //! returns mnemonic seed
     QString getSeed() const;
 
@@ -214,6 +222,17 @@ public:
 
     //! scan transactions
     Q_INVOKABLE bool scanTransactions(const QVector<QString> &txids);
+
+    Q_INVOKABLE void setupBackgroundSync(const BackgroundSyncType background_sync_type, const QString &wallet_password);
+    Q_INVOKABLE BackgroundSyncType getBackgroundSyncType() const;
+    Q_INVOKABLE bool isBackgroundWallet() const;
+    Q_INVOKABLE bool isBackgroundSyncing() const;
+
+    //! scan in the background with just the view key (wipe the spend key)
+    Q_INVOKABLE void startBackgroundSync();
+
+    //! bring the spend key back and process background synced txs
+    Q_INVOKABLE void stopBackgroundSync(const QString &password);
 
     //! refreshes the wallet
     Q_INVOKABLE bool refresh(bool historyAndSubaddresses = true);
@@ -369,6 +388,9 @@ signals:
     void moneyReceived(const QString &txId, quint64 amount);
     void unconfirmedMoneyReceived(const QString &txId, quint64 amount);
     void newBlock(quint64 height, quint64 targetHeight);
+    void backgroundSyncSetup() const;
+    void backgroundSyncStarted() const;
+    void backgroundSyncStopped() const;
     void addressBookChanged() const;
     void historyModelChanged() const;
     void walletCreationHeightChanged();


### PR DESCRIPTION
Pairs with https://github.com/monero-project/monero/pull/8619

- In a wallet's settings, a user can check "Sync in the background when locked". This setting is not supported for view only or HW wallets.
- When checked and the wallet is locked, the password dialog indicates "Syncing in the background...". The wallet wipes the spend key from memory and continues syncing without it.
- NOTE: without this PR, today's GUI ALREADY syncs in the background when locked. This new setting ensures that the wallet wipes the spend key from memory when syncing when locked. Even if the setting isn't checked, the wallet still syncs in the background. Perhaps there is a cleaner way to portray this feature in the UI than "Sync in the background when locked"
    - When the wallet is locked, the spend key ideally *should* be wiped from memory by default. The reason I did not make this the default behavior (and the core reason why this setting is introduced as a toggle in this PR) is to minimize impact if something goes wrong with the implementation.
- NOTE2: even after the spend key is wiped from memory, **the wallet password remains cached in memory**. The wallet password can be used to decrypt the spend key which is stored on disk.
- This PR only implements Option 1 described here https://github.com/monero-project/monero/pull/8619. Option 2 described in that PR is not exposed to the user from the GUI.
- If a CLI/RPC wallet sets up a background wallet with a custom password (Option 2 described in the monero repo PR), then the GUI can still open the corresponding full wallet for that background wallet, and the GUI will process that background cache on open and will write to that background wallet on lock.
    - This leaves room on the table to implement a desktop syncing gadget (e.g. that lives in the system tray) that uses Option 2 from the core PR. Idea: run a script that auto-opens a CLI background wallet on startup, and when the user opens their GUI, it auto-stops that CLI wallet and will then automatically process the background cache on open.
        - Keep in mind using Option 2 in this way would likely leave a plaintext view key stored on disk.
 
 TL;DR this PR brings 2 core benefits:
 - Marginally safer syncing while locked (the spend key is wiped from memory, but the wallet password remains in memory).
 - A clear path to a background syncing process that uses just the view key to sync (and e.g. lives in the system tray).