### PR TITLE
workflows: free up diskspace for docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: ci/gh-actions/gui
 
 on: [push, pull_request]
 
+env:
+  FREE_DISKSPACE: |
+    sudo rm -rf /usr/local/.ghcup /usr/share/dotnet /usr/share/swift /usr/share/miniconda
+
 jobs:
   build-macos:
     runs-on: macOS-latest
@@ -107,6 +111,8 @@ jobs:
           docker-linux-static-
     - name: install dependencies
       run: sudo apt -y install xvfb libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xkb1 libxcb-shape0 libxkbcommon-x11-0
+    - name: free up diskspace
+      run: ${{env.FREE_DISKSPACE}}
     - name: prepare build environment
       run: docker build --tag monero:build-env-linux --build-arg THREADS=3 --file Dockerfile.linux .
     - name: build
@@ -135,6 +141,8 @@ jobs:
         key: docker-windows-static-{hash}
         restore-keys: |
           docker-windows-static-
+    - name: free up diskspace
+      run: ${{env.FREE_DISKSPACE}}
     - name: prepare build environment
       run: docker build --tag monero:build-env-windows --build-arg THREADS=3 --file Dockerfile.windows .
     - name: build
@@ -161,6 +169,8 @@ jobs:
         key: docker-android-static-{hash}
         restore-keys: |
           docker-android-static-
+    - name: free up diskspace
+      run: ${{env.FREE_DISKSPACE}}
     - name: prepare build environment
       run: docker build --tag monero:build-env-android --build-arg THREADS=3 --file Dockerfile.android .
     - name: build


### PR DESCRIPTION
Clears up ~9.3 GB of unneeded files. Should mitigate "No space left on disk" errors for Docker runs: https://github.com/monero-project/monero-gui/actions/runs/6388428621

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   64G   20G  77% /

546M	/usr/share/miniconda
1.9G	/usr/share/swift
2.2G	/usr/share/dotnet
4.7G	/usr/local/.ghcup
```