### PR TITLE
Support multiline transaction descriptions (#4292)

### DIFF
--- a/components/InputDialog.qml
+++ b/components/InputDialog.qml
@@ -40,6 +40,7 @@ Item {
     visible: false
     property alias labelText: label.text
     property alias inputText: input.text
+    property bool multiline: false
 
     // same signals as Dialog has
     signal accepted()
@@ -86,6 +87,7 @@ Item {
 
             MoneroComponents.Input {
                 id : input
+                visible: !root.multiline
                 focus: true
                 Layout.topMargin: 6
                 Layout.fillWidth: true
@@ -108,7 +110,7 @@ Item {
                     color: MoneroComponents.Style.blackTheme ? "black" : "#A9FFFFFF"
                 }
 
-                Keys.enabled: root.visible
+                Keys.enabled: root.visible && !root.multiline
                 Keys.onEnterPressed: Keys.onReturnPressed(event)
                 Keys.onReturnPressed: {
                     root.close()
@@ -118,6 +120,21 @@ Item {
                     root.close()
                     root.rejected()
                 }
+            }
+
+            MoneroComponents.LineEditMulti {
+                id: inputMulti
+                visible: root.multiline
+                focus: true
+                Layout.topMargin: 6
+                Layout.fillWidth: true
+                fontFamily: MoneroComponents.Style.fontLight.name
+                fontSize: 24
+                wrapMode: Text.Wrap
+                // LineEditMulti doesn't expose all properties of its internal InputMulti easily,
+                // but we can bind the text.
+                text: root.inputText
+                onTextChanged: root.inputText = text
             }
 
             // Ok/Cancel buttons

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -597,7 +597,7 @@ Rectangle {
                 anchors.right: parent ? parent.right : undefined
                 height: {
                     if(!collapsed) return 60;
-                    return 320;
+                    return Math.max(320, mainColumn.implicitHeight + 20);
                 }
                 color: {
                     if(!collapsed) return "transparent"
@@ -637,9 +637,8 @@ Rectangle {
                 }
 
                 ColumnLayout {
+                    id: mainColumn
                     spacing: 0
-                    clip: true
-                    height: parent.height
                     anchors.left: parent.left
                     anchors.right: parent.right
                     anchors.leftMargin: sideMargin
@@ -1047,7 +1046,6 @@ Rectangle {
                     ColumnLayout {
                         spacing: 0
                         Layout.fillWidth: true
-                        Layout.preferredHeight: 40
 
                         Rectangle {
                             color: "transparent"
@@ -1065,18 +1063,19 @@ Rectangle {
                             }
                         }
 
-                        Rectangle {
-                            color: "transparent"
+                        RowLayout {
                             Layout.fillWidth: true
-                            Layout.preferredHeight: 20
+                            spacing: 12
 
                             MoneroComponents.TextPlain {
                                 id: txNoteText
+                                Layout.fillWidth: true
                                 font.family: MoneroComponents.Style.fontRegular.name
                                 font.pixelSize: 15
                                 text: tx_note !== "" ? tx_note : "-"
                                 color: MoneroComponents.Style.defaultFontColor
-                                anchors.verticalCenter: parent.verticalCenter
+                                wrapMode: Text.Wrap
+                                Layout.alignment: Qt.AlignVCenter
 
                                 MouseArea {
                                     state: "copyable"
@@ -1088,9 +1087,7 @@ Rectangle {
                             }
 
                             MoneroEffects.ImageMask {
-                                anchors.top: parent.top
-                                anchors.left: txNoteText.right
-                                anchors.leftMargin: 12
+                                Layout.alignment: Qt.AlignVCenter
                                 image: "qrc:///images/edit.svg"
                                 fontAwesomeFallbackIcon: FontAwesome.pencilSquare
                                 fontAwesomeFallbackSize: 22
@@ -1636,13 +1633,17 @@ Rectangle {
     }
 
     function editDescription(_hash, _tx_note, currentPage){
+        inputDialog.multiline = true;
         inputDialog.labelText = qsTr("Set description:") + translationManager.emptyString;
         inputDialog.onAcceptedCallback = function() {
             appWindow.currentWallet.setUserNote(_hash, inputDialog.inputText);
             appWindow.showStatusMessage(qsTr("Updated description."),3);
+            inputDialog.multiline = false;
             root.update(currentPage);
         }
-        inputDialog.onRejectedCallback = null;
+        inputDialog.onRejectedCallback = function() {
+            inputDialog.multiline = false;
+        }
         inputDialog.open(_tx_note);
     }
 

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -770,13 +770,14 @@ Rectangle {
                   }
               }
 
-              LineEdit {
+              MoneroComponents.LineEditMulti {
                   id: descriptionLine
                   placeholderFontSize: 16
                   fontSize: 16
                   placeholderText: qsTr("Saved to local wallet history") + " (" + qsTr("only visible to you") + ")" + translationManager.emptyString
                   Layout.fillWidth: true
                   visible: descriptionCheckbox.checked
+                  wrapMode: Text.Wrap
               }
           }
 


### PR DESCRIPTION
This pull request resolves issue #4292, where long transaction descriptions were truncated in the History page and transaction creation notes were limited to a single line.

Technical changes:
- InputDialog.qml: Introduced a multiline property that toggles between a standard Input and a LineEditMulti component.
- History.qml:
  - Updated the transaction details view to use RowLayout instead of fixed-height containers.
  - Enabled Text.Wrap for the note display.
  - Modified the delegate height calculation to be dynamic (implicitHeight) while maintaining the original 320px minimum.
- Transfer.qml: Replaced the single-line LineEdit for the description field with LineEditMulti to allow multi-line transaction notes.