### PR TITLE
Enforce whonix opengl renderer

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -68,6 +68,7 @@
 #include "qt/updater.h"
 #include "qt/utils.h"
 #include "qt/TailsOS.h"
+#include "qt/WhonixOS.h"
 #include "qt/KeysFiles.h"
 #include "qt/MoneroSettings.h"
 #include "qt/NetworkAccessBlockingFactory.h"
@@ -154,6 +155,7 @@ bool isWindows = false;
 bool isMac = false;
 bool isLinux = false;
 bool isTails = false;
+bool isWhonix = false;
 bool isDesktop = false;
 bool isOpenGL = true;
 bool isARM = false;
@@ -175,6 +177,7 @@ int main(int argc, char *argv[])
 #elif defined(Q_OS_LINUX)
     bool isLinux = true;
     bool isTails = TailsOS::detect();
+    bool isWhonix = WhonixOS::detect();
 #elif defined(Q_OS_MAC)
     bool isMac = true;
 #endif
@@ -185,6 +188,12 @@ int main(int argc, char *argv[])
     // detect low graphics mode (start-low-graphics-mode.bat)
     if(qgetenv("QMLSCENE_DEVICE") == "softwarecontext")
         isOpenGL = false;
+
+    // overwrite QMLSCENE_DEVICE to opengl if whonix is detected
+    if (!isOpenGL && isWhonix) {
+        qputenv("QMLSCENE_DEVICE", "opengl");
+        isOpenGL = true;
+    }
 
 #ifdef Q_OS_MAC
     // macOS window tabbing is not supported

--- a/src/qt/WhonixOS.cpp
+++ b/src/qt/WhonixOS.cpp
@@ -1,0 +1,14 @@
+#include "WhonixOS.h"
+#include "utils.h"
+
+bool WhonixOS::detect()
+{
+    if (!fileExists("/usr/share/anon-ws-base-files/workstation"))
+        return false;
+
+#ifdef QT_DEBUG
+    qDebug() << "Whonix OS detected";
+#endif
+
+    return true;
+}

--- a/src/qt/WhonixOS.h
+++ b/src/qt/WhonixOS.h
@@ -1,0 +1,14 @@
+#ifndef WHONIXOS_H
+#define WHONIXOS_H
+
+#include <QApplication>
+
+
+class WhonixOS
+{
+public:
+    WhonixOS();
+    static bool detect();
+};
+
+#endif // WHONIXOS_H


### PR DESCRIPTION
This PR contains a simple hack to force video rendering mode to `opengl` when the wallet is running in a Whonix environment, fixing a bug described here:

https://bounties.monero.social/posts/182/1-123m-make-monero-wallet-gui-whonix-friendly

> GUI would clear screen improperly leading to shredding and unreadable GUI - to workaround this one had to click away and then it would clear screen and render GUI properly