### PR TITLE
flatpak: Change the branch to stable

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,170 +5,80 @@ on:
     types: released
 
 jobs:
-  part1:
-    name: Part 1/3
+  build:
+    name: org.getmonero.Monero
     if: github.repository == 'monero-project/monero-gui'
-    runs-on: ubuntu-latest
-    container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-22.08
-      options: --privileged
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-
-    - name: Install deps
-      run: dnf -y install docker
-
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
-    - name: Build flatpak
-      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-      env:
-        FLATPAK_BUILDER_N_JOBS: 3
-      with:
-        manifest-path: share/org.getmonero.Monero.yaml
-        arch: ${{ matrix.arch }}
-        cache: false
-        stop-at-module: boost
-
-    - name: Tar flatpak-builder
-      run: tar -cvf flatpak-builder.tar .flatpak-builder
-
-    - name: Save flatpak-builder
-      uses: actions/upload-artifact@v3
-      with:
-        name: flatpak-builder-${{ matrix.arch }}
-        path: flatpak-builder.tar
-
-  part2:
-    name: Part 2/3
-    if: github.repository == 'monero-project/monero-gui'
-    needs: part1
-    runs-on: ubuntu-latest
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-22.08
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-5.15-25.08
       options: --privileged
-    strategy:
-      matrix:
-        arch: [x86_64, aarch64]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
 
-    - name: Install deps
-      run: dnf -y install docker
+      - name: Add version and date
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          DATE="${{ github.event.release.published_at }}"
+          DATE="${DATE%%T*}"
+          sed -i "s/@VERSION@/$VERSION/g" "$GITHUB_WORKSPACE/share/org.getmonero.Monero.metainfo.xml"
+          sed -i "s/@DATE@/$DATE/g" "$GITHUB_WORKSPACE/share/org.getmonero.Monero.metainfo.xml"
 
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
+      - name: Validate Flatpak manifest
+        run: flatpak-builder-lint manifest share/org.getmonero.Monero.yaml
 
-    - name: Restore flatpak-builder
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: flatpak-builder-${{ matrix.arch }}
+      - name: Build flatpak
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        env:
+          FLATPAK_BUILDER_N_JOBS: 3
+        with:
+          manifest-path: share/org.getmonero.Monero.yaml
+          arch: ${{ matrix.arch }}
+          cache: false
+          branch: stable
+          mirror-screenshots-url: https://dl.flathub.org/media
 
-    - name: Untar flatpak-builder
-      run: tar -xvf flatpak-builder.tar
+      - name: Validate AppStream
+        run: flatpak-builder-lint appstream flatpak_app/files/share/metainfo/org.getmonero.Monero.metainfo.xml
 
-    - name: Build flatpak
-      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-      env:
-        FLATPAK_BUILDER_N_JOBS: 3
-      with:
-        manifest-path: share/org.getmonero.Monero.yaml
-        arch: ${{ matrix.arch }}
-        cache: false
-        stop-at-module: monero-gui
+      - name: Verify Icon and Metadata in app-info
+        run: |
+          test -f flatpak_app/files/share/app-info/icons/flatpak/128x128/org.getmonero.Monero.png || { echo "::error::Missing 128x128 icon in app-info"; exit 1; }
+          test -f flatpak_app/files/share/app-info/xmls/org.getmonero.Monero.xml.gz || { echo "::error::Missing org.getmonero.Monero.xml.gz in app-info"; exit 1; }
 
-    - name: Tar flatpak-builder
-      run: tar -cvf flatpak-builder.tar .flatpak-builder
+      - name: Validate build directory
+        run: flatpak-builder-lint builddir flatpak_app
 
-    - name: Save flatpak-builder
-      uses: actions/upload-artifact@v3
-      with:
-        name: flatpak-builder-${{ matrix.arch }}
-        path: flatpak-builder.tar
+      - name: Validate repository
+        run: flatpak-builder-lint repo repo
 
-  part3:
-    name: Part 3/3
-    if: github.repository == 'monero-project/monero-gui'
-    needs: [part1, part2]
-    runs-on: ubuntu-latest
-    container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-22.08
-      options: --privileged
-    strategy:
-      matrix:
-        arch: [x86_64, aarch64]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - name: Print hashes
+        working-directory: flatpak_app/files/bin
+        run: |
+          echo "Hashes of the ${{ matrix.arch }} binaries:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          for bin in monero-* monerod p2pool; do [ -f "$bin" ] && sha256sum "$bin" || echo "$bin not found"; done >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "An example command to check hashes:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "$ flatpak run --command=sha256sum org.getmonero.Monero /app/bin/monero-wallet-gui" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
-    - name: Add version and date
-      run: |
-        sed -i 's/<version>/${{ github.event.release.tag_name }}/g' $GITHUB_WORKSPACE/share/org.getmonero.Monero.metainfo.xml
-        sed -i 's/<date>/'"$(date '+%F')"'/g' $GITHUB_WORKSPACE/share/org.getmonero.Monero.metainfo.xml
-
-    - name: Install deps
-      run: dnf -y install docker
-
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
-    - name: Restore flatpak-builder
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: flatpak-builder-${{ matrix.arch }}
-
-    - name: Untar flatpak-builder
-      run: tar -xvf flatpak-builder.tar
-
-    - name: Build flatpak
-      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-      env:
-        FLATPAK_BUILDER_N_JOBS: 3
-      with:
-        manifest-path: share/org.getmonero.Monero.yaml
-        arch: ${{ matrix.arch }}
-        cache: false
-
-    - name: Validate AppData
-      working-directory: flatpak_app/files/share/appdata
-      run: appstream-util validate org.getmonero.Monero.appdata.xml
-
-    - name: Delete flatpak-builder
-      uses: geekyeggo/delete-artifact@v2
-      with:
-        name: flatpak-builder-${{ matrix.arch }}
-
-    - name: Print hashes
-      working-directory: flatpak_app/files/bin
-      run: |
-        echo "Hashes of the ${{ matrix.arch }} binaries:" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        for bin in monero-blockchain-ancestry monero-blockchain-depth monero-blockchain-export monero-blockchain-import monero-blockchain-mark-spent-outputs monero-blockchain-prune monero-blockchain-prune-known-spent-data monero-blockchain-stats monero-blockchain-usage monerod monero-gen-ssl-cert monero-gen-trusted-multisig monero-wallet-cli monero-wallet-gui monero-wallet-rpc p2pool; do sha256sum $bin; done >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "An example command to check hashes:" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "$ flatpak run --command=sha256sum org.getmonero.Monero /app/bin/monero-wallet-gui" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-    - name: Publish to Flathub Beta
-      uses: flatpak/flatpak-github-actions/flat-manager@v6
-      with:
-        flat-manager-url: https://hub.flathub.org
-        repository: beta
-        token: ${{ secrets.FLATHUB_ }}
+      - name: Publish to Flathub
+        uses: flatpak/flatpak-github-actions/flat-manager@v6
+        with:
+          flat-manager-url: https://hub.flathub.org
+          repository: stable
+          build-log-url: https://github.com/monero-project/monero-gui/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.FLATHUB_TOKEN }}

--- a/share/org.getmonero.Monero.desktop
+++ b/share/org.getmonero.Monero.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Name=Monero GUI
 GenericName=Cryptocurrency wallet
-Comment=Monero GUI
+Comment=The secure, private, untraceable cryptocurrency
 Exec=monero-wallet-gui
 Type=Application
 Terminal=false
-Categories=Network;Qt;Finance;Office;
+Categories=Network;Finance;Office;
 Icon=org.getmonero.Monero
 StartupNotify=true

--- a/share/org.getmonero.Monero.metainfo.xml
+++ b/share/org.getmonero.Monero.metainfo.xml
@@ -3,17 +3,18 @@
     <id>org.getmonero.Monero</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>BSD-3-Clause</project_license>
-    <content_rating type="oars-1.1"/>
-    <developer_name>The Monero Project</developer_name>
+    <content_rating type="oars-1.1" />
+    <developer id="org.getmonero">
+        <name>The Monero Project</name>
+    </developer>
     <categories>
         <category>Network</category>
-        <category>Qt</category>
         <category>Finance</category>
         <category>Office</category>
     </categories>
     <name>Monero GUI</name>
-    <summary>Monero: the secure, private, untraceable cryptocurrency</summary>
-    
+    <summary>The secure, private, untraceable cryptocurrency</summary>
+
     <description>
         <p>Monero is a private, secure, untraceable, decentralised digital currency. You
             are your bank, you control your funds, and nobody can trace your transfers
@@ -39,10 +40,16 @@
 
     <launchable type="desktop-id">org.getmonero.Monero.desktop</launchable>
 
+    <branding>
+        <color type="primary" scheme_preference="light">#ffa348</color>
+        <color type="primary" scheme_preference="dark">#c64600</color>
+    </branding>
+
     <screenshots>
         <screenshot type="default">
             <caption>A screenshot of the Monero GUI wallet</caption>
-            <image>https://raw.githubusercontent.com/monero-project/monero-site/master/img/downloads/gui.png</image>
+            <image>
+                https://raw.githubusercontent.com/monero-project/monero-site/master/img/downloads/gui.png</image>
         </screenshot>
     </screenshots>
 
@@ -51,15 +58,18 @@
     <url type="donation">https://getmonero.org/get-started/contributing</url>
     <url type="faq">https://getmonero.org/get-started/faq</url>
     <url type="help">https://getmonero.org/resources/user-guides</url>
-    <url type="translate">https://translate.getmonero.org</url>
     <url type="contact">https://getmonero.org/community/hangouts</url>
     <url type="contribute">https://getmonero.org/get-started/contributing</url>
+    <url type="vcs-browser">https://github.com/monero-project/monero-gui</url>
 
     <releases>
-        <release version="<version>" date="<date>"/>
+        <release version="@VERSION@" date="@DATE@">
+            <url type="details">https://github.com/monero-project/monero-gui/releases/tag/v@VERSION@</url>
+        </release>
     </releases>
 
     <custom>
-      <value key="flathub::manifest">https://github.com/monero-project/monero-gui/tree/master/share/org.getmonero.Monero.yaml</value>
+        <value key="flathub::manifest">
+            https://github.com/monero-project/monero-gui/tree/master/share/org.getmonero.Monero.yaml</value>
     </custom>
 </component>

--- a/share/org.getmonero.Monero.yaml
+++ b/share/org.getmonero.Monero.yaml
@@ -1,15 +1,17 @@
 app-id: org.getmonero.Monero
 runtime: org.kde.Platform
-runtime-version: 5.15-22.08
+runtime-version: 5.15-25.08
 sdk: org.kde.Sdk
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --device=all
-  - --filesystem=~/Monero:create
+  - --persist=Monero
   - --persist=.bitmonero
+  - --persist=.p2pool
+  - --env=QT_QPA_PLATFORM=wayland;xcb
 
 cleanup:
   - /include
@@ -17,98 +19,11 @@ cleanup:
   - /share/man
   - /lib/pkgconfig
   - /lib/cmake
-  - '*.a'
-  - '*.la'
+  - "*.a"
+  - "*.la"
 
 command: monero-wallet-gui
 modules:
-  - name: protobuf
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-    sources:
-      - type: git
-        url: https://github.com/protocolbuffers/protobuf
-        tag: v22.4
-        commit: 40e1daca18708c21c7edf07c489a688355bd297b
-
-  - name: boost
-    buildsystem: simple
-    build-commands:
-      - ./bootstrap.sh --prefix=$FLATPAK_DEST --with-libraries=chrono,date_time,filesystem,locale,program_options,regex,serialization,system,thread
-      - ./b2 headers
-      - ./b2 -j$FLATPAK_BUILDER_N_JOBS install variant=release --layout=system
-    sources:
-      - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.gz
-        sha256: 66a469b6e608a51f8347236f4912e27dc5c60c60d7d53ae9bfe4683316c6f04c
-
-  - name: libunbound
-    config-opts:
-      - --with-libunbound-only
-    sources:
-      - type: archive
-        url: https://nlnetlabs.nl/downloads/unbound/unbound-1.17.1.tar.gz
-        sha256: ee4085cecce12584e600f3d814a28fa822dfaacec1f94c84bfd67f8a5571a5f4
-
-  - name: libsodium
-    sources:
-      - type: archive
-        url: https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz
-        sha256: 6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
-
-  - name: libusb
-    sources:
-      - type: archive
-        url: https://github.com/libusb/libusb/releases/download/v1.0.26/libusb-1.0.26.tar.bz2
-        sha256: 12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5
-
-  - name: hidapi
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-    sources:
-      - type: archive
-        url: https://github.com/libusb/hidapi/archive/hidapi-0.13.1.tar.gz
-        sha256: 476a2c9a4dc7d1fc97dd223b84338dbea3809a84caea2dcd887d9778725490e3
-
-  - name: libzmq
-    config-opts:
-      - --with-libsodium
-      - --disable-Werror
-    sources:
-      - type: archive
-        url: https://github.com/zeromq/libzmq/releases/download/v4.3.4/zeromq-4.3.4.tar.gz
-        sha256: c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
-
-  - name: libgss
-    sources:
-      - type: archive
-        url: https://ftp.gnu.org/gnu/gss/gss-1.0.4.tar.gz
-        sha256: ecceabdef4cae3fce7218b2ecb83eb4227dba44b53b61b8c2b2e88ae02419c73
-
-  - name: libuv
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-    sources:
-      - type: archive
-        url: https://github.com/libuv/libuv/archive/v1.44.2.tar.gz
-        sha256: e6e2ba8b4c349a4182a33370bb9be5e23c51b32efb9b9e209d0e8556b73a48da
-
-  - name: p2pool
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DWITH_LTO=OFF
-    sources:
-      - type: git
-        url: https://github.com/SChernykh/p2pool
-        tag: v3.2
-        commit: 92827035e07ff15da6b7645a332f3e59aa0ab1c4
-    post-install:
-      - install -Dm755 p2pool $FLATPAK_DEST/bin/p2pool
-
   - name: monero-gui
     buildsystem: cmake-ninja
     config-opts:
@@ -130,4 +45,82 @@ modules:
     post-install:
       - install -Dpm644 share/org.getmonero.Monero.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
       - install -Dpm644 share/org.getmonero.Monero.metainfo.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml
-      - for x in 16 24 32 48 64 96 128 256; do install -Dpm644 images/appicons/${x}x${x}.png $FLATPAK_DEST/share/icons/hicolor/${x}x${x}/apps/$FLATPAK_ID.png; done
+      - for x in 16 24 32 48 64 96 128 256; do install -Dpm644 images/appicons/${x}x${x}.png
+        $FLATPAK_DEST/share/icons/hicolor/${x}x${x}/apps/$FLATPAK_ID.png; done
+    modules:
+      - name: boost
+        buildsystem: simple
+        build-commands:
+          - ./bootstrap.sh --prefix=$FLATPAK_DEST --with-libraries=chrono,date_time,filesystem,locale,program_options,regex,serialization,system,thread
+          - ./b2 headers
+          - ./b2 -j$FLATPAK_BUILDER_N_JOBS install variant=release --layout=system
+        sources:
+          - type: archive
+            url: https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
+            sha256: 3621533e820dcab1e8012afd583c0c73cf0f77694952b81352bf38c1488f9cb4
+
+      - name: protobuf
+        sources:
+          - type: archive
+            url: https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protobuf-cpp-3.21.3.tar.gz
+            sha256: c98a4f17ed57e9e4dafc4a52e76ee012f9a6a13750488b20b4c370a3eb1561fc
+
+      - name: libunbound
+        config-opts:
+          - --with-libunbound-only
+        sources:
+          - type: archive
+            url: https://nlnetlabs.nl/downloads/unbound/unbound-1.25.1.tar.gz
+            sha256: 0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f
+
+      - name: libsodium
+        sources:
+          - type: archive
+            url: https://github.com/jedisct1/libsodium/releases/download/1.0.22-RELEASE/libsodium-1.0.22.tar.gz
+            sha256: adbdd8f16149e81ac6078a03aca6fc03b592b89ef7b5ed83841c086191be3349
+
+      - name: hidapi
+        buildsystem: cmake-ninja
+        config-opts:
+          - -DCMAKE_BUILD_TYPE=Release
+        sources:
+          - type: archive
+            url: https://github.com/libusb/hidapi/archive/hidapi-0.15.0.tar.gz
+            sha256: 5d84dec684c27b97b921d2f3b73218cb773cf4ea915caee317ac8fc73cef8136
+
+      - name: libzmq
+        config-opts:
+          - --with-libsodium
+          - --disable-Werror
+        sources:
+          - type: archive
+            url: https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz
+            sha256: 6653ef5910f17954861fe72332e68b03ca6e4d9c7160eb3a8de5a5a913bfab43
+
+  - name: p2pool
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DWITH_LTO=OFF
+    sources:
+      - type: git
+        url: https://github.com/SChernykh/p2pool
+        tag: v4.17.1
+        commit: 9b7395b8c97e7705a138dda2f4edef6b91eebe5f
+    post-install:
+      - install -Dm755 p2pool $FLATPAK_DEST/bin/p2pool
+    modules:
+      - name: libgss
+        sources:
+          - type: archive
+            url: https://ftp.gnu.org/gnu/gss/gss-1.0.4.tar.gz
+            sha256: ecceabdef4cae3fce7218b2ecb83eb4227dba44b53b61b8c2b2e88ae02419c73
+
+      - name: libuv
+        buildsystem: cmake-ninja
+        config-opts:
+          - -DCMAKE_BUILD_TYPE=Release
+        sources:
+          - type: archive
+            url: https://github.com/libuv/libuv/archive/v1.52.1.tar.gz
+            sha256: 478baf2599bfbc882c355288c9cb6f92e0e7dda435fa04031fa5b607cf3f414c


### PR DESCRIPTION
It can be pushed after Monero gets [verified](https://github.com/monero-project/monero-site/issues/2200) on Flathub and the stable token is added to the `FLATHUB_TOKEN` environment. ~Also, we need to wait for [this](https://github.com/flatpak/flatpak-github-actions/pull/165).~