### PR TITLE
build.yml: pyenv vcs for python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,11 +72,13 @@ jobs:
       with:
         submodules: recursive
     - name: install dependencies
-      run: HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc expat libunwind-headers protobuf pkg-config python3 p7zip aria2
+      run: HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc expat libunwind-headers protobuf pkg-config pyenv p7zip aria2
     - name: install dependencies
-      run: pip3 install defusedxml
+      run: |
+        pyenv install 3.12.0
+        pip install defusedxml
     - name: download qt
-      run: python3 monero-gui/.github/qt_helper.py mac_x64 desktop 5.15.2 clang_64 c384008156fe63cc183bade0316828c598ff3e5074397c0c9ccc588d6cdc5aca
+      run: python monero-gui/.github/qt_helper.py mac_x64 desktop 5.15.2 clang_64 c384008156fe63cc183bade0316828c598ff3e5074397c0c9ccc588d6cdc5aca
       working-directory: ../
     - name: build
       run: |


### PR DESCRIPTION
for macos-bundle workflow

python version bundled with mac has been messed with (assuming for security reasons) so attempting to create a venv dir fails, there surely is a workaround. 

a quicker option is to use [pyenv](https://realpython.com/intro-to-pyenv/) to provide vanilla python versions

we now get to the [POD error](https://github.com/monero-project/monero-gui/actions/runs/11191661096/job/31114822680?pr=4366#step:6:1119), hooray!