### PR TITLE
wizardRestore: blindly (re)enable create wallet button

### DIFF
--- a/wizard/WizardRestoreWallet4.qml
+++ b/wizard/WizardRestoreWallet4.qml
@@ -72,6 +72,7 @@ Rectangle {
                 progress: appWindow.walletMode <= 1 ? 2 : 3
 
                 onPrevClicked: {
+                    btnNext.enabled = true;
                     if (appWindow.walletMode <= 1){
                         wizardStateView.state = "wizardRestoreWallet1";
                     } else {


### PR DESCRIPTION
replacement for #4346 
closes #4341 

simpler and functionally better 