### PR TITLE
qml: escape untrusted text in remaining RichText views

### DIFF
--- a/components/TxConfirmationDialog.qml
+++ b/components/TxConfirmationDialog.qml
@@ -242,6 +242,7 @@ Rectangle {
                     Layout.fillWidth: true
                     font.pixelSize: 15
                     color: MoneroComponents.Style.defaultFontColor
+                    textFormat: Text.RichText
                     text: {
                         if (currentWallet) {
                             var walletTitle = function() {
@@ -257,9 +258,9 @@ Rectangle {
                             if (appWindow.currentWallet.numSubaddressAccounts() > 1) {
                                 var currentSubaddressAccount = currentWallet.currentSubaddressAccount;
                                 var currentAccountLabel =  currentWallet.getSubaddressLabel(currentWallet.currentSubaddressAccount, 0);
-                                return walletTitle() + " (" + walletName + ")" + "<br>" + qsTr("Account #") + currentSubaddressAccount + (currentAccountLabel !== "" ? " (" + currentAccountLabel + ")" : "") + translationManager.emptyString;
+                                return walletTitle() + " (" + Utils.htmlEscape(walletName) + ")" + "<br>" + qsTr("Account #") + currentSubaddressAccount + (currentAccountLabel !== "" ? " (" + Utils.htmlEscape(currentAccountLabel) + ")" : "") + translationManager.emptyString;
                             } else {
-                                return walletTitle() + " (" + walletName + ")" + translationManager.emptyString;
+                                return walletTitle() + " (" + Utils.htmlEscape(walletName) + ")" + translationManager.emptyString;
                             }
                         } else {
                             return "";

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1746,7 +1746,7 @@ Rectangle {
             + (paymentId ? trStart + qsTr("Payment ID:") + trMiddle + paymentId + trEnd : "")
             + (integratedAddress ? trStart + qsTr("Integrated address") + ":" + trMiddle + integratedAddress + trEnd : "")
             + (tx_key ? trStart + qsTr("Tx key:") + trMiddle + tx_key + trEnd : "")
-            + (tx_note ? trStart + qsTr("Tx note:") + trMiddle + tx_note + trEnd : "")
+            + (tx_note ? trStart + qsTr("Tx note:") + trMiddle + Utils.htmlEscape(tx_note) + trEnd : "")
             + (destinations ? trStart + qsTr("Destinations:") + trMiddle + destinations + trEnd : "")
             + (rings ? trStart + qsTr("Rings:") + trMiddle + rings + trEnd : "")
             + "</table>"

--- a/pages/merchant/Merchant.qml
+++ b/pages/merchant/Merchant.qml
@@ -295,7 +295,7 @@ Item {
                     color: "white"
                     text: "<style type='text/css'>a {text-decoration: none; color: #FF6C3C; font-size: 12px;}</style>%1: %2 <a href='#'>(%3)</a>"
                         .arg(qsTr("Currently selected address"))
-                        .arg(addressLabel)
+                        .arg(Utils.htmlEscape(addressLabel))
                         .arg(qsTr("Change")) + translationManager.emptyString
                     textFormat: Text.RichText
                     themeTransition: false

--- a/pages/settings/SettingsInfo.qml
+++ b/pages/settings/SettingsInfo.qml
@@ -142,7 +142,7 @@ Rectangle {
                     <style type='text/css'>\
                         a {cursor:pointer;text-decoration: none; color: #FF6C3C}\
                     </style>\
-                    <a href='#'>%1</a>".arg(walletPath)
+                    <a href='#'>%1</a>".arg(Utils.htmlEscape(walletPath))
                 textFormat: Text.RichText
                 onLinkActivated: oshelper.openContainingFolder(walletPath)
 


### PR DESCRIPTION
Extends the escaping from #4577 to the RichText sinks it did not cover: the transaction note in the tx details popup (History), the wallet name and account label in the send confirmation (TxConfirmationDialog), the address label on the merchant page (Merchant), and the wallet path on the info page (SettingsInfo). These were interpolated unescaped, so a value containing markup is rendered as rich text.

The transaction note is the notable case: it can be set from a payment request's tx_description, so it is attacker influenced.

Escape these fields with Utils.htmlEscape. Set the send confirmation From field to Text.RichText explicitly so the escaped entities decode in both of its branches; the single-account branch contains no tag and would otherwise render as plain text and show the raw entity.