### PR TITLE
main: hint at device state when a hardware wallet fails to open

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -538,7 +538,13 @@ ApplicationWindow {
                 default:
                     // opening with password but password doesn't match
                     console.error("Error opening wallet with password: ", wallet.errorString);
-                    passwordDialog.showError(qsTr("Couldn't open wallet: ") + wallet.errorString);
+                    var errorMessage = qsTr("Couldn't open wallet: ") + wallet.errorString;
+                    if (wallet.isLedger()) {
+                        errorMessage += "\n" + qsTr("Make sure your Ledger is connected and unlocked, and the Monero app is open.");
+                    } else if (wallet.isTrezor()) {
+                        errorMessage += "\n" + qsTr("Make sure your Trezor is connected and unlocked.");
+                    }
+                    passwordDialog.showError(errorMessage);
                     console.log("closing wallet async : " + wallet.address)
                     closeWallet();
                     return;


### PR DESCRIPTION
## Problem

When a hardware wallet fails to open — locked, disconnected, or with the Monero app
closed — the password dialog shows the raw error from the device layer and nothing
else. For a locked Ledger that is:

```
Couldn't open wallet: Wrong Device Status: 0x5515 (UNKNOWN), EXPECTED 0x9000 (UNKNOWN), MASK 0xffff
```

Nothing there tells the user to unlock the device, so it reads like a failure of the
wallet rather than a device that needs attention.

## Change

When a wallet fails to open and the wallet is hardware-backed, append a line saying
what to check. The device type comes from `wallet.isLedger()` / `wallet.isTrezor()`,
matching how `TxConfirmationDialog.qml` already distinguishes them, so Trezor users
are not told to open a Monero app that does not exist on their device.

```
Couldn't open wallet: <device error>
Make sure your Ledger is connected and unlocked, and the Monero app is open.
```

## Why detect the device instead of matching the error text

Device-layer error strings change over time: the status word name in this error was
renamed, and monero-project/monero#10997 replaces the hex dump altogether. Matching on
`isHwBacked()` is unaffected by wording changes, and covers device failures that have
not been catalogued yet.

Related prior work: #3508.

Closes #3507
