### PR TITLE
open-wallet: set network type when using file browser

### DIFF
--- a/src/main/oshelper.cpp
+++ b/src/main/oshelper.cpp
@@ -63,6 +63,7 @@
 
 #include "QR-Code-scanner/Decoder.h"
 #include "qt/ScopeGuard.h"
+#include "NetworkType.h"
 
 namespace
 {
@@ -279,4 +280,36 @@ bool OSHelper::installed() const
 #else
     return false;
 #endif
+}
+
+std::pair<quint8, QString> OSHelper::getNetworkTypeAndAddressFromFile(const QString &wallet)
+{
+    quint8 networkType = NetworkType::MAINNET;
+    QString address = QString("");
+    // attempt to retreive wallet address
+    if(QFile::exists(wallet + ".address.txt")){
+        QFile file(wallet + ".address.txt");
+        file.open(QFile::ReadOnly | QFile::Text);
+        QString _address = QString(file.readAll());
+        if(!_address.isEmpty()){
+            address = _address;
+            if(address.startsWith("5") || address.startsWith("7")){
+                networkType = NetworkType::STAGENET;
+            } else if(address.startsWith("9") || address.startsWith("B")){
+                networkType = NetworkType::TESTNET;
+            }
+        }
+
+        file.close();
+    }
+    return std::make_pair(networkType, address);
+}
+
+quint8 OSHelper::getNetworkTypeFromFile(const QString &keysPath) const
+{
+    QString walletPath = keysPath;
+    if(keysPath.endsWith(".keys")){
+        walletPath = keysPath.mid(0,keysPath.length()-5);
+    }
+    return getNetworkTypeAndAddressFromFile(walletPath).first;
 }

--- a/src/main/oshelper.h
+++ b/src/main/oshelper.h
@@ -52,7 +52,9 @@ public:
     Q_INVOKABLE QString temporaryPath() const;
     Q_INVOKABLE bool removeTemporaryWallet(const QString &walletName) const;
     Q_INVOKABLE bool isCapsLock() const;
+    Q_INVOKABLE quint8 getNetworkTypeFromFile(const QString &keysPath) const;
 
+    static std::pair<quint8, QString> getNetworkTypeAndAddressFromFile(const QString &wallet);
 private:
     bool installed() const;
 

--- a/src/qt/KeysFiles.cpp
+++ b/src/qt/KeysFiles.cpp
@@ -39,6 +39,7 @@
 #include "libwalletqt/WalletManager.h"
 #include "NetworkType.h"
 #include "qt/utils.h"
+#include "main/oshelper.h"
 
 #include "KeysFiles.h"
 
@@ -121,26 +122,9 @@ void WalletKeysFilesModel::findWallets(const QString &moneroAccountsDir)
         }
 
         QString wallet(keysFileinfo.path() + QDir::separator() + keysFileinfo.completeBaseName());
-        quint8 networkType = NetworkType::MAINNET;
-        QString address = QString("");
-
-        // attempt to retreive wallet address
-        if(fileExists(wallet + ".address.txt")){
-            QFile file(wallet + ".address.txt");
-            file.open(QFile::ReadOnly | QFile::Text);
-            QString _address = QString(file.readAll());
-
-            if(!_address.isEmpty()){
-                address = _address;
-                if(address.startsWith("5") || address.startsWith("7")){
-                    networkType = NetworkType::STAGENET;
-                } else if(address.startsWith("9") || address.startsWith("B")){
-                    networkType = NetworkType::TESTNET;
-                }
-            }
-
-            file.close();
-        }
+        auto networkTypeAndAddress = OSHelper::getNetworkTypeAndAddressFromFile(wallet);
+        quint8 networkType = networkTypeAndAddress.first;
+        QString address = networkTypeAndAddress.second;
 
         this->addWalletKeysFile(WalletKeysFiles(wallet, networkType, std::move(address)));
     }

--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -308,7 +308,9 @@ Rectangle {
         sidebarVisible: false
 
         onAccepted: {
-            wizardController.openWalletFile(fileDialog.fileUrl);
+            var keysPath = walletManager.urlToLocalPath(fileDialog.fileUrl)
+            persistentSettings.nettype = oshelper.getNetworkTypeFromFile(keysPath);
+            wizardController.openWalletFile(keysPath);
         }
         onRejected: {
             console.log("Canceled")


### PR DESCRIPTION
closes #4069
 at open wallet file menu, if you click "Browse Filesystem" and open a .keys file - you will see an error if the networktype differs to the current one. Opening via the wallet icons adjust the network type automatically before opening.

to confirm: 
- all wallet icons are assigned their correct network type / open correctly as normal @ open wallet file menu.
- any wallet keys file opened via "Browse Filesystem" does not complain about a different network type.

(var networktype breaks things if i try "int" - although parseInt is still not required)

selsta is helping / offering advice for v1..2..- this is v5.0 >_<