### PR TITLE
Receive: fix stale subaddress selection after switching accounts

### DIFF
--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -61,6 +61,24 @@ Rectangle {
         inputDialog.open(appWindow.currentWallet.getSubaddressLabel(appWindow.currentWallet.currentSubaddressAccount, _index))
     }
 
+    function updateSelectedAddressDisplay() {
+        appWindow.current_subaddress_table_index = subaddressListView.currentIndex;
+        appWindow.current_address = appWindow.currentWallet.address(
+            appWindow.currentWallet.currentSubaddressAccount,
+            subaddressListView.currentIndex
+        );
+        if (subaddressListView.currentIndex == 0) {
+            selectedAddressDrescription.text = qsTr("Primary address") + translationManager.emptyString;
+        } else {
+            var selectedAddressLabel = appWindow.currentWallet.getSubaddressLabel(appWindow.currentWallet.currentSubaddressAccount, appWindow.current_subaddress_table_index);
+            if (selectedAddressLabel == "") {
+                selectedAddressDrescription.text = "(" + qsTr("no label") + ")" + translationManager.emptyString
+            } else {
+                selectedAddressDrescription.text = selectedAddressLabel
+            }
+        }
+    }
+
     function generateQRCodeString() {
         if (pageReceive.state == "PaymentRequest") {
             return walletManager.make_uri(appWindow.current_address,
@@ -708,24 +726,7 @@ Rectangle {
                             }
                         }
                     }
-                    onCurrentItemChanged: {
-                        // reset global vars
-                        appWindow.current_subaddress_table_index = subaddressListView.currentIndex;
-                        appWindow.current_address = appWindow.currentWallet.address(
-                            appWindow.currentWallet.currentSubaddressAccount,
-                            subaddressListView.currentIndex
-                        );
-                        if (subaddressListView.currentIndex == 0) {
-                            selectedAddressDrescription.text = qsTr("Primary address") + translationManager.emptyString;
-                        } else {
-                            var selectedAddressLabel = appWindow.currentWallet.getSubaddressLabel(appWindow.currentWallet.currentSubaddressAccount, appWindow.current_subaddress_table_index);
-                            if (selectedAddressLabel == "") {
-                                selectedAddressDrescription.text = "(" + qsTr("no label") + ")" + translationManager.emptyString
-                            } else {
-                                selectedAddressDrescription.text = selectedAddressLabel
-                            }
-                        }
-                    }
+                    onCurrentItemChanged: updateSelectedAddressDisplay()
                 }
             }
 
@@ -773,11 +774,12 @@ Rectangle {
         subaddressListView.model = appWindow.currentWallet.subaddressModel;
 
         if (appWindow.currentWallet) {
-            appWindow.current_address = appWindow.currentWallet.address(appWindow.currentWallet.currentSubaddressAccount, 0)
             appWindow.currentWallet.subaddress.refresh(appWindow.currentWallet.currentSubaddressAccount)
-            if (subaddressListView.currentIndex == -1) {
+            var numSubaddresses = appWindow.currentWallet.numSubaddresses(appWindow.currentWallet.currentSubaddressAccount);
+            if (subaddressListView.currentIndex == -1 || subaddressListView.currentIndex >= numSubaddresses) {
                 subaddressListView.currentIndex = 0;
             }
+            updateSelectedAddressDisplay();
         }
     }
 


### PR DESCRIPTION
Fixes #4169.

subaddressListView.currentIndex only gets reset back to 0 when it's -1 (the
initial sentinel value). Switching accounts happens outside Receive.qml
(Account.qml calls appWindow.currentWallet.switchSubaddressAccount()), so
nothing tells the Receive page's ListView that its selection may no longer
be valid. If you had, say, subaddress #5 selected and switch to an account
that only has 2 addresses, currentIndex stays at 5 and onCurrentItemChanged
never fires again, so the "Address #5" label and description stay stuck
showing the old account's data. Meanwhile onPageCompleted() always sets
current_address to index 0 regardless of currentIndex, so the QR code and
address text underneath correctly show the new account's primary address.
Same index/label text, different actual address - that's the mismatch in
the issue's screenshots.

That hardcoded 0 also means just leaving the Receive tab and coming back
(no account switch involved) snaps the shown address back to primary while
the row highlighted in the list and its label stay wherever you last left
them, if you'd selected something other than index 0.

Change:
- Added updateSelectedAddressDisplay(), pulled out of the ListView's
  onCurrentItemChanged handler so it can be called from both places.
- onPageCompleted() now checks currentIndex against
  numSubaddresses(currentSubaddressAccount) for the account actually being
  shown, not just currentIndex == -1, and resets to 0 if it's out of range.
- onPageCompleted() calls updateSelectedAddressDisplay() instead of
  hardcoding address(..., 0), so the address/index/label shown always
  matches the selected row for whichever account is current.

Checked with qmllint (Qt 6.11, Arch package) - same warnings before and
after the change, all pre-existing "not found" notices from custom module
types the linter can't resolve outside a full build, nothing new introduced
by this patch. I don't have a build of the GUI to click through, so I
traced through Account.qml's switchSubaddressAccount call path and
MiddlePanel.qml's onPageCompleted dispatch to work out when this fires.
