### PR TITLE
main: allow graceful application shutdown

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -55,6 +55,7 @@ import "version.js" as Version
 
 ApplicationWindow {
     id: appWindow
+    signal gracefulShutdownComplete()
     title: "Monero" +
         (persistentSettings.displayWalletNameInTitleBar && walletName
         ? " - " + walletName
@@ -288,7 +289,7 @@ ApplicationWindow {
             return;
         isQuitting = true;
         closeWallet(function() {
-            Qt.quit();
+            gracefulShutdownComplete();
         })
     }
 
@@ -2243,11 +2244,16 @@ ApplicationWindow {
     }
 
     function closeAccepted(){
+        if (isQuitting)
+            return;
+        isQuitting = true;
         console.log("close accepted");
-        // Close wallet non async on exit
         daemonManager.exit();
         p2poolManager.exit();
-        closeWallet(Qt.quit);
+        closeWallet(function() {
+            console.log("wallet closed, requesting final application quit");
+            gracefulShutdownComplete();
+        });
     }
 
     function onWalletCheckUpdatesComplete(version, downloadUrl, hash, firstSigner, secondSigner) {

--- a/src/main/filter.cpp
+++ b/src/main/filter.cpp
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "filter.h"
+#include <QCoreApplication>
 #include <QKeyEvent>
 #include <QDebug>
 
@@ -35,10 +36,14 @@ filter::filter(QObject *parent) :
 {
     m_tabPressed = false;
     m_backtabPressed = false;
+    m_acceptQuit = false;
 }
 
 bool filter::eventFilter(QObject *obj, QEvent *ev) {
     if (ev->type() == QEvent::Quit) {
+        if (m_acceptQuit)
+            return QObject::eventFilter(obj, ev);
+
         emit quitRequested();
         return true;
     }
@@ -134,4 +139,10 @@ bool filter::eventFilter(QObject *obj, QEvent *ev) {
     }
 
     return QObject::eventFilter(obj, ev);
+}
+
+void filter::acceptQuit()
+{
+    m_acceptQuit = true;
+    QCoreApplication::quit();
 }

--- a/src/main/filter.h
+++ b/src/main/filter.h
@@ -37,11 +37,15 @@ class filter : public QObject
 private:
     bool m_tabPressed;
     bool m_backtabPressed;
+    bool m_acceptQuit;
 public:
     explicit filter(QObject *parent = 0);
 
 protected:
     bool eventFilter(QObject *obj, QEvent *ev);
+
+public slots:
+    void acceptQuit();
 
 signals:
     void quitRequested();

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -564,6 +564,7 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 #endif
 
     QObject::connect(eventFilter, &filter::quitRequested, rootObject, [rootObject]{ QMetaObject::invokeMethod(rootObject, "gracefulQuit", Qt::QueuedConnection); });
+    QObject::connect(rootObject, SIGNAL(gracefulShutdownComplete()), eventFilter, SLOT(acceptQuit()));
     QObject::connect(eventFilter, SIGNAL(sequencePressed(QVariant,QVariant)), rootObject, SLOT(sequencePressed(QVariant,QVariant)));
     QObject::connect(eventFilter, SIGNAL(sequenceReleased(QVariant,QVariant)), rootObject, SLOT(sequenceReleased(QVariant,QVariant)));
     QObject::connect(eventFilter, SIGNAL(mousePressed(QVariant,QVariant,QVariant)), rootObject, SLOT(mousePressed(QVariant,QVariant,QVariant)));


### PR DESCRIPTION
This is part of the upcoming Qt 6 migration.

With Qt 6, calling `Qt.quit()` directly during the current shutdown flow can leave the GUI stuck instead of exiting cleanly. This change separates the initial quit request from the final application quit: the event filter first lets QML perform graceful shutdown, and once cleanup is complete, QML signals back to C++ to allow the application to quit.

The change is compatible with the existing Qt 5 shutdown path and also adds a guard to avoid duplicate cleanup when quit can be triggered through multiple paths.