### PR TITLE
DaemonManager, P2PoolManager: supervise spawned processes

### DIFF
--- a/pages/settings/SettingsLog.qml
+++ b/pages/settings/SettingsLog.qml
@@ -178,6 +178,12 @@ Rectangle {
                     function logCommand(msg){
                         msg = log_color(msg, MoneroComponents.Style.blackTheme ? "lime" : "green");
                         consoleArea.append(msg);
+                        trimExcess();
+                    }
+                    function trimExcess(){
+                        if (consoleArea.length > 100000) {
+                            consoleArea.remove(0, consoleArea.length - 75000);
+                        }
                     }
                     function logMessage(msg){
                         msg = Utils.htmlEscape(msg.trim());
@@ -208,6 +214,7 @@ Rectangle {
                         var _timestamp = log_color("[" + timestamp + "]", MoneroComponents.Style.defaultFontColor);
                         var _msg = log_color(msg, color);
                         consoleArea.append(_timestamp + " " + _msg);
+                        trimExcess();
 
                         // scroll to bottom
                         //if(flickable.contentHeight > content.height){

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -44,8 +44,23 @@
 #include <QVariant>
 #include <QMap>
 
+#ifdef Q_OS_UNIX
+#include <unistd.h>
+#endif
+
 namespace {
     static const int DAEMON_START_TIMEOUT_SECONDS = 120;
+
+#ifdef Q_OS_UNIX
+    class SessionProcess : public QProcess
+    {
+    protected:
+        void setupChildProcess() override
+        {
+            setsid();
+        }
+    };
+#endif
 }
 
 bool DaemonManager::start(const QString &flags, NetworkType::Type nettype, const QString &dataDir, const QString &bootstrapNodeAddress, bool noSync /* = false*/, bool pruneBlockchain /* = false*/)
@@ -58,11 +73,6 @@ bool DaemonManager::start(const QString &flags, NetworkType::Type nettype, const
 
     // prepare command line arguments and pass to monerod
     QStringList arguments;
-
-    // Start daemon with --detach flag on non-windows platforms
-#ifndef Q_OS_WIN
-    arguments << "--detach";
-#endif
 
     if (nettype == NetworkType::TESTNET)
         arguments << "--testnet";
@@ -111,17 +121,28 @@ bool DaemonManager::start(const QString &flags, NetworkType::Type nettype, const
 
     QMutexLocker locker(&m_daemonMutex);
 
-    m_daemon.reset(new QProcess());
+    if (m_daemon && m_daemon->state() != QProcess::NotRunning) {
+        emit daemonStartFailure(tr("Previous local node instance is still running"));
+        return false;
+    }
 
-    // Connect output slots
+    m_daemonWasRunning = false;
+#ifdef Q_OS_UNIX
+    m_daemon.reset(new SessionProcess());
+#else
+    m_daemon.reset(new QProcess());
+#endif
+
+    // Connect output and state slots
     connect(m_daemon.get(), SIGNAL(readyReadStandardOutput()), this, SLOT(printOutput()));
     connect(m_daemon.get(), SIGNAL(readyReadStandardError()), this, SLOT(printError()));
+    connect(m_daemon.get(), SIGNAL(stateChanged(QProcess::ProcessState)), this, SLOT(stateChanged(QProcess::ProcessState)));
 
     // Start monerod
-    bool started = m_daemon->startDetached(m_monerod, arguments);
-
-    // add state changed listener
-    connect(m_daemon.get(), SIGNAL(stateChanged(QProcess::ProcessState)), this, SLOT(stateChanged(QProcess::ProcessState)));
+    m_daemon->setProgram(m_monerod);
+    m_daemon->setArguments(arguments);
+    m_daemon->start();
+    const bool started = m_daemon->waitForStarted();
 
     if (!started) {
         qDebug() << "Daemon start error: " + m_daemon->errorString();
@@ -177,7 +198,8 @@ bool DaemonManager::startWatcher(NetworkType::Type nettype, const QString &dataD
 
 bool DaemonManager::stopWatcher(NetworkType::Type nettype, const QString &dataDir) const
 {
-    // Check if daemon is running every 2 seconds. Kill if still running after 10 seconds
+    // Check if daemon is running every 2 seconds. Kill if still running after 10 seconds, give up
+    // after 20; once the RPC is down, wait for the owned process to exit before reporting success
     int counter = 0;
     while(true && !m_app_exit) {
         QThread::sleep(2);
@@ -186,15 +208,32 @@ bool DaemonManager::stopWatcher(NetworkType::Type nettype, const QString &dataDi
             qDebug() << "Daemon still running.  " << counter;
             if(counter >= 5) {
                 qDebug() << "Killing it! ";
+                QMutexLocker locker(&m_daemonMutex);
+                if (m_daemon) {
 #ifdef Q_OS_WIN
-                QProcess::execute("taskkill",  {"/F", "/IM", "monerod.exe"});
+                    m_daemon->kill();
 #else
-                QProcess::execute("pkill", {"monerod"});
+                    if (counter >= 8) {
+                        m_daemon->kill();
+                    } else {
+                        m_daemon->terminate();
+                    }
 #endif
+                }
+            }
+            if(counter >= 10) {
+                return false;
             }
 
-        } else
-            return true;
+        } else {
+            QMutexLocker locker(&m_daemonMutex);
+            if (!m_daemon || m_daemon->state() == QProcess::NotRunning) {
+                return true;
+            }
+            if(counter >= 60) {
+                return false;
+            }
+        }
     }
     return false;
 }
@@ -203,7 +242,10 @@ bool DaemonManager::stopWatcher(NetworkType::Type nettype, const QString &dataDi
 void DaemonManager::stateChanged(QProcess::ProcessState state)
 {
     qDebug() << "STATE CHANGED: " << state;
-    if (state == QProcess::NotRunning) {
+    if (state == QProcess::Running) {
+        m_daemonWasRunning = true;
+    } else if (state == QProcess::NotRunning && m_daemonWasRunning) {
+        m_daemonWasRunning = false;
         emit daemonStopped();
     }
 }
@@ -217,8 +259,9 @@ void DaemonManager::printOutput()
     QStringList strLines = QString(byteArray).split("\n");
 
     foreach (QString line, strLines) {
+        if (line.isEmpty())
+            continue;
         emit daemonConsoleUpdated(line);
-        qDebug() << "Daemon: " + line;
     }
 }
 
@@ -231,6 +274,8 @@ void DaemonManager::printError()
     QStringList strLines = QString(byteArray).split("\n");
 
     foreach (QString line, strLines) {
+        if (line.isEmpty())
+            continue;
         emit daemonConsoleUpdated(line);
         qDebug() << "Daemon ERROR: " + line;
     }
@@ -412,4 +457,10 @@ DaemonManager::DaemonManager(QObject *parent)
 DaemonManager::~DaemonManager()
 {
     m_scheduler.shutdownWaitForFinished();
+
+    QMutexLocker locker(&m_daemonMutex);
+    if (m_daemon && m_daemon->state() != QProcess::NotRunning) {
+        m_daemon->disconnect(this);
+        m_daemon.release();
+    }
 }

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -79,8 +79,9 @@ public slots:
 
 private:
     std::unique_ptr<QProcess> m_daemon;
-    QMutex m_daemonMutex;
+    mutable QMutex m_daemonMutex;
     QString m_monerod;
+    bool m_daemonWasRunning = false;
     bool m_app_exit = false;
     bool m_noSync = false;
     QString args = "";

--- a/src/p2pool/P2PoolManager.cpp
+++ b/src/p2pool/P2PoolManager.cpp
@@ -209,7 +209,8 @@ bool P2PoolManager::start(const QString &flags, const QString &address, const QS
     m_p2poold->setWorkingDirectory(m_p2poolPath);
 
     // Start p2pool
-    started = m_p2poold->startDetached();
+    m_p2poold->start();
+    started = m_p2poold->waitForStarted();
 
     if (!started) {
         qDebug() << "P2Pool start error: " + m_p2poold->errorString();
@@ -224,11 +225,20 @@ void P2PoolManager::exit()
 {
     qDebug("P2PoolManager: exit()");
     if (started) {
-    #ifdef Q_OS_WIN
-        QProcess::execute("taskkill",  {"/F", "/IM", "p2pool.exe"});
-    #else
-        QProcess::execute("pkill", {"p2pool"});
-    #endif
+        {
+            QMutexLocker locker(&m_p2poolMutex);
+            if (m_p2poold) {
+#ifdef Q_OS_WIN
+                m_p2poold->kill();
+#else
+                m_p2poold->terminate();
+                if (!m_p2poold->waitForFinished(5000)) {
+                    m_p2poold->kill();
+                }
+#endif
+                m_p2poold->waitForFinished(2000);
+            }
+        }
         started = false;
         QString dirName = m_p2poolPath + "/stats/";
         QDir dir(dirName);


### PR DESCRIPTION
Both managers launched their child with startDetached(), monerod additionally with --detach on Unix, so the QProcess object never tracked it: the output and state connections never fired, leaving the log page console without daemon output and daemon exit undetected, and shutdown had to fall back to pkill/taskkill by image name, which also killed monerod and p2pool instances the GUI did not start.

Track the child with start() + waitForStarted() and signal the owned process on shutdown, escalating from SIGTERM to SIGKILL and giving up after 20 seconds when the daemon cannot be killed because this process does not own it. Once the RPC is down, wait for the owned process to actually exit, and refuse to start while the previous daemon is still running: destroying the tracking QProcess of a live daemon would kill it. Windows kills directly, as taskkill /F did, since console applications ignore the WM_CLOSE posted by terminate().

Drop --detach; --non-interactive already prevents stdin reads. monerod runs in its own session on Unix, so a node kept running in the background still survives the launching terminal closing, and ~DaemonManager disowns a running node instead of letting ~QProcess kill it on exit.

Cap the log page console now that daemon output reaches it, skip empty output lines, and do not mirror stdout into the GUI log; monerod writes its own log file. daemonStopped() is only emitted after the daemon actually ran.