### PR TITLE
security: remove sensitive data from logs and escape HTML in tx details

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -545,7 +545,6 @@ ApplicationWindow {
                         errorMessage += "\n" + qsTr("Make sure your Trezor is connected and unlocked.");
                     }
                     passwordDialog.showError(errorMessage);
-                    console.log("closing wallet async : " + wallet.address)
                     closeWallet();
                     return;
             }
@@ -1075,10 +1074,8 @@ ApplicationWindow {
             var result = currentWallet.getReserveProof(false, currentWallet.currentSubaddressAccount, amount, message)
             txProofComputed(null, result)
         } else {
-            console.log("Getting payment proof: ")
-            console.log("\ttxid: ", txid,
-                        ", address: ", address,
-                        ", message: ", message);
+            // Don't log txid/address/message; payment-proof signatures are
+            // sensitive and must not end up in the logs.
             function spendProofFallback(txid, result){
                 if (!result || result.indexOf("error|") === 0) {
                     currentWallet.getSpendProofAsync(txid, message, txProofComputed);
@@ -1107,11 +1104,8 @@ ApplicationWindow {
 
     // called on "checkProof"
     function handleCheckProof(txid, address, message, signature) {
-        console.log("Checking payment proof: ")
-        console.log("\ttxid: ", txid,
-                    ", address: ", address,
-                    ", message: ", message,
-                    ", signature: ", signature);
+        // Don't log txid/address/message/signature; payment-proof signatures
+        // are sensitive and must not end up in the logs.
 
         var result;
         var isReserveProof = signature.indexOf("ReserveProofV") === 0;

--- a/pages/AddressBook.qml
+++ b/pages/AddressBook.qml
@@ -151,7 +151,6 @@ Rectangle {
                         color: itemMouseArea.containsMouse ? MoneroComponents.Style.titleBarButtonHoverColor : "transparent"
 
                         function doSend() {
-                            console.log("Sending to: ", address +" "+ paymentId);
                             middlePanel.sendTo(address, paymentId);
                             leftPanel.selectItem(middlePanel.state)
                         }

--- a/pages/History.qml
+++ b/pages/History.qml
@@ -1719,7 +1719,6 @@ Rectangle {
             console.log('getProof: Error checking TxId and/or address');
         }
 
-        console.log("getProof: Generate clicked: txid " + hash + ", address " + address);
         middlePanel.getProofClicked(hash, address, '', null);
         informationPopup.title  = qsTr("Payment proof") + translationManager.emptyString;
         informationPopup.text = qsTr("Generating payment proof") + "..." + translationManager.emptyString;
@@ -1738,17 +1737,21 @@ Rectangle {
             trMiddle = '</b></td><td style="padding-left:10px;padding-top:5px;">',
             trEnd = "</td></tr>";
 
+        // destinations may intentionally contain "<br>" separators inserted by the wallet backend;
+        // escape everything first, then restore the literal "<br>" so line breaks are preserved.
+        destinations = Utils.htmlEscape(destinations).replace(/&lt;br&gt;/g, '<br>');
+
         return '<table border="0">'
-            + (tx_id ? trStart + qsTr("Tx ID:") + trMiddle + tx_id + trEnd : "")
-            + (dateTime ? trStart + qsTr("Date") + ":" + trMiddle + dateTime + trEnd : "")
-            + (amount ? trStart + qsTr("Amount") + ":" + trMiddle + amount + trEnd : "")
-            + (address ? trStart + qsTr("Address:") + trMiddle + address + trEnd : "")
-            + (paymentId ? trStart + qsTr("Payment ID:") + trMiddle + paymentId + trEnd : "")
-            + (integratedAddress ? trStart + qsTr("Integrated address") + ":" + trMiddle + integratedAddress + trEnd : "")
-            + (tx_key ? trStart + qsTr("Tx key:") + trMiddle + tx_key + trEnd : "")
+            + (tx_id ? trStart + qsTr("Tx ID:") + trMiddle + Utils.htmlEscape(tx_id) + trEnd : "")
+            + (dateTime ? trStart + qsTr("Date") + ":" + trMiddle + Utils.htmlEscape(dateTime) + trEnd : "")
+            + (amount ? trStart + qsTr("Amount") + ":" + trMiddle + Utils.htmlEscape(amount) + trEnd : "")
+            + (address ? trStart + qsTr("Address:") + trMiddle + Utils.htmlEscape(address) + trEnd : "")
+            + (paymentId ? trStart + qsTr("Payment ID:") + trMiddle + Utils.htmlEscape(paymentId) + trEnd : "")
+            + (integratedAddress ? trStart + qsTr("Integrated address") + ":" + trMiddle + Utils.htmlEscape(integratedAddress) + trEnd : "")
+            + (tx_key ? trStart + qsTr("Tx key:") + trMiddle + Utils.htmlEscape(tx_key) + trEnd : "")
             + (tx_note ? trStart + qsTr("Tx note:") + trMiddle + Utils.htmlEscape(tx_note) + trEnd : "")
             + (destinations ? trStart + qsTr("Destinations:") + trMiddle + destinations + trEnd : "")
-            + (rings ? trStart + qsTr("Rings:") + trMiddle + rings + trEnd : "")
+            + (rings ? trStart + qsTr("Rings:") + trMiddle + Utils.htmlEscape(rings) + trEnd : "")
             + "</table>"
             + translationManager.emptyString;
     }

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -148,7 +148,6 @@ Rectangle {
                 text: qsTr("Generate") + translationManager.emptyString
                 enabled: TxUtils.checkTxID(getProofTxIdLine.text) && (getProofAddressLine.text.length == 0 || TxUtils.checkAddress(getProofAddressLine.text, appWindow.persistentSettings.nettype)) || getReserveProofAmtLine.text.length != 0 && walletManager.amountFromString(getReserveProofAmtLine.text) < appWindow.getUnlockedBalance() && walletManager.amountFromString(getReserveProofAmtLine.text) > 0
                 onClicked: {
-                    console.log("getProof: Generate clicked: txid " + getProofTxIdLine.text + ", address " + getProofAddressLine.text + ", message: " + getProofMessageLine.text);
                     middlePanel.getProofClicked(getProofTxIdLine.text, getProofAddressLine.text, getProofMessageLine.text, getReserveProofAmtLine.text)
                 }
             }
@@ -233,7 +232,6 @@ Rectangle {
                 text: qsTr("Check") + translationManager.emptyString
                 enabled: (TxUtils.checkTxID(checkProofTxIdLine.text) && TxUtils.checkSignature(checkProofSignatureLine.text) && ((checkProofSignatureLine.text.indexOf("SpendProofV") === 0 && checkProofAddressLine.text.length == 0) || (checkProofSignatureLine.text.indexOf("SpendProofV") !== 0 && TxUtils.checkAddress(checkProofAddressLine.text, appWindow.persistentSettings.nettype)))) || (TxUtils.checkSignature(checkProofSignatureLine.text) && checkProofSignatureLine.text.indexOf("ReserveProofV") === 0 && TxUtils.checkAddress(checkProofAddressLine.text, appWindow.persistentSettings.nettype))
                 onClicked: {
-                    console.log("checkProof: Check clicked: txid " + checkProofTxIdLine.text + ", address " + checkProofAddressLine.text + ", message " + checkProofMessageLine.text + ", signature " + checkProofSignatureLine.text);
                     middlePanel.checkProofClicked(checkProofTxIdLine.text, checkProofAddressLine.text, checkProofMessageLine.text, checkProofSignatureLine.text)
                 }
             }


### PR DESCRIPTION
## Summary

Two low-severity security hardening changes in the QML UI.

### 1. Stop logging sensitive wallet data
Several `console.log` calls wrote transaction IDs, wallet addresses, payment IDs and payment-proof signatures to the debug output:
- `pages/History.qml`: proof generation logged txid + address
- `pages/TxKey.qml`: proof generation and verification logged txid + address + signature
- `pages/AddressBook.qml`: sending logged address + paymentId
- `main.qml`: failed wallet open logged wallet.address

A payment-proof signature is a signed proof of ownership; writing it to the log alongside the txid weakens the proof's usefulness if the log ever leaks.

### 2. Escape HTML in the transaction details dialog
`buildTxDetailsString` in `pages/History.qml` builds a rich-text table (`StandardDialog` uses `TextEdit.AutoText`) with values that originate from the user or the chain. Only tx_note was escaped; the remaining fields (tx_id, address, paymentId, integratedAddress, tx_key, rings, destinations) were inserted raw. All fields are now passed through `Utils.htmlEscape()`. The intentional `<br>` line separators inside the destinations field are restored after escaping so the display is unchanged.

## Files changed
- main.qml
- pages/AddressBook.qml
- pages/History.qml
- pages/TxKey.qml

## Testing
Not built; changes are limited to removing log lines and HTML-escaping string interpolation. No functional behavior is intended to change.