### PR TITLE
components: make daemon manager dialog non-modal

### DIFF
--- a/components/DaemonManagerDialog.qml
+++ b/components/DaemonManagerDialog.qml
@@ -38,7 +38,7 @@ import "../components" as MoneroComponents
 
 Window {
     id: root
-    modality: Qt.ApplicationModal
+    modality: Qt.NonModal
     flags: Qt.Window | Qt.FramelessWindowHint
     property int countDown: 10;
     signal rejected()


### PR DESCRIPTION
This essentially just allows you to still interact with the rest of the GUI while the "Starting local node in 10 seconds" dialog is active. The window blocking the rest of the GUI is a bit of a pain.