### PR TITLE
tails: fix detection

### DIFF
--- a/src/qt/TailsOS.cpp
+++ b/src/qt/TailsOS.cpp
@@ -14,7 +14,7 @@ bool TailsOS::detect()
         return false;
 
     QByteArray data = fileOpen("/etc/os-release");
-    QRegularExpression re("TAILS_PRODUCT_NAME=\"Tails\"");
+    QRegularExpression re("NAME=\"Tails\"");
     QRegularExpressionMatch os_match = re.match(data);
     bool matched = os_match.hasMatch();
 


### PR DESCRIPTION
Tails 6.0 removed the `TAILS_PRODUCT_NAME` variable.