### PR TITLE
Fix the testnet address check

### DIFF
--- a/src/main/oshelper.cpp
+++ b/src/main/oshelper.cpp
@@ -303,7 +303,7 @@ std::pair<quint8, QString> OSHelper::getNetworkTypeAndAddressFromFile(const QStr
             address = _address;
             if(address.startsWith("5") || address.startsWith("7")){
                 networkType = NetworkType::STAGENET;
-            } else if(address.startsWith("9") || address.startsWith("B")){
+            } else if(address.startsWith("9") || address.startsWith("A")){
                 networkType = NetworkType::TESTNET;
             }
         }


### PR DESCRIPTION
This PR changes the current address check, which currently checks for addresses that start with either the character 9 or B. I believe that the letter A is supposed to be here instead of B. I have not been able to find any information on the proper starting characters for testnet addresses, so this could be incorrect. However, if this is the case, then half of all testnet addresses are unable to be used, as the current code only checks for an address to either be stagenet or testnet before assuming it to be mainnet. This too is a separate object of concern, although I do not know if there are any significant issues with allowing the function to continue past this point with invalid addresses.