### PR TITLE
chore: update copyright year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2025, The Monero Project
 
 All rights reserved.
 

--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monero GUI
 
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2025, The Monero Project
 
 ## Table of Contents
   * [Development resources](#development-resources)

--- a/cmake/32-bit-toolchain.cmake
+++ b/cmake/32-bit-toolchain.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/cmake/64-bit-toolchain.cmake
+++ b/cmake/64-bit-toolchain.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/cmake/VersionGui.cmake
+++ b/cmake/VersionGui.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2024, The Monero Project
+# Copyright (c) 2014-2025, The Monero Project
 # 
 # All rights reserved.
 # 

--- a/components/CheckBox.qml
+++ b/components/CheckBox.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/CheckBox2.qml
+++ b/components/CheckBox2.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/DatePicker.qml
+++ b/components/DatePicker.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/DevicePassphraseDialog.qml
+++ b/components/DevicePassphraseDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/Dialog.qml
+++ b/components/Dialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/IconButton.qml
+++ b/components/IconButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/InlineButton.qml
+++ b/components/InlineButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/Input.qml
+++ b/components/Input.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/InputDialog.qml
+++ b/components/InputDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/InputMulti.qml
+++ b/components/InputMulti.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/Label.qml
+++ b/components/Label.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/LabelButton.qml
+++ b/components/LabelButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/LabelSubheader.qml
+++ b/components/LabelSubheader.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/LanguageButton.qml
+++ b/components/LanguageButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/LanguageSidebar.qml
+++ b/components/LanguageSidebar.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/LineEdit.qml
+++ b/components/LineEdit.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/LineEditMulti.qml
+++ b/components/LineEditMulti.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/MenuBar.qml
+++ b/components/MenuBar.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/MenuButton.qml
+++ b/components/MenuButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/Navbar.qml
+++ b/components/Navbar.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/NavbarItem.qml
+++ b/components/NavbarItem.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/NetworkStatusItem.qml
+++ b/components/NetworkStatusItem.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/ProcessingSplash.qml
+++ b/components/ProcessingSplash.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/ProgressBar.qml
+++ b/components/ProgressBar.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/QRCodeScanner.qml
+++ b/components/QRCodeScanner.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/RadioButton.qml
+++ b/components/RadioButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/RemoteNodeDialog.qml
+++ b/components/RemoteNodeDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/RemoteNodeEdit.qml
+++ b/components/RemoteNodeEdit.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/RemoteNodeList.qml
+++ b/components/RemoteNodeList.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/StandardButton.qml
+++ b/components/StandardButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/StandardDialog.qml
+++ b/components/StandardDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/StandardDropdown.qml
+++ b/components/StandardDropdown.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/SuccessfulTxDialog.qml
+++ b/components/SuccessfulTxDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/TipItem.qml
+++ b/components/TipItem.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/components/Tooltip.qml
+++ b/components/Tooltip.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/TxConfirmationDialog.qml
+++ b/components/TxConfirmationDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/UpdateDialog.qml
+++ b/components/UpdateDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/effects/ColorTransition.qml
+++ b/components/effects/ColorTransition.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/effects/GradientBackground.qml
+++ b/components/effects/GradientBackground.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/components/effects/ImageMask.qml
+++ b/components/effects/ImageMask.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/installers/windows/LICENSE
+++ b/installers/windows/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2024, The Monero Project
+Copyright (c) 2014-2025, The Monero Project
 
 All rights reserved.
 

--- a/installers/windows/Monero.iss
+++ b/installers/windows/Monero.iss
@@ -1,5 +1,5 @@
 ; Monero Fluorine Fermi GUI Wallet Installer for Windows
-; Copyright (c) 2017-2024, The Monero Project
+; Copyright (c) 2017-2025, The Monero Project
 ; See LICENSE
 #define GuiVersion GetFileVersion("bin\monero-wallet-gui.exe")
 

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -1,6 +1,6 @@
 # Monero GUI Wallet Windows Installer #
 
-Copyright (c) 2017-2024, The Monero Project
+Copyright (c) 2017-2025, The Monero Project
 
 ## Introduction ##
 

--- a/installers/windows/ReadMe.htm
+++ b/installers/windows/ReadMe.htm
@@ -6,7 +6,7 @@
 <body style="font-family: Arial, Helvetica, sans-serif">
 <h1>Monero Fluorine Fermi GUI Wallet</h1>
 
-  <p>Copyright (c) 2014-2024, The Monero Project</p>
+  <p>Copyright (c) 2014-2025, The Monero Project</p>
 
 <h2>Preface</h2>
 

--- a/main.qml
+++ b/main.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/Account.qml
+++ b/pages/Account.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/Advanced.qml
+++ b/pages/Advanced.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024, The Monero Project
+// Copyright (c) 2021-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/Keys.qml
+++ b/pages/Keys.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/SharedRingDB.qml
+++ b/pages/SharedRingDB.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024, The Monero Project
+// Copyright (c) 2018-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/Sign.qml
+++ b/pages/Sign.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/merchant/MerchantTitlebar.qml
+++ b/pages/merchant/MerchantTitlebar.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/pages/settings/Settings.qml
+++ b/pages/settings/Settings.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/settings/SettingsInfo.qml
+++ b/pages/settings/SettingsInfo.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/settings/SettingsNode.qml
+++ b/pages/settings/SettingsNode.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/pages/settings/SettingsWallet.qml
+++ b/pages/settings/SettingsWallet.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/NetworkType.h
+++ b/src/NetworkType.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/QR-Code-scanner/Decoder.cpp
+++ b/src/QR-Code-scanner/Decoder.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/QR-Code-scanner/Decoder.h
+++ b/src/QR-Code-scanner/Decoder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/QR-Code-scanner/QrCodeScanner.cpp
+++ b/src/QR-Code-scanner/QrCodeScanner.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/QR-Code-scanner/QrCodeScanner.h
+++ b/src/QR-Code-scanner/QrCodeScanner.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/QR-Code-scanner/QrScanThread.cpp
+++ b/src/QR-Code-scanner/QrScanThread.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/QR-Code-scanner/QrScanThread.h
+++ b/src/QR-Code-scanner/QrScanThread.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/TranslationManager.cpp
+++ b/src/TranslationManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/TranslationManager.h
+++ b/src/TranslationManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/AddressBook.cpp
+++ b/src/libwalletqt/AddressBook.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/AddressBook.h
+++ b/src/libwalletqt/AddressBook.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/PassphraseHelper.cpp
+++ b/src/libwalletqt/PassphraseHelper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/PassphraseHelper.h
+++ b/src/libwalletqt/PassphraseHelper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/PendingTransaction.cpp
+++ b/src/libwalletqt/PendingTransaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/PendingTransaction.h
+++ b/src/libwalletqt/PendingTransaction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/QRCodeImageProvider.cpp
+++ b/src/libwalletqt/QRCodeImageProvider.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/QRCodeImageProvider.h
+++ b/src/libwalletqt/QRCodeImageProvider.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/Subaddress.cpp
+++ b/src/libwalletqt/Subaddress.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/Subaddress.h
+++ b/src/libwalletqt/Subaddress.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/SubaddressAccount.cpp
+++ b/src/libwalletqt/SubaddressAccount.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/SubaddressAccount.h
+++ b/src/libwalletqt/SubaddressAccount.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/TransactionHistory.cpp
+++ b/src/libwalletqt/TransactionHistory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/TransactionHistory.h
+++ b/src/libwalletqt/TransactionHistory.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/TransactionInfo.cpp
+++ b/src/libwalletqt/TransactionInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/TransactionInfo.h
+++ b/src/libwalletqt/TransactionInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/Transfer.h
+++ b/src/libwalletqt/Transfer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/UnsignedTransaction.cpp
+++ b/src/libwalletqt/UnsignedTransaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/UnsignedTransaction.h
+++ b/src/libwalletqt/UnsignedTransaction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/Wallet.cpp
+++ b/src/libwalletqt/Wallet.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/Wallet.h
+++ b/src/libwalletqt/Wallet.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/WalletListenerImpl.cpp
+++ b/src/libwalletqt/WalletListenerImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/WalletListenerImpl.h
+++ b/src/libwalletqt/WalletListenerImpl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/Logger.cpp
+++ b/src/main/Logger.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/Logger.h
+++ b/src/main/Logger.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/MainApp.cpp
+++ b/src/main/MainApp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/MainApp.h
+++ b/src/main/MainApp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/clipboardAdapter.cpp
+++ b/src/main/clipboardAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/main/clipboardAdapter.h
+++ b/src/main/clipboardAdapter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/filter.cpp
+++ b/src/main/filter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/src/main/filter.h
+++ b/src/main/filter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/oscursor.cpp
+++ b/src/main/oscursor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/oscursor.h
+++ b/src/main/oscursor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/oshelper.cpp
+++ b/src/main/oshelper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/main/oshelper.h
+++ b/src/main/oshelper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/AddressBookModel.cpp
+++ b/src/model/AddressBookModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/AddressBookModel.h
+++ b/src/model/AddressBookModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/SubaddressAccountModel.cpp
+++ b/src/model/SubaddressAccountModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/SubaddressAccountModel.h
+++ b/src/model/SubaddressAccountModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/SubaddressModel.cpp
+++ b/src/model/SubaddressModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/SubaddressModel.h
+++ b/src/model/SubaddressModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/TransactionHistoryModel.cpp
+++ b/src/model/TransactionHistoryModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/TransactionHistoryModel.h
+++ b/src/model/TransactionHistoryModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/TransactionHistorySortFilterModel.cpp
+++ b/src/model/TransactionHistorySortFilterModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/model/TransactionHistorySortFilterModel.h
+++ b/src/model/TransactionHistorySortFilterModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/openpgp/hash.h
+++ b/src/openpgp/hash.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/openpgp/mpi.h
+++ b/src/openpgp/mpi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/openpgp/openpgp.cpp
+++ b/src/openpgp/openpgp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/openpgp/openpgp.h
+++ b/src/openpgp/openpgp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/openpgp/packet_stream.h
+++ b/src/openpgp/packet_stream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/openpgp/s_expression.h
+++ b/src/openpgp/s_expression.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/openpgp/serialization.h
+++ b/src/openpgp/serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/p2pool/P2PoolManager.cpp
+++ b/src/p2pool/P2PoolManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/p2pool/P2PoolManager.h
+++ b/src/p2pool/P2PoolManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/KeysFiles.cpp
+++ b/src/qt/KeysFiles.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/KeysFiles.h
+++ b/src/qt/KeysFiles.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/MoneroSettings.cpp
+++ b/src/qt/MoneroSettings.cpp
@@ -4,7 +4,7 @@
 ** Contact: https://www.qt.io/licensing/
 **
 ****************************************************************************/
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/MoneroSettings.h
+++ b/src/qt/MoneroSettings.h
@@ -4,7 +4,7 @@
 ** Contact: https://www.qt.io/licensing/
 **
 ****************************************************************************/
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/downloader.cpp
+++ b/src/qt/downloader.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/downloader.h
+++ b/src/qt/downloader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/ipc.cpp
+++ b/src/qt/ipc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/ipc.h
+++ b/src/qt/ipc.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/macoshelper.h
+++ b/src/qt/macoshelper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/macoshelper.mm
+++ b/src/qt/macoshelper.mm
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/network.cpp
+++ b/src/qt/network.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/network.h
+++ b/src/qt/network.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/updater.cpp
+++ b/src/qt/updater.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/updater.h
+++ b/src/qt/updater.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024, The Monero Project
+// Copyright (c) 2020-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/qt/utils.h
+++ b/src/qt/utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/zxcvbn-c/zxcvbn.c
+++ b/src/zxcvbn-c/zxcvbn.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/src/zxcvbn-c/zxcvbn.h
+++ b/src/zxcvbn-c/zxcvbn.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 //
 // All rights reserved.
 //

--- a/wizard/WizardAskPassword.qml
+++ b/wizard/WizardAskPassword.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardController.qml
+++ b/wizard/WizardController.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardCreateDevice1.qml
+++ b/wizard/WizardCreateDevice1.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardCreateWallet1.qml
+++ b/wizard/WizardCreateWallet1.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardCreateWallet2.qml
+++ b/wizard/WizardCreateWallet2.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardCreateWallet3.qml
+++ b/wizard/WizardCreateWallet3.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardCreateWallet4.qml
+++ b/wizard/WizardCreateWallet4.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardCreateWallet5.qml
+++ b/wizard/WizardCreateWallet5.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardDaemonSettings.qml
+++ b/wizard/WizardDaemonSettings.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardHeader.qml
+++ b/wizard/WizardHeader.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardHome.qml
+++ b/wizard/WizardHome.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardLanguage.qml
+++ b/wizard/WizardLanguage.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardMenuItem.qml
+++ b/wizard/WizardMenuItem.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardModeBootstrap.qml
+++ b/wizard/WizardModeBootstrap.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardModeRemoteNodeWarning.qml
+++ b/wizard/WizardModeRemoteNodeWarning.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardModeSelection.qml
+++ b/wizard/WizardModeSelection.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardNav.qml
+++ b/wizard/WizardNav.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardOpenWallet1.qml
+++ b/wizard/WizardOpenWallet1.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardRestoreWallet2.qml
+++ b/wizard/WizardRestoreWallet2.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardRestoreWallet3.qml
+++ b/wizard/WizardRestoreWallet3.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardRestoreWallet4.qml
+++ b/wizard/WizardRestoreWallet4.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardSummary.qml
+++ b/wizard/WizardSummary.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardSummaryItem.qml
+++ b/wizard/WizardSummaryItem.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 

--- a/wizard/WizardWalletInput.qml
+++ b/wizard/WizardWalletInput.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, The Monero Project
+// Copyright (c) 2014-2025, The Monero Project
 // 
 // All rights reserved.
 // 


### PR DESCRIPTION
This PR updates the copyright year to 2025 in the entire codebase. I used the following command to programmatically update the year in the entire codebase:

```bash
git grep -l '2024, The Monero Project' | xargs sed -i 's/2024, The Monero Project/2025, The Monero Project/g'
```

I did the same in the `monero` codebase: https://github.com/monero-project/monero/pull/10171.