### PR TITLE
Dockerfiles: pin Qt to commit hashes

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -58,6 +58,7 @@ RUN wget -q https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zl
 
 RUN git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 \
     && cd qt5 \
+    && git reset --hard dc2ac680fa9d0ef7b0d9520859593d13951bedea \
     && perl init-repository --module-subset=default,-qtwebengine \
     && PATH=${HOST_PATH} ./configure -v -developer-build -release \
     -xplatform android-clang \

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -190,18 +190,8 @@ RUN rm /usr/lib/x86_64-linux-gnu/libX11.a && \
     rm /usr/lib/x86_64-linux-gnu/libX11-xcb.a && \
     git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
     cd qt5 && \
-    git clone https://code.qt.io/qt/qtbase.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtdeclarative.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtgraphicaleffects.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtimageformats.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtmultimedia.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtquickcontrols.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtquickcontrols2.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtsvg.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qttools.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qttranslations.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtx11extras.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtxmlpatterns.git -b ${QT_VERSION} --depth 1 && \
+    git reset --hard dc2ac680fa9d0ef7b0d9520859593d13951bedea && \
+    git submodule update --init --depth 1 qtbase qtdeclarative qtgraphicaleffects qtimageformats qtmultimedia qtquickcontrols qtquickcontrols2 qtsvg qttools qttranslations qtx11extras qtxmlpatterns && \
     sed -ri s/\(Libs:.*\)/\\1\ -lexpat/ /usr/local/lib/pkgconfig/fontconfig.pc && \
     sed -ri s/\(Libs:.*\)/\\1\ -lz/ /usr/local/lib/pkgconfig/freetype2.pc && \
     sed -ri s/\(Libs:.*\)/\\1\ -lXau/ /usr/local/lib/pkgconfig/xcb.pc && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -23,17 +23,8 @@ RUN make -j$THREADS -C /depends HOST=x86_64-w64-mingw32 NO_QT=1
 
 RUN git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
     cd qt5 && \
-    git clone https://code.qt.io/qt/qtbase.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtdeclarative.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtgraphicaleffects.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtimageformats.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtmultimedia.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtquickcontrols.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtquickcontrols2.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtsvg.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qttools.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qttranslations.git -b ${QT_VERSION} --depth 1 && \
-    git clone https://code.qt.io/qt/qtxmlpatterns.git -b ${QT_VERSION} --depth 1 && \
+    git reset --hard dc2ac680fa9d0ef7b0d9520859593d13951bedea && \
+    git submodule update --init --depth 1 qtbase qtdeclarative qtgraphicaleffects qtimageformats qtmultimedia qtquickcontrols qtquickcontrols2 qtsvg qttools qttranslations qtxmlpatterns && \
     ./configure --prefix=/depends/x86_64-w64-mingw32 -xplatform win32-g++ \
     -device-option CROSS_COMPILE=/usr/bin/x86_64-w64-mingw32- \
     -I $(pwd)/qtbase/src/3rdparty/angle/include \


### PR DESCRIPTION
Qt was cloned with -b ${QT_VERSION} --depth 1 but, unlike every other dependency in these files, never reset to a commit, so a moved upstream tag would silently change the Qt source built into the release. Pin each module to its v5.15.19-lts-lgpl tag commit with git reset --hard, matching the existing pattern (e.g. libgpg-error/libgcrypt). linux and windows pin every module explicitly; android pins the qt5 superproject that init-repository resolves the submodules from.

Follow-up to #4613.