### PR TITLE
settings: add System/Light/Dark theme selector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,19 @@ if(Qt5QmlModels_PKG_CONFIG_FOUND)
   list(APPEND QT5_LIBRARIES Qt5QmlModels)
 endif()
 
+# Optional. Lets the "System" theme setting read the desktop colour-scheme preference
+# from xdg-desktop-portal. Without it we fall back to inspecting the Qt palette.
+if(UNIX AND NOT APPLE AND NOT ANDROID)
+  find_package(Qt5DBus ${QT_MIN_VERSION} QUIET)
+  if(Qt5DBus_FOUND)
+    message(STATUS "Found Qt5DBus, system colour-scheme detection will use xdg-desktop-portal")
+    list(APPEND QT5_LIBRARIES Qt5DBus)
+    add_definitions(-DHAVE_QT_DBUS)
+  else()
+    message(STATUS "Qt5DBus not found, system colour-scheme detection will use the Qt palette")
+  endif()
+endif()
+
 foreach(QT5_MODULE ${QT5_LIBRARIES})
   find_package(${QT5_MODULE} ${QT_MIN_VERSION} REQUIRED)
   include_directories(${${QT5_MODULE}_INCLUDE_DIRS})

--- a/components/Style.qml
+++ b/components/Style.qml
@@ -3,7 +3,16 @@ pragma Singleton
 import QtQuick 2.5
 
 QtObject {
-    property bool blackTheme: true
+    // Theme selection: "system" follows the OS preference, "light" and "dark" force one.
+    property string theme: "dark"
+
+    // Reported by the ColorScheme helper; only consulted when theme is "system".
+    property bool systemPrefersDark: typeof colorScheme !== "undefined" ? colorScheme.prefersDark : true
+
+    // Derived, read-only. Every existing Style.blackTheme reference keeps working unchanged.
+    readonly property bool blackTheme: theme === "light" ? false :
+                                       theme === "dark" ? true :
+                                       systemPrefersDark
     property QtObject fontMedium: FontLoader { id: _fontMedium; source: "qrc:/fonts/Roboto-Medium.ttf"; }
     property QtObject fontBold: FontLoader { id: _fontBold; source: "qrc:/fonts/Roboto-Bold.ttf"; }
     property QtObject fontLight: FontLoader { id: _fontLight; source: "qrc:/fonts/Roboto-Light.ttf"; }

--- a/components/TitleBar.qml
+++ b/components/TitleBar.qml
@@ -251,7 +251,7 @@ Rectangle {
                     btnSwitchThemeTooltip.tooltipPopup.close()
                 }
                 onClicked: {
-                    MoneroComponents.Style.blackTheme = !MoneroComponents.Style.blackTheme;
+                    appWindow.toggleTheme();
                 }
             }
         }

--- a/main.qml
+++ b/main.qml
@@ -1508,7 +1508,8 @@ ApplicationWindow {
         property bool lockOnUserInActivity: true
         property int walletMode: 2
         property int lockOnUserInActivityInterval: 10  // minutes
-        property bool blackTheme: MoneroComponents.Style.blackTheme
+        property bool blackTheme: true  // legacy, superseded by `theme`; kept in sync for downgrades
+        property string theme: ""       // "system" | "light" | "dark"; empty means not migrated yet
         property bool checkForUpdates: true
         property bool autosave: true
         property int autosaveMinutes: 10
@@ -1546,8 +1547,28 @@ ApplicationWindow {
         }
 
         Component.onCompleted: {
-            MoneroComponents.Style.blackTheme = persistentSettings.blackTheme
+            // Migrate the pre-existing boolean setting to the tri-state theme selector.
+            if (persistentSettings.theme === "") {
+                persistentSettings.theme = persistentSettings.blackTheme ? "dark" : "light";
+            }
         }
+    }
+
+    Binding {
+        target: MoneroComponents.Style
+        property: "theme"
+        value: persistentSettings.theme
+        when: persistentSettings.theme !== ""
+    }
+
+    // Keep the legacy key current so downgrading to an older release preserves the choice.
+    // Held inactive until migration has run, so it cannot write Style's default over the
+    // stored blackTheme that the migration above depends on reading.
+    Binding {
+        target: persistentSettings
+        property: "blackTheme"
+        value: MoneroComponents.Style.blackTheme
+        when: persistentSettings.theme !== ""
     }
 
     ListModel {
@@ -2050,6 +2071,12 @@ ApplicationWindow {
                 color: "#FFFFFF"
             }
         }
+    }
+
+    // Quick toggle used by the title bar button and the View menu. Flips to the explicit
+    // theme opposite to whatever is currently showing, including when following the system.
+    function toggleTheme(){
+        persistentSettings.theme = MoneroComponents.Style.blackTheme ? "light" : "dark";
     }
 
     function toggleLanguageView(){

--- a/pages/settings/SettingsLayout.qml
+++ b/pages/settings/SettingsLayout.qml
@@ -84,16 +84,59 @@ Rectangle {
             text: qsTr("Hide balance") + translationManager.emptyString
         }
 
-        MoneroComponents.CheckBox {
-            id: themeCheckbox
-            checked: !MoneroComponents.Style.blackTheme
-            text: qsTr("Light theme") + translationManager.emptyString
-            toggleOnClick: false
-            onClicked: {
-                MoneroComponents.Style.blackTheme = !MoneroComponents.Style.blackTheme;
+        MoneroComponents.TextPlain {
+            Layout.topMargin: 6
+            text: qsTr("Theme") + translationManager.emptyString
+            color: MoneroComponents.Style.defaultFontColor
+        }
+
+        RowLayout {
+            Layout.leftMargin: 12
+            spacing: 24
+
+            // RadioButton.toggle() assigns `checked` directly, which would break a plain
+            // binding, so the selection is driven by Binding elements that re-assert.
+            MoneroComponents.RadioButton {
+                id: themeSystemButton
+                enabled: !themeSystemButton.checked
+                text: qsTr("System") + translationManager.emptyString
+                onClicked: persistentSettings.theme = "system"
+            }
+
+            MoneroComponents.RadioButton {
+                id: themeLightButton
+                enabled: !themeLightButton.checked
+                text: qsTr("Light") + translationManager.emptyString
+                onClicked: persistentSettings.theme = "light"
+            }
+
+            MoneroComponents.RadioButton {
+                id: themeDarkButton
+                enabled: !themeDarkButton.checked
+                text: qsTr("Dark") + translationManager.emptyString
+                onClicked: persistentSettings.theme = "dark"
+            }
+
+            Binding {
+                target: themeSystemButton
+                property: "checked"
+                value: persistentSettings.theme === "system"
+            }
+
+            Binding {
+                target: themeLightButton
+                property: "checked"
+                value: persistentSettings.theme === "light"
+            }
+
+            Binding {
+                target: themeDarkButton
+                property: "checked"
+                value: persistentSettings.theme === "dark"
             }
         }
-        
+
+
         MoneroComponents.CheckBox {
             checked: persistentSettings.askPasswordBeforeSending
             text: qsTr("Ask for password before sending a transaction") + translationManager.emptyString

--- a/src/main/ColorScheme.cpp
+++ b/src/main/ColorScheme.cpp
@@ -1,0 +1,208 @@
+// Copyright (c) 2014-2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "ColorScheme.h"
+
+#include <QColor>
+#include <QEvent>
+#include <QGuiApplication>
+#include <QPalette>
+
+#ifdef HAVE_QT_DBUS
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QVariant>
+#endif
+
+#ifdef Q_OS_WIN
+#include <QSettings>
+#include <QTimer>
+#include <QVariant>
+#endif
+
+namespace {
+
+// Qt reflects the desktop's light/dark choice in the application palette whenever a
+// platform theme plugin is active (gtk3, qt5ct, kde, and macOS). Comparing the window
+// and text lightness is more robust than testing the window colour against a fixed
+// threshold, because it stays correct for low-contrast and tinted palettes.
+bool palettePrefersDark()
+{
+    const QPalette palette = QGuiApplication::palette();
+    const QColor window = palette.color(QPalette::Active, QPalette::Window);
+    const QColor windowText = palette.color(QPalette::Active, QPalette::WindowText);
+    return window.lightness() < windowText.lightness();
+}
+
+#ifdef HAVE_QT_DBUS
+// org.freedesktop.appearance color-scheme: 0 = no preference, 1 = prefer dark, 2 = prefer light.
+bool colorSchemeFromVariant(const QVariant &value, bool &prefersDark)
+{
+    QVariant unwrapped = value;
+    // Settings.Read returns the value wrapped in one or two layers of variant,
+    // depending on the portal implementation.
+    while (unwrapped.canConvert<QDBusVariant>())
+    {
+        unwrapped = unwrapped.value<QDBusVariant>().variant();
+    }
+
+    bool ok = false;
+    const uint colorScheme = unwrapped.toUInt(&ok);
+    if (!ok || colorScheme == 0)
+    {
+        return false;
+    }
+
+    prefersDark = colorScheme == 1;
+    return true;
+}
+
+// Ask xdg-desktop-portal for the desktop's colour-scheme preference. This is the only
+// mechanism that works across desktops that do not theme Qt applications themselves,
+// such as COSMIC, and on setups where the Qt palette comes from a static qt5ct profile.
+bool portalPrefersDark(bool &prefersDark)
+{
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    if (!sessionBus.isConnected())
+    {
+        return false;
+    }
+
+    QDBusMessage request = QDBusMessage::createMethodCall(
+        QStringLiteral("org.freedesktop.portal.Desktop"),
+        QStringLiteral("/org/freedesktop/portal/desktop"),
+        QStringLiteral("org.freedesktop.portal.Settings"),
+        QStringLiteral("Read"));
+    request << QStringLiteral("org.freedesktop.appearance") << QStringLiteral("color-scheme");
+
+    // Short timeout: a missing or wedged portal must not delay startup.
+    const QDBusMessage reply = sessionBus.call(request, QDBus::Block, 500);
+    if (reply.type() != QDBusMessage::ReplyMessage || reply.arguments().isEmpty())
+    {
+        return false;
+    }
+
+    return colorSchemeFromVariant(reply.arguments().constFirst(), prefersDark);
+}
+#endif
+
+}
+
+ColorScheme::ColorScheme(QObject *parent)
+    : QObject(parent)
+    , m_prefersDark(false)
+{
+    m_prefersDark = detect();
+
+    qApp->installEventFilter(this);
+
+#ifdef HAVE_QT_DBUS
+    QDBusConnection::sessionBus().connect(
+        QString(),
+        QStringLiteral("/org/freedesktop/portal/desktop"),
+        QStringLiteral("org.freedesktop.portal.Settings"),
+        QStringLiteral("SettingChanged"),
+        this,
+        SLOT(portalSettingChanged(QString, QString, QDBusVariant)));
+#endif
+
+#ifdef Q_OS_WIN
+    // Qt 5 delivers no notification when the Windows theme changes; poll the registry.
+    QTimer *timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, this, &ColorScheme::refresh);
+    timer->start(2000);
+#endif
+}
+
+bool ColorScheme::prefersDark() const
+{
+    return m_prefersDark;
+}
+
+bool ColorScheme::detect() const
+{
+#ifdef Q_OS_WIN
+    // Qt 5 does not reflect the Windows dark mode preference in the palette.
+    const QSettings personalize(
+        QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"),
+        QSettings::NativeFormat);
+    const QVariant appsUseLightTheme = personalize.value(QStringLiteral("AppsUseLightTheme"));
+    if (appsUseLightTheme.isValid())
+    {
+        return appsUseLightTheme.toInt() == 0;
+    }
+#endif
+
+#ifdef HAVE_QT_DBUS
+    bool prefersDark = false;
+    if (portalPrefersDark(prefersDark))
+    {
+        return prefersDark;
+    }
+#endif
+
+    return palettePrefersDark();
+}
+
+bool ColorScheme::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == qApp && (event->type() == QEvent::ApplicationPaletteChange
+                            || event->type() == QEvent::ThemeChange))
+    {
+        refresh();
+    }
+
+    return QObject::eventFilter(watched, event);
+}
+
+void ColorScheme::refresh()
+{
+    const bool prefersDark = detect();
+    if (prefersDark == m_prefersDark)
+    {
+        return;
+    }
+
+    m_prefersDark = prefersDark;
+    emit prefersDarkChanged();
+}
+
+#ifdef HAVE_QT_DBUS
+void ColorScheme::portalSettingChanged(const QString &group, const QString &key, const QDBusVariant &value)
+{
+    Q_UNUSED(value)
+
+    if (group != QStringLiteral("org.freedesktop.appearance") || key != QStringLiteral("color-scheme"))
+    {
+        return;
+    }
+
+    // Re-read through detect() so the platform precedence rules stay in one place.
+    refresh();
+}
+#endif

--- a/src/main/ColorScheme.h
+++ b/src/main/ColorScheme.h
@@ -26,30 +26,49 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import Qt.labs.platform 1.0 as PlatformLabs
-import "." as MoneroComponents
+#ifndef COLORSCHEME_H
+#define COLORSCHEME_H
 
-PlatformLabs.MenuBar {
-    PlatformLabs.Menu {
-        title: qsTr("File")
-        PlatformLabs.MenuItem {
-            enabled: appWindow.viewState === "normal"
-            text: qsTr("Close Wallet")
-            onTriggered: appWindow.showWizard()
-        }
-    }
-    PlatformLabs.Menu {
-        title: qsTr("View")
-        PlatformLabs.MenuItem {
-            text: MoneroComponents.Style.blackTheme ? qsTr("Light Theme") : qsTr("Dark Theme")
-            onTriggered: {
-                appWindow.toggleTheme();
-            }
-        }
-        PlatformLabs.MenuItem {
-            text: qsTr("Change Language")
-            onTriggered: appWindow.toggleLanguageView();
-        }
-    }
-}
+#include <QObject>
 
+#ifdef HAVE_QT_DBUS
+#include <QDBusVariant>
+#endif
+
+class QEvent;
+
+/**
+ * @brief The ColorScheme class - exports the OS light/dark preference to QML
+ *
+ * Consulted by MoneroComponents.Style when the theme setting is "system".
+ */
+class ColorScheme : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool prefersDark READ prefersDark NOTIFY prefersDarkChanged)
+
+public:
+    explicit ColorScheme(QObject *parent = nullptr);
+
+    bool prefersDark() const;
+
+signals:
+    void prefersDarkChanged();
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private slots:
+    void refresh();
+
+#ifdef HAVE_QT_DBUS
+    void portalSettingChanged(const QString &group, const QString &key, const QDBusVariant &value);
+#endif
+
+private:
+    bool detect() const;
+
+    bool m_prefersDark;
+};
+
+#endif // COLORSCHEME_H

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -41,6 +41,7 @@
 #include <version.h>
 
 #include "clipboardAdapter.h"
+#include "ColorScheme.h"
 #include "filter.h"
 #include "oscursor.h"
 #include "oshelper.h"
@@ -464,6 +465,8 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
     engine.rootContext()->setContextProperty("globalCursor", &cursor);
     OSHelper osHelper;
     engine.rootContext()->setContextProperty("oshelper", &osHelper);
+    ColorScheme colorScheme;
+    engine.rootContext()->setContextProperty("colorScheme", &colorScheme);
 
     engine.addImportPath(":/fonts");
 


### PR DESCRIPTION
Closes #3660.

Replaces the "Light theme" checkbox in Settings → Interface with a System / Light / Dark selector. When set to System, the wallet follows the desktop's colour-scheme preference and updates live, without a restart.

### Approach

`Style.blackTheme` becomes a read-only property derived from a new `Style.theme` tri-state (`"system"`, `"light"`, `"dark"`). All 34 files that read `Style.blackTheme` are untouched — only the four sites that wrote to it are updated. Making the derived property `readonly` means any future write is a load-time error rather than a silently broken binding.

System detection is a small `ColorScheme` QObject exposed to QML:

- **Linux**: reads `org.freedesktop.appearance color-scheme` from  xdg-desktop-portal and subscribes to `SettingChanged` for live updates. 
- **Fallback**: compares the `Window` and `WindowText` lightness of the  application palette, which covers macOS and Linux setups with a Qt platform  theme plugin.
- **Windows**: Qt 5 does not reflect the preference in the palette, so it reads  `AppsUseLightTheme` from the registry.

`Qt5DBus` is an **optional** build dependency — when it is not found, the palette fallback is used and nothing else changes. This avoids touching the depends/Guix setup.

The portal path exists because the palette heuristic is not sufficient on its own: on desktops that do not theme Qt applications (COSMIC, and any setup where the Qt palette comes from a static qt5ct profile), the palette never reflects the user's actual choice.

### Migration

The existing `blackTheme` setting is migrated to the new `theme` key on first run, and the legacy key is kept in sync afterwards so downgrading to an earlier release preserves the user's choice. The default for new profiles is unchanged (dark).

### Testing

Pop!_OS 24.04, COSMIC, Wayland, Qt 5.15.13:

- Dark theme is visually unchanged from before.
- Selector persists across restarts; light and dark both apply correctly.
- With System selected, toggling COSMIC → Appearance switches the wallet live  in both directions (screenshots below).
- Migration from a config containing only `blackTheme=false` resolves to  `theme=light`, verified with the migration path instrumented.

Not verified: the migrated value being written to disk on the first upgrade run specifically. Settings writes are disabled on the wizard path (`WizardLanguage.qml` calls `setWritable(false)`), so this needs a profile with
an existing wallet to exercise end to end.

macOS and Windows are untested — I don't have access to either.

### Screenshots
<img width="3793" height="1981" alt="dark" src="https://github.com/user-attachments/assets/37d52e87-84df-49d2-852b-cd6e967ea5e8" />
<img width="3793" height="1981" alt="light" src="https://github.com/user-attachments/assets/670b0fdc-7cb4-4c99-ba44-a0b07dcfee98" />
<img width="3793" height="1981" alt="system toggle dark" src="https://github.com/user-attachments/assets/db6423ac-11aa-4b2c-ba7b-b7a4711d4bdc" />
<img width="3793" height="1981" alt="system toggle light" src="https://github.com/user-attachments/assets/526a4030-d297-482a-8d90-78553d07b060" />
