### PR TITLE
TitleBar: fix signal calls with extra arguments

### DIFF
--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -130,7 +130,7 @@ Rectangle {
                     parent.color = "transparent"
                     btnLockWalletTooltip.tooltipPopup.close()
                 }
-                onClicked: root.lockWalletClicked(leftPanel.visible)
+                onClicked: root.lockWalletClicked()
             }
         }
 
@@ -171,7 +171,7 @@ Rectangle {
                     parent.color = "transparent"
                     btnCloseWalletTooltip.tooltipPopup.close()
                 }
-                onClicked: root.closeWalletClicked(leftPanel.visible)
+                onClicked: root.closeWalletClicked()
             }
         }
 


### PR DESCRIPTION
```
2026-07-05 23:21:19.515	W expression for onClicked@qrc:/components/TitleBar.qml:173
2026-07-05 23:21:19.516	W Too many arguments, ignoring 1
```

Part of the upcoming Qt 6 migration, as it now warns about this.