### PR TITLE
Utils: simplify ago func

### DIFF
--- a/js/Utils.js
+++ b/js/Utils.js
@@ -57,12 +57,12 @@ function ago(epoch) {
 
     if(delta < 60)
         return qsTr("%n second(s) ago", "0", Math.floor(delta))
-    else if (delta >= 60 && delta <= 3600)
+    else if (delta < 3600)
         return qsTr("%n minute(s) ago", "0", Math.floor(delta / 60))
-    else if (delta >= 3600 && delta <= 86400)
-        return qsTr("%n hour(s) ago", "0", Math.floor(delta / 60 / 60))
-    else if (delta >= 86400)
-        return qsTr("%n day(s) ago", "0", Math.floor(delta / 24 / 60 / 60))
+    else if (delta < 86400)
+        return qsTr("%n hour(s) ago", "0", Math.floor(delta / 3600))
+    else
+        return qsTr("%n day(s) ago", "0", Math.floor(delta / 86400))
 }
 
 function netTypeToString(){


### PR DESCRIPTION
Fix issue where the minutes display is shown when delta is 3600 (one hour) and the hour display is shown when delta is 86400 (one day).