### PR TITLE
fix overlap in certain languages

### DIFF
--- a/wizard/WizardDaemonSettings.qml
+++ b/wizard/WizardDaemonSettings.qml
@@ -104,6 +104,7 @@ ColumnLayout {
 
         RowLayout {
             id: pruningOptionRow
+            spacing: 200
             MoneroComponents.CheckBox {
                 id: pruneBlockchainCheckBox
                 checked: !existingDbWarning.visible ? persistentSettings.pruneBlockchain : false

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -112,7 +112,7 @@ Rectangle {
 
             RowLayout {
                 Layout.topMargin: -10
-                spacing: 30
+                spacing: 200
                 Layout.fillWidth: true
 
                 MoneroComponents.RadioButton {


### PR DESCRIPTION
Overlapping elements fixed for every translation that is currently available.
Future changes of the translations (if translated string is longer than source string) may break this.