### PR TITLE
Don't try negative numbers when translating "%n second(s) ago"-style strings

### DIFF
--- a/js/Utils.js
+++ b/js/Utils.js
@@ -53,7 +53,7 @@ function ago(epoch) {
     // Returns '<delta> [seconds|minutes|hours|days] ago' string given an epoch
 
     var now = new Date().getTime() / 1000;
-    var delta = now - epoch;
+    var delta = Math.max(now - epoch, 0);
 
     if(delta < 60)
         return qsTr("%n second(s) ago", "0", Math.floor(delta))


### PR DESCRIPTION
When the local clock is running behind,
transactions may appear to have been confirmed in the future, which seems to leave the %n in "%n second(s) ago" unreplaced, so round negative times ago to 0

Ref: #3284

This is not a "Closes" because, while I can validate this will do the round-off correctly, I can't test this in-app to validate that the `qsTr()` end result is fixed. But I can't think of another reason this would happen