### PR TITLE
SettingsWallet: Update scan transaction for changes to behavior in monero repo PR 8566

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -379,7 +379,7 @@ ApplicationWindow {
     }
 
     function isTrustedDaemon() {
-        return !persistentSettings.useRemoteNode || remoteNodesModel.currentRemoteNode().trusted;
+        return appWindow.walletMode >= 2 && (!persistentSettings.useRemoteNode || remoteNodesModel.currentRemoteNode().trusted);
     }
 
     function usefulName(path) {

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -144,7 +144,7 @@ Rectangle {
                         console.error("Error: ", currentWallet.errorString);
                         if (currentWallet.errorString == "The wallet has already seen 1 or more recent transactions than the scanned tx") {
                             informationPopup.title = qsTr("Error") + translationManager.emptyString;
-                            informationPopup.text = currentWallet.errorString + ".\n\nIn order to rescan the transaction, you can re-sync your wallet by resetting the wallet restore height in the Settings > Info page. Make sure to use a restore height from before your wallet's earliest transaction." + translationManager.emptyString;
+                            informationPopup.text = qsTr("The wallet has already seen 1 or more recent transactions than the scanned transaction.\n\nIn order to rescan the transaction, you can re-sync your wallet by resetting the wallet restore height in the Settings > Info page. Make sure to use a restore height from before your wallet's earliest transaction.") + translationManager.emptyString;
                             informationPopup.icon = StandardIcon.Critical
                             informationPopup.onCloseCallback = null
                             informationPopup.open();

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -138,6 +138,7 @@ Rectangle {
                 inputDialog.onAcceptedCallback = function() {
                     var txid = inputDialog.inputText.trim();
                     if (currentWallet.scanTransactions([txid])) {
+                        updateBalance();
                         appWindow.showStatusMessage(qsTr("Transaction successfully scanned"), 3);
                     } else {
                         appWindow.showStatusMessage(qsTr("Failed to scan transaction") + ": " + currentWallet.errorString, 5);

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -141,7 +141,16 @@ Rectangle {
                         updateBalance();
                         appWindow.showStatusMessage(qsTr("Transaction successfully scanned"), 3);
                     } else {
-                        appWindow.showStatusMessage(qsTr("Failed to scan transaction") + ": " + currentWallet.errorString, 5);
+                        console.error("Error: ", currentWallet.errorString);
+                        if (currentWallet.errorString == "The wallet has already seen 1 or more recent transactions than the scanned tx") {
+                            informationPopup.title = qsTr("Error") + translationManager.emptyString;
+                            informationPopup.text = currentWallet.errorString + ".\n\nIn order to rescan the transaction, you can re-sync your wallet by resetting the wallet restore height in the Settings > Info page. Make sure to use a restore height from before your wallet's earliest transaction." + translationManager.emptyString;
+                            informationPopup.icon = StandardIcon.Critical
+                            informationPopup.onCloseCallback = null
+                            informationPopup.open();
+                        } else {
+                            appWindow.showStatusMessage(qsTr("Failed to scan transaction") + ": " + currentWallet.errorString, 5);
+                        }
                     }
                 }
                 inputDialog.onRejectedCallback = null;


### PR DESCRIPTION
EDIT: also ensures GUI simple mode and bootstrap mode users default to "untrusted" daemon

1. Update balance after calling `scanTransaction` in order to reflect correct balance along with https://github.com/monero-project/monero/pull/8566
2. Display clear error when user is connected to an untrusted daemon and requests to scan a tx that is older than their wallet's most recent tx.