### PR TITLE
Set desktop file name for the application

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -230,6 +230,7 @@ int main(int argc, char *argv[])
 #endif
 
     app.setApplicationName("monero-core");
+    app.setDesktopFileName("org.getmonero.Monero");
     app.setOrganizationDomain("getmonero.org");
     app.setOrganizationName("monero-project");
 


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `org.getmonero.monero-wallet-gui`, but the desktop file is called as [`org.getmonero.Monero`](https://github.com/monero-project/monero-gui/blob/239a5350cf15b59278e3152a1982a0ac5cb185ff/share/org.getmonero.Monero.desktop).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id