### PR TITLE
qml: replace XmlListModel for languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,11 +160,6 @@ if(Qt5QmlModels_PKG_CONFIG_FOUND)
   list(APPEND QT5_LIBRARIES Qt5QmlModels)
 endif()
 
-find_package(Qt5XmlPatterns QUIET)
-if(Qt5XmlPatterns_FOUND)
-  list(APPEND QT5_LIBRARIES Qt5XmlPatterns)
-endif()
-
 foreach(QT5_MODULE ${QT5_LIBRARIES})
   find_package(${QT5_MODULE} ${QT_MIN_VERSION} REQUIRED)
   include_directories(${${QT5_MODULE}_INCLUDE_DIRS})
@@ -234,7 +229,6 @@ if(STATIC)
   list(APPEND QT5_EXTRA_PATHS ${QT5_PKG_CONFIG_Qt5Qml_PREFIX}/qml/QtQuick/PrivateWidgets)
   list(APPEND QT5_EXTRA_PATHS ${QT5_PKG_CONFIG_Qt5Qml_PREFIX}/qml/QtQuick/Templates.2)
   list(APPEND QT5_EXTRA_PATHS ${QT5_PKG_CONFIG_Qt5Qml_PREFIX}/qml/QtQuick/Window.2)
-  list(APPEND QT5_EXTRA_PATHS ${QT5_PKG_CONFIG_Qt5Qml_PREFIX}/qml/QtQuick/XmlListModel)
 
   set(QT5_EXTRA_LIBRARIES_LIST
     qtquicktemplates2plugin
@@ -246,7 +240,6 @@ if(STATIC)
     qmlfolderlistmodelplugin
     qmlsettingsplugin
     qtlabsplatformplugin
-    qmlxmllistmodelplugin
     qquicklayoutsplugin
     modelsplugin
   )

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -191,7 +191,7 @@ RUN rm /usr/lib/x86_64-linux-gnu/libX11.a && \
     git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
     cd qt5 && \
     git reset --hard dc2ac680fa9d0ef7b0d9520859593d13951bedea && \
-    git submodule update --init --depth 1 qtbase qtdeclarative qtgraphicaleffects qtimageformats qtmultimedia qtquickcontrols qtquickcontrols2 qtsvg qttools qttranslations qtx11extras qtxmlpatterns && \
+    git submodule update --init --depth 1 qtbase qtdeclarative qtgraphicaleffects qtimageformats qtmultimedia qtquickcontrols qtquickcontrols2 qtsvg qttools qttranslations qtx11extras && \
     sed -ri s/\(Libs:.*\)/\\1\ -lexpat/ /usr/local/lib/pkgconfig/fontconfig.pc && \
     sed -ri s/\(Libs:.*\)/\\1\ -lz/ /usr/local/lib/pkgconfig/freetype2.pc && \
     sed -ri s/\(Libs:.*\)/\\1\ -lXau/ /usr/local/lib/pkgconfig/xcb.pc && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -24,7 +24,7 @@ RUN make -j$THREADS -C /depends HOST=x86_64-w64-mingw32 NO_QT=1
 RUN git clone https://code.qt.io/qt/qt5.git -b ${QT_VERSION} --depth 1 && \
     cd qt5 && \
     git reset --hard dc2ac680fa9d0ef7b0d9520859593d13951bedea && \
-    git submodule update --init --depth 1 qtbase qtdeclarative qtgraphicaleffects qtimageformats qtmultimedia qtquickcontrols qtquickcontrols2 qtsvg qttools qttranslations qtxmlpatterns && \
+    git submodule update --init --depth 1 qtbase qtdeclarative qtgraphicaleffects qtimageformats qtmultimedia qtquickcontrols qtquickcontrols2 qtsvg qttools qttranslations && \
     ./configure --prefix=/depends/x86_64-w64-mingw32 -xplatform win32-g++ \
     -device-option CROSS_COMPILE=/usr/bin/x86_64-w64-mingw32- \
     -I $(pwd)/qtbase/src/3rdparty/angle/include \

--- a/components/LanguageSidebar.qml
+++ b/components/LanguageSidebar.qml
@@ -29,9 +29,9 @@
 import "../components" as MoneroComponents
 
 import QtQuick 2.9
-import QtQuick.XmlListModel 2.0
 import QtQuick.Layouts 1.2
 import QtQuick.Controls 2.0
+import moneroComponents.LanguageModel 1.0
 
 
 Drawer {
@@ -171,24 +171,8 @@ Drawer {
     }
 
     //Flags model
-    XmlListModel {
+    LanguageModel {
         id: langModel
-        source: "/lang/languages.xml"
-        query: "/languages/language"
-
-        XmlRole { name: "display_name"; query: "@display_name/string()" }
-        XmlRole { name: "locale"; query: "@locale/string()" }
-        XmlRole { name: "wallet_language"; query: "@wallet_language/string()" }
-        XmlRole { name: "flag"; query: "@flag/string()" }
-        // TODO: XmlListModel is read only, we should store current language somewhere else
-        // and set current language accordingly
-        XmlRole { name: "isCurrent"; query: "@enabled/string()" }
-
-        onStatusChanged: {
-            if(status === XmlListModel.Ready){
-                console.log("languages available: ",count);
-            }
-        }
     }
 
     function selectCurrentLanguage() {

--- a/lang/languages.xml
+++ b/lang/languages.xml
@@ -42,7 +42,7 @@ Lojban
         <language display_name="עברית" locale="he_HE" wallet_language="English" flag="/lang/flags/il.png" qs="none"/>
         <language display_name="한국어" locale="ko_KO" wallet_language="English" flag="/lang/flags/kr.png" qs="none"/>
         <language display_name="Română" locale="ro_RO" wallet_language="English" flag="/lang/flags/ro.png" qs="none"/>
-        <language display_name="Dansk" locale="da_DK" wallet-language="English" flag="/lang/flags/dk.png" qs="none"/>
+        <language display_name="Dansk" locale="da_DK" wallet_language="English" flag="/lang/flags/dk.png" qs="none"/>
         <language display_name="Česky" locale="cs_CZ" wallet_language="English" flag="/lang/flags/cz.png" qs="none"/>
         <language display_name="Slovensky" locale="sk_SK" wallet_language="English" flag="/lang/flags/sk.png" qs="none"/>
         <language display_name="العربية" locale="ar_AR" wallet_language="English" flag="/lang/flags/eg.png" qs="none"/>

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -54,6 +54,7 @@
 #include "TransactionHistory.h"
 #include "model/TransactionHistoryModel.h"
 #include "model/TransactionHistorySortFilterModel.h"
+#include "model/LanguageModel.h"
 #include "AddressBook.h"
 #include "model/AddressBookModel.h"
 #include "Subaddress.h"
@@ -141,7 +142,6 @@ Q_IMPORT_PLUGIN(QtQuick2DialogsPrivatePlugin)
 Q_IMPORT_PLUGIN(QtQuick2PrivateWidgetsPlugin)
 Q_IMPORT_PLUGIN(QtQuickControls2Plugin)
 Q_IMPORT_PLUGIN(QtQuickTemplates2Plugin)
-Q_IMPORT_PLUGIN(QmlXmlListModelPlugin)
 #ifdef WITH_SCANNER
 Q_IMPORT_PLUGIN(QMultimediaDeclarativeModule)
 #endif
@@ -382,6 +382,7 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
     qmlRegisterType<Downloader>("moneroComponents.Downloader", 1, 0, "Downloader");
     qmlRegisterType<Network>("moneroComponents.Network", 1, 0, "Network");
     qmlRegisterType<WalletKeysFilesModel>("moneroComponents.WalletKeysFilesModel", 1, 0, "WalletKeysFilesModel");
+    qmlRegisterType<LanguageModel>("moneroComponents.LanguageModel", 1, 0, "LanguageModel");
     qmlRegisterType<WalletManager>("moneroComponents.WalletManager", 1, 0, "WalletManager");
 
     // Temporary Qt.labs.settings replacement

--- a/src/model/LanguageModel.cpp
+++ b/src/model/LanguageModel.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "LanguageModel.h"
+
+#include <QFile>
+#include <QXmlStreamReader>
+
+LanguageModel::LanguageModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+    QFile file(QStringLiteral(":/lang/languages.xml"));
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning("Could not open the embedded language list: %s", qPrintable(file.errorString()));
+        return;
+    }
+
+    QXmlStreamReader xml(&file);
+    if (!xml.readNextStartElement()) {
+        if (xml.hasError())
+            qWarning("Could not parse the embedded language list: %s", qPrintable(xml.errorString()));
+        else
+            qWarning("The embedded language list is empty");
+        return;
+    }
+    if (xml.name() != QStringLiteral("languages")) {
+        qWarning("Could not parse the embedded language list: root element must be <languages>");
+        return;
+    }
+
+    QVector<Language> languages;
+    while (xml.readNextStartElement()) {
+        if (xml.name() != QStringLiteral("language")) {
+            xml.skipCurrentElement();
+            continue;
+        }
+
+        const auto attributes = xml.attributes();
+        Language language{
+            attributes.value(QStringLiteral("display_name")).toString(),
+            attributes.value(QStringLiteral("locale")).toString(),
+            attributes.value(QStringLiteral("wallet_language")).toString(),
+            attributes.value(QStringLiteral("flag")).toString()
+        };
+        if (language.displayName.isEmpty() || language.locale.isEmpty()
+                || language.walletLanguage.isEmpty() || language.flag.isEmpty()) {
+            qWarning("Ignoring incomplete language entry at line %lld",
+                     static_cast<long long>(xml.lineNumber()));
+        } else {
+            languages.append(language);
+        }
+        xml.skipCurrentElement();
+    }
+
+    if (xml.hasError()) {
+        qWarning("Could not parse the embedded language list: %s", qPrintable(xml.errorString()));
+        return;
+    }
+    if (languages.isEmpty())
+        qWarning("The embedded language list contains no languages");
+    m_languages.swap(languages);
+}
+
+int LanguageModel::count() const
+{
+    return m_languages.size();
+}
+
+int LanguageModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : m_languages.size();
+}
+
+QVariant LanguageModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_languages.size())
+        return {};
+
+    const auto &language = m_languages.at(index.row());
+    switch (role) {
+    case DisplayNameRole: return language.displayName;
+    case LocaleRole: return language.locale;
+    case WalletLanguageRole: return language.walletLanguage;
+    case FlagRole: return language.flag;
+    default: return {};
+    }
+}
+
+QHash<int, QByteArray> LanguageModel::roleNames() const
+{
+    return {
+        {DisplayNameRole, "display_name"},
+        {LocaleRole, "locale"},
+        {WalletLanguageRole, "wallet_language"},
+        {FlagRole, "flag"}
+    };
+}
+
+QVariantMap LanguageModel::get(int row) const
+{
+    QVariantMap result;
+    if (row < 0 || row >= m_languages.size())
+        return result;
+
+    const auto roles = roleNames();
+    for (auto it = roles.cbegin(); it != roles.cend(); ++it)
+        result.insert(QString::fromUtf8(it.value()), data(index(row), it.key()));
+    return result;
+}

--- a/src/model/LanguageModel.h
+++ b/src/model/LanguageModel.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <QAbstractListModel>
+#include <QVariantMap>
+#include <QVector>
+
+class LanguageModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ count CONSTANT)
+
+public:
+    enum Role {
+        DisplayNameRole = Qt::UserRole + 1,
+        LocaleRole,
+        WalletLanguageRole,
+        FlagRole
+    };
+
+    explicit LanguageModel(QObject *parent = nullptr);
+
+    int count() const;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    Q_INVOKABLE QVariantMap get(int row) const;
+
+private:
+    struct Language {
+        QString displayName;
+        QString locale;
+        QString walletLanguage;
+        QString flag;
+    };
+
+    QVector<Language> m_languages;
+};


### PR DESCRIPTION
Replace `XmlListModel` with a C++ language model to remove a Qt 6-incompatible QML dependency.

Part of the upcoming Qt 6 migration.