### PR TITLE
Remove instructions for Void Linux, add NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Status of the translations:
 
 Packages are available for
 * Arch Linux: [monero-gui](https://archlinux.org/packages/extra/x86_64/monero-gui/)
-* Void Linux: `xbps-install -S monero-gui`
+* NixOS: `nix-shell -p monero-gui`
 * Flatpak: [Monero GUI](https://flathub.org/apps/details/org.getmonero.Monero)
 * GuixSD: `guix package -i monero-gui`
 * macOS (homebrew): `brew install --cask monero-wallet`


### PR DESCRIPTION
Void Linux decided to remove all cryptocurrency related packages including Monero from their official repositories. See https://github.com/void-linux/void-packages/pull/44422

Added instructions for NixOS: https://search.nixos.org/packages?channel=23.11&show=monero-gui&type=packages&query=monero