### PR TITLE
Override desktop theming

### DIFF
--- a/qml.qrc
+++ b/qml.qrc
@@ -282,5 +282,6 @@
         <file>images/ledgerNanoX.png</file>
         <file>images/trezor.png</file>
         <file>images/trezor@2x.png</file>
+        <file>qtquickcontrols2.conf</file>
     </qresource>
 </RCC>

--- a/qtquickcontrols2.conf
+++ b/qtquickcontrols2.conf
@@ -1,0 +1,2 @@
+[Controls]
+Style=Desktop


### PR DESCRIPTION
Resolves #3938 
Forces "Desktop" theme for qtquickcontrols.