### PR TITLE
DaemonManager: remove systemd check

### DIFF
--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -299,13 +299,7 @@ Rectangle {
                                             startP2Pool()
                                         }
                                         else {
-                                            var underSystemd = daemonManager.checkUnderSystemd();
-                                            if (underSystemd) {
-                                                miningError(qsTr("Monerod is managed by Systemd. Manually add --zmq-pub tcp://127.0.0.1:18083 to the unit file <br>") + translationManager.emptyString)
-                                            }
-                                            else {
-                                                daemonManager.stopAsync(persistentSettings.nettype, persistentSettings.blockchainDataDir, startP2PoolLocal)
-                                            }
+                                            daemonManager.stopAsync(persistentSettings.nettype, persistentSettings.blockchainDataDir, startP2PoolLocal)
                                         }
                                     }
                                     else {

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -342,34 +342,6 @@ bool DaemonManager::checkLmdbExists(QString datadir) {
     return validateDataDir(datadir).value("lmdbExists").value<bool>();
 }
 
-bool DaemonManager::checkUnderSystemd() {
-    #ifdef Q_OS_LINUX
-        QProcess p;
-        QStringList args;
-        args << "monerod";
-        p.setProgram("pgrep");
-        p.setArguments(args);
-        p.start();
-        p.waitForFinished();
-        QString pid = p.readAllStandardOutput().trimmed();
-        if (pid.isEmpty()) {
-            return false;
-        }
-        args.clear();
-
-        args << "-c";
-        args << "ps -eo pid,cgroup | grep " + pid + " | grep -q .service$";
-        p.setProgram("sh");
-        p.setArguments(args);
-        p.start();
-        p.waitForFinished();
-        if (p.exitCode() == 0) {
-            return true;
-        }
-    #endif
-    return false;
-}
-
 QString DaemonManager::getArgs(const QString &dataDir) {
     if (!running(NetworkType::MAINNET, dataDir)) {
         return args;

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -59,7 +59,6 @@ public:
     Q_INVOKABLE QVariantMap validateDataDir(const QString &dataDir) const;
     Q_INVOKABLE bool checkLmdbExists(QString datadir);
     Q_INVOKABLE QString getArgs(const QString &dataDir);
-    Q_INVOKABLE bool checkUnderSystemd();
 
 private:
 


### PR DESCRIPTION
#4122 for me, 'double clicking' the monero gui binary leads to monerod being launched as a dbus.service. running it from the terminal. i did not notice this on Mint but i would sleep easier if this check was disabled for now until a better method of detecting if monerod is running under systemd or not.