### PR TITLE
readme: tweak build instructions to include ARM64 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ The following instructions will fetch Qt from your distribution's repositories i
     ```
     make release -j4
     ```
+    If on ARM64:
+
+    ```
+    make release-linux-armv8 -j4
+    ```
 
     If on ppc64le:
 

--- a/README.md
+++ b/README.md
@@ -257,17 +257,12 @@ The following instructions will fetch Qt from your distribution's repositories i
 
 4. Build
 
-    If on x86-64:
+    If on x86-64 or ARM:
 
     ```
     make release -j4
     ```
-    If on ARM64:
-
-    ```
-    make release-linux-armv8 -j4
-    ```
-
+    
     If on ppc64le:
 
     ```


### PR DESCRIPTION
ARM64 Linux is growing rapidly in popularity, both due to advances in SBC design and Asahi Linux for M1 Macs. This PR makes the process of compiling monero-gui slightly easier for beginners and seasoned users alike.