### PR TITLE
Dockerfiles: fetch dependencies over https instead of git:// / http://

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -56,7 +56,7 @@ RUN wget -q https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zl
     && make -j${THREADS} install \
     && rm -rf $(pwd)
 
-RUN git clone git://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 \
+RUN git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 \
     && cd qt5 \
     && perl init-repository --module-subset=default,-qtwebengine \
     && PATH=${HOST_PATH} ./configure -v -developer-build -release \
@@ -90,7 +90,7 @@ RUN git clone git://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 \
 
 ARG ICONV_VERSION=1.16
 ARG ICONV_HASH=e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
-RUN wget -q http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
+RUN wget -q https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
     && echo "${ICONV_HASH}  libiconv-${ICONV_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf libiconv-${ICONV_VERSION}.tar.gz \
     && rm -f libiconv-${ICONV_VERSION}.tar.gz \
@@ -179,7 +179,7 @@ RUN set -ex \
     && make -j${THREADS} install \
     && rm -rf $(pwd)
 
-RUN git clone -b libgpg-error-1.41 --depth 1 git://git.gnupg.org/libgpg-error.git \
+RUN git clone -b libgpg-error-1.41 --depth 1 https://dev.gnupg.org/source/libgpg-error.git \
     && cd libgpg-error \
     && git reset --hard 98032624ae89a67ee6fe3b1db5d95032e681d163 \
     && ./autogen.sh \
@@ -188,7 +188,7 @@ RUN git clone -b libgpg-error-1.41 --depth 1 git://git.gnupg.org/libgpg-error.gi
     && make -j${THREADS} install \
     && rm -rf $(pwd)
 
-RUN git clone -b libgcrypt-1.10.1 --depth 1 git://git.gnupg.org/libgcrypt.git \
+RUN git clone -b libgcrypt-1.10.1 --depth 1 https://dev.gnupg.org/source/libgcrypt.git \
     && cd libgcrypt \
     && git reset --hard ae0e567820c37f9640440b3cff77d7c185aa6742 \
     && ./autogen.sh \

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -188,20 +188,20 @@ RUN wget https://www.nlnetlabs.nl/downloads/unbound/unbound-1.16.2.tar.gz && \
 RUN rm /usr/lib/x86_64-linux-gnu/libX11.a && \
     rm /usr/lib/x86_64-linux-gnu/libXext.a && \
     rm /usr/lib/x86_64-linux-gnu/libX11-xcb.a && \
-    git clone git://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
     cd qt5 && \
-    git clone git://code.qt.io/qt/qtbase.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtdeclarative.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtgraphicaleffects.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtimageformats.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtmultimedia.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtquickcontrols.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtquickcontrols2.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtsvg.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qttools.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qttranslations.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtx11extras.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtxmlpatterns.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtbase.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtdeclarative.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtgraphicaleffects.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtimageformats.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtmultimedia.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtquickcontrols.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtquickcontrols2.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtsvg.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qttools.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qttranslations.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtx11extras.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtxmlpatterns.git -b ${QT_VERSION} --depth 1 && \
     sed -ri s/\(Libs:.*\)/\\1\ -lexpat/ /usr/local/lib/pkgconfig/fontconfig.pc && \
     sed -ri s/\(Libs:.*\)/\\1\ -lz/ /usr/local/lib/pkgconfig/freetype2.pc && \
     sed -ri s/\(Libs:.*\)/\\1\ -lXau/ /usr/local/lib/pkgconfig/xcb.pc && \
@@ -251,7 +251,7 @@ RUN git clone -b v4.3.4 --depth 1 https://github.com/zeromq/libzmq && \
     make -j$THREADS install && \
     rm -rf $(pwd)
 
-RUN git clone -b libgpg-error-1.45 --depth 1 git://git.gnupg.org/libgpg-error.git && \
+RUN git clone -b libgpg-error-1.45 --depth 1 https://dev.gnupg.org/source/libgpg-error.git && \
     cd libgpg-error && \
     git reset --hard dbac537e5e865fb6f3aa8596d213aa8c47a9dea1 && \
     ./autogen.sh && \
@@ -260,7 +260,7 @@ RUN git clone -b libgpg-error-1.45 --depth 1 git://git.gnupg.org/libgpg-error.gi
     make -j$THREADS install && \
     rm -rf $(pwd)
 
-RUN git clone -b libgcrypt-1.10.1 --depth 1 git://git.gnupg.org/libgcrypt.git && \
+RUN git clone -b libgcrypt-1.10.1 --depth 1 https://dev.gnupg.org/source/libgcrypt.git && \
     cd libgcrypt && \
     git reset --hard ae0e567820c37f9640440b3cff77d7c185aa6742 && \
     ./autogen.sh && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -21,19 +21,19 @@ RUN git clone -b v0.18.5.0 --depth 1 https://github.com/monero-project/monero &&
 
 RUN make -j$THREADS -C /depends HOST=x86_64-w64-mingw32 NO_QT=1
 
-RUN git clone git://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
+RUN git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
     cd qt5 && \
-    git clone git://code.qt.io/qt/qtbase.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtdeclarative.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtgraphicaleffects.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtimageformats.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtmultimedia.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtquickcontrols.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtquickcontrols2.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtsvg.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qttools.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qttranslations.git -b ${QT_VERSION} --depth 1 && \
-    git clone git://code.qt.io/qt/qtxmlpatterns.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtbase.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtdeclarative.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtgraphicaleffects.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtimageformats.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtmultimedia.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtquickcontrols.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtquickcontrols2.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtsvg.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qttools.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qttranslations.git -b ${QT_VERSION} --depth 1 && \
+    git clone https://code.qt.io/qt/qtxmlpatterns.git -b ${QT_VERSION} --depth 1 && \
     ./configure --prefix=/depends/x86_64-w64-mingw32 -xplatform win32-g++ \
     -device-option CROSS_COMPILE=/usr/bin/x86_64-w64-mingw32- \
     -I $(pwd)/qtbase/src/3rdparty/angle/include \
@@ -58,7 +58,7 @@ RUN git clone git://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
     cd ../../../.. && \
     rm -rf $(pwd)
 
-RUN git clone -b libgpg-error-1.38 --depth 1 git://git.gnupg.org/libgpg-error.git && \
+RUN git clone -b libgpg-error-1.38 --depth 1 https://dev.gnupg.org/source/libgpg-error.git && \
     cd libgpg-error && \
     git reset --hard 71d278824c5fe61865f7927a2ed1aa3115f9e439 && \
     ./autogen.sh && \
@@ -69,7 +69,7 @@ RUN git clone -b libgpg-error-1.38 --depth 1 git://git.gnupg.org/libgpg-error.gi
     cd .. && \
     rm -rf libgpg-error
 
-RUN git clone -b libgcrypt-1.8.5 --depth 1 git://git.gnupg.org/libgcrypt.git && \
+RUN git clone -b libgcrypt-1.8.5 --depth 1 https://dev.gnupg.org/source/libgcrypt.git && \
     cd libgcrypt && \
     git reset --hard 56606331bc2a80536db9fc11ad53695126007298 && \
     ./autogen.sh && \


### PR DESCRIPTION
The release Dockerfiles cloned Qt (code.qt.io) and libgpg-error/libgcrypt (git.gnupg.org) over unauthenticated git://, and fetched libiconv (ftp.gnu.org) over http://. Qt is tag-pinned only, so a MITM on its clone could substitute source into the build. Switch them all to https, like every other dependency in these files. The gnupg commit pins and the libiconv sha256sum are unchanged.