### PR TITLE
workflows: remove unmaintained docker caching action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,13 +104,6 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      if: "!startsWith(github.ref, 'refs/tags/v')"
-      continue-on-error: true
-      with:
-        key: docker-linux-static-{hash}
-        restore-keys: |
-          docker-linux-static-
     - name: install dependencies
       run: sudo apt -y install xvfb libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xkb1 libxcb-shape0 libxkbcommon-x11-0
     - name: free up diskspace
@@ -136,13 +129,6 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      if: "!startsWith(github.ref, 'refs/tags/v')"
-      continue-on-error: true
-      with:
-        key: docker-windows-static-{hash}
-        restore-keys: |
-          docker-windows-static-
     - name: free up diskspace
       run: ${{env.FREE_DISKSPACE}}
     - name: prepare build environment
@@ -164,21 +150,12 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      if: "!startsWith(github.ref, 'refs/tags/v')"
-      continue-on-error: true
-      with:
-        key: docker-android-static-{hash}
-        restore-keys: |
-          docker-android-static-
     - name: free up diskspace
       run: ${{env.FREE_DISKSPACE}}
     - name: prepare build environment
       run: docker build --tag monero:build-env-android --build-arg THREADS=3 --file Dockerfile.android .
     - name: build
       run: docker run --rm -v /home/runner/work/monero-gui/monero-gui:/monero-gui -e THREADS=3 monero:build-env-android
-    - name: Remove obsolete docker layers
-      run: docker images -a | grep none | awk '{ print $3; }' | xargs docker rmi || true
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ github.job }}


### PR DESCRIPTION
Does not work anymore. Action hasn't been updated since 2020. There's a fork but it also appears unmaintained.