### PR TITLE
Win deploy: Boost Regex is header-only since 1.77

### DIFF
--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -58,7 +58,6 @@ if(APPLE OR (WIN32 AND NOT STATIC))
             libboost_filesystem-mt.dll
             libboost_locale-mt.dll
             libboost_program_options-mt.dll
-            libboost_regex-mt.dll
             libboost_serialization-mt.dll
             libboost_thread-mt.dll
             libprotobuf.dll
@@ -103,6 +102,12 @@ if(APPLE OR (WIN32 AND NOT STATIC))
             libicutu74.dll
             libicuuc74.dll
         )
+
+        # Boost Regex is header-only since 1.77
+        if (Boost_VERSION_STRING VERSION_LESS 1.77.0)
+            list(APPEND WIN_DEPLOY_DLLS libboost_regex-mt.dll)
+        endif()
+
         list(TRANSFORM WIN_DEPLOY_DLLS PREPEND "$ENV{MSYSTEM_PREFIX}/bin/")
         add_custom_command(TARGET deploy
                            POST_BUILD


### PR DESCRIPTION
same as https://github.com/monero-project/monero/blob/master/CMakeLists.txt#L1048