### PR TITLE
wizard: fix restore from QR code

### DIFF
--- a/js/Wizard.js
+++ b/js/Wizard.js
@@ -1,29 +1,5 @@
 .pragma library
 
-function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name, extra_parameters) {
-    // Switch to recover from keys
-    recoverFromSeedMode = false
-    spendKeyLine.text = ""
-    viewKeyLine.text = ""
-    restoreHeight.text = ""
-
-    if(typeof extra_parameters.secret_view_key != "undefined") {
-        viewKeyLine.text = extra_parameters.secret_view_key
-    }
-    if(typeof extra_parameters.secret_spend_key != "undefined") {
-        spendKeyLine.text = extra_parameters.secret_spend_key
-    }
-    if(typeof extra_parameters.restore_height != "undefined") {
-        restoreHeight.text = extra_parameters.restore_height
-    }
-    addressLine.text = address
-
-    cameraUi.qrcode_decoded.disconnect(updateFromQrCode)
-
-    // Check if keys are correct
-    checkNextButton();
-}
-
 function switchPage(next) {
     // Android focus workaround
     releaseFocus();

--- a/wizard/WizardRestoreWallet1.qml
+++ b/wizard/WizardRestoreWallet1.qml
@@ -60,6 +60,23 @@ Rectangle {
         return false;
     }
 
+    function updateFromQrCode(address, payment_id, amount, tx_description, recipient_name, extra_parameters) {
+        // the key fields are only visible in 'keys' mode
+        seedRadioButton.checked = false;
+        keysRadioButton.checked = true;
+        qrRadioButton.checked = false;
+        wizardController.walletRestoreMode = 'keys';
+
+        // extra_parameters is null when a bare address was scanned
+        var params = extra_parameters || {};
+        addressLine.text = address;
+        viewKeyLine.text = typeof params.secret_view_key != "undefined" ? params.secret_view_key : "";
+        spendKeyLine.text = typeof params.secret_spend_key != "undefined" ? params.secret_spend_key : "";
+        restoreHeight.text = typeof params.restore_height != "undefined" ? params.restore_height : "";
+
+        cameraUi.qrcode_decoded.disconnect(updateFromQrCode);
+    }
+
     function verifyFromKeys() {
         var result = Wizard.restoreWalletCheckViewSpendAddress(
             walletManager,
@@ -156,7 +173,7 @@ Rectangle {
                         keysRadioButton.checked = false;
                         wizardController.walletRestoreMode = 'qr';
                         cameraUi.state = "Capture";
-                        cameraUi.qrcode_decoded.connect(Wizard.updateFromQrCode);
+                        cameraUi.qrcode_decoded.connect(updateFromQrCode);
                     }
                 }
             }


### PR DESCRIPTION
updateFromQrCode lived in Wizard.js, a .pragma library script with no access to QML scope, so every scan aborted on its first statement and filled nothing. Broken since the wizard redesign (f329a710), the function also still referenced pre-redesign items that no longer exist.

Move it into WizardRestoreWallet1.qml next to the fields it fills, switch to the keys form so the scanned values are visible, and handle the null extra_parameters emitted for bare-address QR codes.