### PR TITLE
p2pool: update to v4.9

### DIFF
--- a/src/p2pool/P2PoolManager.cpp
+++ b/src/p2pool/P2PoolManager.cpp
@@ -53,21 +53,21 @@ void P2PoolManager::download() {
         QString fileName;
         QString validHash;
         #ifdef Q_OS_WIN
-            url = "https://github.com/SChernykh/p2pool/releases/download/v4.8.1/p2pool-v4.8.1-windows-x64.zip";
-            fileName = m_p2poolPath + "/p2pool-v4.8.1-windows-x64.zip";
-            validHash = "a5378296a202625014623235ac347ddb5d9618b9ac8d1159a6cd9511966f86c0";
+            url = "https://github.com/SChernykh/p2pool/releases/download/v4.9/p2pool-v4.9-windows-x64.zip";
+            fileName = m_p2poolPath + "/p2pool-v4.9-windows-x64.zip";
+            validHash = "d109b6dcb01907695a8728063a1495a0d339cc7d03bbc5ad08262d0b876fab2d";
         #elif defined(Q_OS_LINUX)
-            url = "https://github.com/SChernykh/p2pool/releases/download/v4.8.1/p2pool-v4.8.1-linux-x64.tar.gz";
-            fileName = m_p2poolPath + "/p2pool-v4.8.1-linux-x64.tar.gz";
-            validHash = "2c182de88aac7fbd5a3f9a8ac1840b5f9d6050a2d1829c7b177f7a6df8b32117";
+            url = "https://github.com/SChernykh/p2pool/releases/download/v4.9/p2pool-v4.9-linux-x64.tar.gz";
+            fileName = m_p2poolPath + "/p2pool-v4.9-linux-x64.tar.gz";
+            validHash = "db33e4c1cd1a48008f1c52b0d0eb1a2d6a2bae6fe5191277c94dbbf5b098907a";
         #elif defined(Q_OS_MACOS_AARCH64)
-            url = "https://github.com/SChernykh/p2pool/releases/download/v4.8.1/p2pool-v4.8.1-macos-aarch64.tar.gz";
-            fileName = m_p2poolPath + "/p2pool-v4.8.1-macos-aarch64.tar.gz";
-            validHash = "38d63384cb183477593460a917183ddb8345f242231efe54020f8e93c399700a";
+            url = "https://github.com/SChernykh/p2pool/releases/download/v4.9/p2pool-v4.9-macos-aarch64.tar.gz";
+            fileName = m_p2poolPath + "/p2pool-v4.9-macos-aarch64.tar.gz";
+            validHash = "6116cc25e34d1840c3f0e5697b444049cd936deee072dfd7e67d83577c1dc546";
         #elif defined(Q_OS_MACOS)
-            url = "https://github.com/SChernykh/p2pool/releases/download/v4.8.1/p2pool-v4.8.1-macos-x64.tar.gz";
-            fileName = m_p2poolPath + "/p2pool-v4.8.1-macos-x64.tar.gz";
-            validHash = "da7eea2a0b5ec0fc5f51deff63903d2cbe0ead9be04a18327a0fbb4004fba399";
+            url = "https://github.com/SChernykh/p2pool/releases/download/v4.9/p2pool-v4.9-macos-x64.tar.gz";
+            fileName = m_p2poolPath + "/p2pool-v4.9-macos-x64.tar.gz";
+            validHash = "a275d4c2a66481833926b181e3e910126d9e67169d7a31c905d6bb39e80f1e8f";
         #endif
         QFile file(fileName);
         epee::net_utils::http::http_simple_client http_client;


### PR DESCRIPTION
P2Pool binaries are reproducible now, so it's possible to verify the hashes by following the build instructions: https://github.com/SChernykh/P2Pool?tab=readme-ov-file#reproducible-builds