### PR TITLE
sync: show human-readable estimation of remaining sync time

### DIFF
--- a/LeftPanel.qml
+++ b/LeftPanel.qml
@@ -526,7 +526,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: daemonProgressBar.top
-            height: 48
+            height: 66
             syncType: qsTr("Wallet") + translationManager.emptyString
             visible: !appWindow.disconnected
         }
@@ -538,7 +538,7 @@ Rectangle {
             anchors.bottom: networkStatus.top
             syncType: qsTr("Daemon") + translationManager.emptyString
             visible: !appWindow.disconnected
-            height: 62
+            height: 80
         }
         
         MoneroComponents.NetworkStatusItem {

--- a/components/ProgressBar.qml
+++ b/components/ProgressBar.qml
@@ -30,6 +30,7 @@ import QtQuick 2.9
 import moneroComponents.Wallet 1.0
 
 import "../components" as MoneroComponents
+import "../js/Utils.js" as Utils
 
 Rectangle {
     id: item
@@ -39,6 +40,9 @@ Rectangle {
     visible: false
     color: "transparent"
 
+    property double syncStartTime: 0
+    property double syncStartBlock: -1
+
     function updateProgress(currentBlock,targetBlock, blocksToSync, statusTxt){
         if(targetBlock > 0) {
             var remaining = (currentBlock < targetBlock) ? targetBlock - currentBlock : 0
@@ -47,9 +51,27 @@ Rectangle {
             if(typeof statusTxt != "undefined" && statusTxt != "") {
                 progressText.text = statusTxt;
                 progressTextValue.text = "";
+                progressTextEta.text = "";
+                syncStartBlock = -1;
             } else {
                 progressText.text = syncText;
-                progressTextValue.text = remaining.toFixed(0);
+
+                if(syncStartBlock < 0) {
+                    syncStartBlock = currentBlock;
+                    syncStartTime = Date.now();
+                }
+
+                progressTextValue.text = Utils.formatThousands(remaining.toFixed(0));
+
+                var elapsed = (Date.now() - syncStartTime) / 1000;
+                var syncedBlocks = currentBlock - syncStartBlock;
+                if(remaining > 0 && syncedBlocks > 0 && elapsed > 0) {
+                    var blocksPerSecond = syncedBlocks / elapsed;
+                    var etaSeconds = Math.round(remaining / blocksPerSecond);
+                    progressTextEta.text = qsTr("%1 left").arg(walletManager.getHumanReadableTimespan(etaSeconds));
+                } else {
+                    progressTextEta.text = "";
+                }
             }
         }
     }
@@ -62,9 +84,21 @@ Rectangle {
         anchors.fill: parent
 
         MoneroComponents.TextPlain {
-            id: progressText
+            id: progressTextEta
             anchors.top: parent.top
             anchors.topMargin: 6
+            anchors.right: parent.right
+            horizontalAlignment: Text.AlignRight
+            font.family: MoneroComponents.Style.fontMedium.name
+            font.pixelSize: 13
+            font.bold: MoneroComponents.Style.progressBarProgressTextBold
+            color: MoneroComponents.Style.defaultFontColor
+            height: 18
+        }
+
+        MoneroComponents.TextPlain {
+            id: progressText
+            anchors.top: progressTextEta.bottom
             font.family: MoneroComponents.Style.fontMedium.name
             font.pixelSize: 13
             font.bold: MoneroComponents.Style.progressBarProgressTextBold
@@ -75,8 +109,7 @@ Rectangle {
 
         MoneroComponents.TextPlain {
             id: progressTextValue
-            anchors.top: parent.top
-            anchors.topMargin: 6
+            anchors.top: progressTextEta.bottom
             anchors.right: parent.right
             font.family: MoneroComponents.Style.fontMedium.name
             font.pixelSize: 13

--- a/js/Utils.js
+++ b/js/Utils.js
@@ -65,6 +65,10 @@ function ago(epoch) {
         return qsTr("%n day(s) ago", "0", Math.floor(delta / 86400))
 }
 
+function formatThousands(num) {
+    return num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
+}
+
 function netTypeToString(){
     // 0: mainnet, 1: testnet, 2: stagenet
     var nettype = appWindow.persistentSettings.nettype;

--- a/js/Utils.js
+++ b/js/Utils.js
@@ -65,6 +65,10 @@ function ago(epoch) {
         return qsTr("%n day(s) ago", "0", Math.floor(delta / 86400))
 }
 
+function formatThousands(num) {
+    return num.toLocaleString("en-US");
+}
+
 function netTypeToString(){
     // 0: mainnet, 1: testnet, 2: stagenet
     var nettype = appWindow.persistentSettings.nettype;

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -45,6 +45,7 @@
 
 #include "qt/updater.h"
 #include "qt/ScopeGuard.h"
+#include "common/util.h"
 
 class WalletPassphraseListenerImpl : public  Monero::WalletListener, public PassphraseReceiver
 {
@@ -266,6 +267,11 @@ QString WalletManager::maximumAllowedAmountAsString() const
 QString WalletManager::displayAmount(quint64 amount)
 {
     return QString::fromStdString(Monero::Wallet::displayAmount(amount));
+}
+
+QString WalletManager::getHumanReadableTimespan(quint64 seconds)
+{
+    return QString::fromStdString(tools::get_human_readable_timespan(seconds));
 }
 
 quint64 WalletManager::amountFromString(const QString &amount)

--- a/src/libwalletqt/WalletManager.h
+++ b/src/libwalletqt/WalletManager.h
@@ -140,6 +140,8 @@ public:
     Q_INVOKABLE static QString amountsSumFromStrings(const QVector<QString> &amounts);
     Q_INVOKABLE static quint64 maximumAllowedAmount();
 
+    Q_INVOKABLE static QString getHumanReadableTimespan(quint64 seconds);
+
     // QML JS engine doesn't support unsigned integers
     Q_INVOKABLE QString maximumAllowedAmountAsString() const;
 


### PR DESCRIPTION
Adds a text label to display an estimation of remaining blockchain sync time. Also formats the number of remaining blocks with comma separators.