### PR TITLE
workflows: set default arch for macOS bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,19 +75,22 @@ jobs:
       run: python3 monero-gui/.github/qt_helper.py mac_x64 desktop 5.15.2 clang_64 c384008156fe63cc183bade0316828c598ff3e5074397c0c9ccc588d6cdc5aca
       working-directory: ../
     - name: build
-      run: CMAKE_PREFIX_PATH=/Users/runner/work/monero-gui/5.15.2/clang_64 make release -j3
+      run: |
+        mkdir build && cd build
+        cmake -D CMAKE_BUILD_TYPE=Release -D ARCH=default -D CMAKE_PREFIX_PATH=/Users/runner/work/monero-gui/5.15.2/clang_64 ..
+        make
     - name: deploy
       run: make deploy
-      working-directory: build/release
+      working-directory: build
     - name: test qml
-      run: build/release/bin/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui --test-qml
+      run: build/bin/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui --test-qml
     - name: create .tar
       run: tar -cf monero-wallet-gui.tar monero-wallet-gui.app
-      working-directory: build/release/bin
+      working-directory: build/bin
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ github.job }}
-        path: build/release/bin/monero-wallet-gui.tar
+        path: build/bin/monero-wallet-gui.tar
 
   docker-linux-static:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Avoids a crash when running the .app on Apple Silicon.