### PR TITLE
qml: fix restore height from a date typed without hyphens

### DIFF
--- a/js/Utils.js
+++ b/js/Utils.js
@@ -121,7 +121,7 @@ function parseDateStringOrRestoreHeightAsInteger(value) {
     var restoreHeight = 0;
     if (value.indexOf('-') === 4 && value.length === 10) {
         restoreHeight = Wizard.getApproximateBlockchainHeight(value, Utils.netTypeToString());
-    } else if (parseInt(value.substring(0, 4)) >= 2014 && parseInt(value.substring(0, 4)) <= 2025 && value.length === 8) {
+    } else if (parseInt(value.substring(0, 4)) >= 2014 && parseInt(value.substring(0, 4)) <= new Date().getFullYear() && value.length === 8) {
         // Correct date typed in a wrong format (20201225 instead of 2020-12-25)
         var restoreHeightHyphenated = value.substring(0, 4) + "-" + value.substring(4, 6) + "-" + value.substring(6, 8);
         restoreHeight = Wizard.getApproximateBlockchainHeight(restoreHeightHyphenated, Utils.netTypeToString());

--- a/tests/qml/tst_Utils.qml
+++ b/tests/qml/tst_Utils.qml
@@ -1,0 +1,75 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import QtQuick 2.9
+import QtTest 1.2
+
+import "../../js/Utils.js" as Utils
+import "../../js/Wizard.js" as Wizard
+
+Item {
+    id: appWindow
+
+    property alias persistentSettings: persistentSettings
+
+    QtObject {
+        id: persistentSettings
+        // NetworkType.MAINNET, spelled out so this file needs no wallet backend
+        property int nettype: 0
+    }
+
+    TestCase {
+        name: "Utils"
+
+        function test_restore_height_stays_a_height() {
+            compare(Utils.parseDateStringOrRestoreHeightAsInteger("0"), 0)
+            compare(Utils.parseDateStringOrRestoreHeightAsInteger("1234567"), 1234567)
+        }
+
+        function test_hyphenated_date_becomes_a_height() {
+            var height = Utils.parseDateStringOrRestoreHeightAsInteger("2020-12-25")
+            compare(height, Wizard.getApproximateBlockchainHeight("2020-12-25", "Mainnet"))
+            verify(height > 0)
+        }
+
+        function test_compact_date_matches_hyphenated_date() {
+            // A date typed without hyphens has to keep working as the years go by,
+            // otherwise it silently turns into a restore height millions of blocks
+            // into the future.
+            var year = new Date().getFullYear()
+            var compact = Utils.parseDateStringOrRestoreHeightAsInteger(year + "0315")
+            compare(compact, Utils.parseDateStringOrRestoreHeightAsInteger(year + "-03-15"))
+            verify(compact > 0)
+        }
+
+        function test_compact_number_before_monero_stays_a_height() {
+            compare(Utils.parseDateStringOrRestoreHeightAsInteger("20130315"), 20130315)
+        }
+    }
+}


### PR DESCRIPTION
The restore height field takes either a block height or a wallet creation date. `parseDateStringOrRestoreHeightAsInteger` has a fallback for the date typed without hyphens (20201225 instead of 2020-12-25). That fallback is gated on the year sitting between 2014 and a hardcoded 2025:

```js
} else if (parseInt(value.substring(0, 4)) >= 2014 && parseInt(value.substring(0, 4)) <= 2025 && value.length === 8) {
```

So it stopped firing on January 1st. Type 20260315 today and it drops through to `parseInt`. The restore height ends up as literally 20260315, far past the current tip. The wallet restores and scans nothing. You get an empty balance and no hint as to why.

Nothing downstream catches it either. The wizard's LineEdit validator is `/^(\d+|\d{4}-\d{2}-\d{2})$/` so eight digits pass, and SettingsInfo only checks the result is a number and not negative.

Three call sites: wizard/WizardRestoreWallet1.qml, wizard/WizardCreateDevice1.qml, pages/settings/SettingsInfo.qml.

The change is the upper bound: `new Date().getFullYear()` instead of 2025, so the window cannot expire again.

I also added tests/qml/tst_Utils.qml. The date case builds both spellings of a date in the current year and asserts they land on the same height. That stays valid every year. The other three pin down what should not change: a plain height stays a height, a hyphenated date goes through the estimator, and eight digits starting before 2014 are still read as a height.

The file only imports QtQuick and QtTest. The existing `--test-qml` runner picks it up, and it also runs on its own, which is how I checked it here without building the GUI. On this branch:

```
$ QT_QPA_PLATFORM=offscreen qmltestrunner-qt5 -input tests/qml/tst_Utils.qml 2>&1 | grep -vE "QDEBUG|Loc:"
********* Start testing of qmltestrunner *********
Config: Using QtTest library 5.15.19, Qt 5.15.19 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 16.1.1 20260430), endeavouros unknown
PASS   : qmltestrunner::Utils::initTestCase()
PASS   : qmltestrunner::Utils::test_compact_date_matches_hyphenated_date()
PASS   : qmltestrunner::Utils::test_compact_number_before_monero_stays_a_height()
PASS   : qmltestrunner::Utils::test_hyphenated_date_becomes_a_height()
PASS   : qmltestrunner::Utils::test_restore_height_stays_a_height()
PASS   : qmltestrunner::Utils::cleanupTestCase()
Totals: 6 passed, 0 failed, 0 skipped, 0 blacklisted, 2ms
********* Finished testing of qmltestrunner *********
```

With js/Utils.js put back to master and the test kept, same command:

```
********* Start testing of qmltestrunner *********
Config: Using QtTest library 5.15.19, Qt 5.15.19 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 16.1.1 20260430), endeavouros unknown
PASS   : qmltestrunner::Utils::initTestCase()
FAIL!  : qmltestrunner::Utils::test_compact_date_matches_hyphenated_date() Compared values are not the same
   Actual   (): 20260315
   Expected (): 3611428
PASS   : qmltestrunner::Utils::test_compact_number_before_monero_stays_a_height()
PASS   : qmltestrunner::Utils::test_hyphenated_date_becomes_a_height()
PASS   : qmltestrunner::Utils::test_restore_height_stays_a_height()
PASS   : qmltestrunner::Utils::cleanupTestCase()
Totals: 5 passed, 1 failed, 0 skipped, 0 blacklisted, 1ms
********* Finished testing of qmltestrunner *********
```

The grep only drops the `Calculated blockchain height:` logging from `getApproximateBlockchainHeight` plus the local source path on the failure line. qmllint is clean on the new file under Qt 5.15.19 and Qt 6.11.1.
