### PR TITLE
feat: add pagination on the Receive page (optional)

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -1521,6 +1521,8 @@ ApplicationWindow {
         property bool autosave: true
         property int autosaveMinutes: 10
         property bool pruneBlockchain: false
+        property bool enableSubaddressPagination: false
+        property int subaddressPageSize: 100
 
         property bool fiatPriceEnabled: false
         property bool fiatPriceToggle: false

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -121,6 +121,12 @@ Rectangle {
             text: qsTr("Autosave") + translationManager.emptyString
         }
 
+        MoneroComponents.CheckBox {
+            checked: persistentSettings.enableSubaddressPagination
+            onClicked: persistentSettings.enableSubaddressPagination = !persistentSettings.enableSubaddressPagination
+            text: qsTr("Enable subaddress pagination") + translationManager.emptyString
+        }
+
         MoneroComponents.Slider {
             Layout.fillWidth: true
             Layout.leftMargin: 35

--- a/src/libwalletqt/Subaddress.h
+++ b/src/libwalletqt/Subaddress.h
@@ -36,12 +36,17 @@
 #include <QObject>
 #include <QList>
 #include <QDateTime>
+#include <QCache>
+#include <QPair>
 
 class Subaddress : public QObject
 {
     Q_OBJECT
 public:
     Q_INVOKABLE void getAll() const;
+    Q_INVOKABLE void getPage(int offset, int limit) const;
+    void getPageSilent(int offset, int limit) const;
+    Q_INVOKABLE quint64 getTotalCount() const;
     Q_INVOKABLE bool getRow(int index, std::function<void (Monero::SubaddressRow &row)> callback) const;
     Q_INVOKABLE void addRow(quint32 accountIndex, const QString &label) const;
     Q_INVOKABLE void setLabel(quint32 accountIndex, quint32 addressIndex, const QString &label) const;
@@ -60,6 +65,11 @@ private:
     mutable QReadWriteLock m_lock;
     Monero::Subaddress * m_subaddressImpl;
     mutable QList<Monero::SubaddressRow*> m_rows;
+    
+    mutable QCache<int, QList<Monero::SubaddressRow*>> m_pageCache;
+    mutable quint64 m_totalCount;
+    mutable bool m_totalCountCached;
+    void clearCache() const;
 };
 
 #endif // SUBADDRESS_H

--- a/src/model/SubaddressModel.h
+++ b/src/model/SubaddressModel.h
@@ -36,6 +36,8 @@ class Subaddress;
 class SubaddressModel : public QAbstractListModel
 {
     Q_OBJECT
+    Q_PROPERTY(int loadedCount READ getLoadedCount NOTIFY loadedCountChanged)
+    Q_PROPERTY(int totalCount READ getTotalCount NOTIFY totalCountChanged)
 
 public:
     enum SubaddressRowRole {
@@ -50,6 +52,18 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const  override;
+    
+    bool canFetchMore(const QModelIndex &parent) const override;
+    void fetchMore(const QModelIndex &parent) override;
+    
+    Q_INVOKABLE bool shouldPreload(int firstVisible, int lastVisible) const;
+    
+    int getLoadedCount() const { return m_loadedCount; }
+    int getTotalCount() const;
+
+signals:
+    void loadedCountChanged();
+    void totalCountChanged();
 
 public slots:
     void startReset();
@@ -57,6 +71,10 @@ public slots:
 
 private:
     Subaddress *m_subaddress;
+    
+    mutable int m_loadedCount;
+    mutable int m_pageSize;
+    mutable bool m_fetchingMore;
 };
 
 #endif // SUBADDRESSMODEL_H


### PR DESCRIPTION
Closes https://github.com/monero-project/monero-gui/issues/4500.

Without this feature, opening a wallet with many subaddresses causes severe lag and impacts usability.  This change introduces optional pagination to the subaddresses in the Receive tab.

To reproduce the issue, create a wallet with many addresses in monero-wallet-cli.  For example, using:
```
address mnew 1000
```
30+ times in monero-wallet-cli will create a wallet with 30,001 addresses (like a very active BTCPay wallet).  Before this feature and without it enabled (disabled by default), the app will lag on a performant PC when navigating to the Receive page.  With this feature, it shows a "Loading addresses..." message while loading the first "page" of addresses.  As a Quality of Life (QoL) feature, a "Scroll to bottom" button allows loading all remaining addresses at once.

  - Add pagination support to the Subaddress backend.
  - Add "Enable subaddress pagination" setting to Interface section.
  - When pagination is disabled (default): behaves exactly like original GUI.
  - When pagination is enabled:
    - Load first 100 subaddresses (the default page size) initially.
    - "Scroll to bottom" button loads all remaining addresses.
    - Loading footer shows progress during fetch operations.