### PR TITLE
macOS: support dark mode again

### DIFF
--- a/share/Info.plist
+++ b/share/Info.plist
@@ -38,9 +38,6 @@
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
 
-  <key>NSRequiresAquaSystemAppearance</key>
-  <string>True</string>
-
   <key>CFBundleURLTypes</key>
   <array>
     <dict>


### PR DESCRIPTION
Initially disabled in #1769, but so far I was not able to find any UI issues when reverting this change.