### PR TITLE
cmake: warn if qmake has -qt5 suffix during deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ jobs:
       with:
         update: true
         install: mingw-w64-x86_64-toolchain make mingw-w64-x86_64-pcre mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-openssl mingw-w64-x86_64-zeromq mingw-w64-x86_64-libsodium mingw-w64-x86_64-hidapi mingw-w64-x86_64-protobuf-c mingw-w64-x86_64-libusb mingw-w64-x86_64-unbound git mingw-w64-x86_64-qt5 mingw-w64-x86_64-libgcrypt mingw-w64-x86_64-angleproject
+    - name: add qmake.exe and windeployqt.exe
+      run: |
+        cp -f "$MSYSTEM_PREFIX/bin/qmake-qt5.exe" "$MSYSTEM_PREFIX/bin/qmake.exe"
+        cp -f "$MSYSTEM_PREFIX/bin/windeployqt-qt5.exe" "$MSYSTEM_PREFIX/bin/windeployqt.exe"
     - name: build
       run: DEV_MODE=ON make release-win64 -j2
     - name: deploy

--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -51,8 +51,12 @@ if(APPLE OR (WIN32 AND NOT STATIC))
         endif()
 
     elseif(WIN32)
+        find_program(QMAKE_EXECUTABLE qmake HINTS "${_qt_bin_dir}")
         find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
-        add_custom_command(TARGET monero-wallet-gui POST_BUILD
+        if(NOT QMAKE_EXECUTABLE OR NOT WINDEPLOYQT_EXECUTABLE)
+            message(WARNING "Deploy requires qmake.exe and windeployqt.exe (no -qt5 suffix) in ${_qt_bin_dir}")
+        endif()
+        add_custom_command(TARGET deploy POST_BUILD
                            COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}" "${WINDEPLOYQT_EXECUTABLE}" "$<TARGET_FILE:monero-wallet-gui>" -no-translations -qmldir="${CMAKE_SOURCE_DIR}"
                            COMMENT "Running windeployqt..."
         )


### PR DESCRIPTION
Fixes CI. Ugly solution but wasn't able to find anything better. `windeployqt` in Qt5 requires qmake.exe, it's not possible to set a custom binary with `--qmake` like in Qt6.