### PR TITLE
linux: use screenshot portal for Wayland QR scanning

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -9,7 +9,7 @@ ENV CXXFLAGS="-fPIC"
 ENV SOURCE_DATE_EPOCH=1397818193
 
 RUN apt update && \
-    apt install -y automake autopoint bison gettext git gperf libgl1-mesa-dev libglib2.0-dev \
+    apt install -y autoconf-archive automake autopoint bison gettext git gperf libgl1-mesa-dev libglib2.0-dev \
     libpng-dev libpthread-stubs0-dev libsodium-dev libtool-bin libudev-dev libusb-1.0-0-dev mesa-common-dev \
     pkg-config python wget xutils-dev
 
@@ -136,6 +136,15 @@ RUN wget https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.
     rm expat-2.4.8.tar.bz2 && \
     cd expat-2.4.8 && \
     ./configure --enable-static --disable-shared --prefix=/usr && \
+    make -j$THREADS && \
+    make -j$THREADS install && \
+    rm -rf $(pwd)
+
+RUN git clone -b dbus-1.12.2 --depth 1 https://gitlab.freedesktop.org/dbus/dbus.git && \
+    cd dbus && \
+    git reset --hard 0f0968336b9711349023e1d41f075b2bccf7c20b && \
+    ./autogen.sh && \
+    ./configure --disable-shared --enable-static --disable-systemd --disable-launchd --disable-selinux --disable-apparmor --disable-libaudit --disable-xml-docs --disable-doxygen-docs --disable-ducktype-docs --disable-modular-tests --disable-embedded-tests --disable-x11-autolaunch --without-x --with-systemdsystemunitdir=no --with-systemduserunitdir=no && \
     make -j$THREADS && \
     make -j$THREADS install && \
     rm -rf $(pwd)


### PR DESCRIPTION
 Fixes https://github.com/monero-project/monero-gui/issues/4607

 ### What changed

  This updates `OSHelper::grabQrCodesFromScreen()` so the Transfer page's "Grab QR code from screen" action can work on Wayland.

  On Wayland, `QScreen::grabWindow(0)` does not capture the desktop, so the
  existing QR screen scan path silently failed. This PR detects Wayland on Linux
  and uses `org.freedesktop.portal.Screenshot` instead. The existing
  `QScreen::grabWindow(0)` path is still used for non-Wayland platforms.

  The portal path:
  - asks the desktop portal for a screenshot using the standard user-consent
  prompt
  - waits for the portal response
  - loads the returned local screenshot URI
  - runs the existing QR decoder on that image
  - returns no QR codes if the request is cancelled, denied, times out, or the
  portal is unavailable

  ### Why

  Wayland intentionally blocks direct screen capture APIs like
  `QScreen::grabWindow(0)`. The XDG screenshot portal is the desktop-supported
  way for applications to request a screenshot under Wayland while keeping user
  consent in the flow.

  This keeps the existing Transfer page behavior where possible, instead of
  leaving the button doing nothing on Wayland.

  ### Notes

 This adds `Qt5DBus` on Linux desktop builds so the application can communicate with the XDG desktop portal.
