### PR TITLE
makefile: remove unused variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ ifeq ($(USE_SINGLE_BUILDDIR), OFF)
     builddir := $(builddir)/$(branch)
     topdir := $(topdir)/..
   endif
-
-  deldirs := $(builddir)
-else
-  deldirs := $(builddir)/debug $(builddir)/release $(builddir)/fuzz
 endif
 
 default:


### PR DESCRIPTION
Removes the unused `deldirs` variable in the `Makefile`.