### PR TITLE
Respect CMake install paths

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,5 +159,5 @@ add_custom_command(TARGET monero-wallet-gui POST_BUILD COMMAND ${CMAKE_COMMAND} 
 include(Deploy)
 
 install(TARGETS monero-wallet-gui
-    DESTINATION bin
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
 )


### PR DESCRIPTION
There is `CMakeLists.txt` file with an absolute installation path:

```
install(TARGETS monero-wallet-gui
  DESTINATION bin
)
```

where `bin` usually points to `/usr/local/bin`.

It works well, but if some build system attempts to produce a package, it will fail since a user might not have root privileges. Such build systems usually place artifacts in a dedicated directory, like `~/my-package/usr/local/bin/`. As an example, FreeBSD's Makefile and Poudriere always fail during the insufficient access rights. I believe this is not the only case.

So I just changed the installation path to respect CMake prefixes according to [CMake documentation](https://cmake.org/cmake/help/latest/command/install.html#targets):

```
install(TARGETS monero-wallet-gui
  DESTINATION ${CMAKE_INSTALL_BINDIR}
)
```

And now the produced executable can be placed to the right directory.