### PR TITLE
DaemonManager: prevent GUI from hanging on hanging `monerod` launch

### DIFF
--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -63,7 +63,7 @@ public:
 private:
 
     bool running(NetworkType::Type nettype, const QString &dataDir) const;
-    bool sendCommand(const QStringList &cmd, NetworkType::Type nettype, const QString &dataDir, QString &message) const;
+    bool sendCommand(const QStringList &cmd, NetworkType::Type nettype, const QString &dataDir, QString &message, const int ms_timeout) const;
     bool startWatcher(NetworkType::Type nettype, const QString &dataDir) const;
     bool stopWatcher(NetworkType::Type nettype, const QString &dataDir) const;
 signals:


### PR DESCRIPTION
Fixes https://github.com/monero-project/monero-gui/issues/4240

## Problem 1
`monerod` hangs on this line when creating an http connection (for local `json-rpc`):
https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/src/common/rpc_client.h#L125

using the generic 3 minutes and 30 seconds connection timeout:
https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/src/common/http_connection.h#L42-L45

This causes direct `json-rpc` invocation (`./monerod sync_info`) to hang for 3m30s before exiting if `monerod` can't bind.

## Problem 2
Monero GUI relies on direct `json-rpc` invocation to tell if `monerod` is "running":
https://github.com/monero-project/monero-gui/blob/e9cd4588aef3f0808ce153957a504f43dcdbeb26/src/daemon/DaemonManager.cpp#L239-L245

This causes the GUI to hang and the [`Watcher`](https://github.com/monero-project/monero-gui/blob/e9cd4588aef3f0808ce153957a504f43dcdbeb26/src/daemon/DaemonManager.cpp#L160) is not quite in sync so it'll hang (in 3m30s chunks) until the 2 miraculously sync up.

## Change
When launching `monerod`, launch it with a timeout of `5 seconds` before assuming something has gone wrong and return `false`, as in we failed to launch.

This lowers the "is monerod running?" poll-rate to every 5 seconds which makes the error screen surface around the `120s` mark as intended.