### PR TITLE
main: only create native menu bar on macOS

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -2478,7 +2478,10 @@ ApplicationWindow {
         onClosed: { if (previousActiveFocusItem) previousActiveFocusItem.forceActiveFocus() }
     }
 
-    MoneroComponents.MenuBar { }
+    Loader {
+        active: isMac
+        sourceComponent: MoneroComponents.MenuBar {}
+    }
 
     Network {
         id: network


### PR DESCRIPTION
Part of the upcoming Qt 6 migration. With Qt 6, a native menu bar was also created on Windows, which disrupted the layout.