### PR TITLE
wizardWalletInput: check wallet exists / pick correct default name 

### DIFF
--- a/js/Wizard.js
+++ b/js/Wizard.js
@@ -76,8 +76,9 @@ function walletPathExists(accountsDir, directory, filename, isIOS, walletManager
         var path = accountsDir + filename;
     else
         var path = directory + filename + "/" + filename;
+        var path2 = directory + filename;
 
-    if (walletManager.walletExists(path))
+    if (walletManager.walletExists(path) || walletManager.walletExists(path2))
         return true;
     return false;
 }

--- a/js/Wizard.js
+++ b/js/Wizard.js
@@ -83,10 +83,10 @@ function walletPathExists(accountsDir, directory, filename, isIOS, walletManager
     return false;
 }
 
-function unusedWalletName(directory, filename, walletManager) {
+function unusedWalletName(directory, filename, isIOS, walletManager) {
     for (var i = 0; i < 100; i++) {
         var walletName = filename + (i > 0 ? "_" + i : "");
-        if (!walletManager.walletExists(directory + "/" + walletName + "/" + walletName)) {
+        if (!walletPathExists(directory, directory, walletName, isIOS, walletManager)) {
             return walletName;
         }
     }

--- a/wizard/WizardWalletInput.qml
+++ b/wizard/WizardWalletInput.qml
@@ -58,7 +58,7 @@ GridLayout {
         walletName.error = !walletName.verify();
         walletLocation.error = !walletLocation.verify();
         walletLocation.text = appWindow.accountsDir;
-        walletName.text = Wizard.unusedWalletName(appWindow.accountsDir, defaultAccountName, walletManager);
+        walletName.text = Wizard.unusedWalletName(appWindow.accountsDir, defaultAccountName, isIOS, walletManager);
     }
 
     MoneroComponents.LineEdit {


### PR DESCRIPTION
small bug, if you have `walletdir/username_1/username_1.keys` and `walletdir/username_2.keys` (but no folder `username_2`) the create a new wallet name will be `username_2` and fail ot save to file (as it exists already) , this patch adds a warning that the file already exists, and also prevents the default name from being wrong to begin with