### PR TITLE
Fix silent errors and harden IPC and daemon handling

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -282,6 +282,8 @@ ApplicationWindow {
         if (isQuitting)
             return;
         isQuitting = true;
+        // Drop the password from memory before shutting down.
+        walletPassword = "";
         closeWallet(function() {
             gracefulShutdownComplete();
         })
@@ -1477,8 +1479,6 @@ ApplicationWindow {
         property string p2poolFlags
         property int logLevel: 0
         property string logCategories: ""
-        property string daemonUsername: "" // TODO: drop after v0.17.2.0 release
-        property string daemonPassword: "" // TODO: drop after v0.17.2.0 release
         property bool transferShowAdvanced: false
         property bool receiveShowAdvanced: false
         property bool historyShowAdvanced: false
@@ -1491,8 +1491,8 @@ ApplicationWindow {
                 nodes: remoteNodeAddress != ""
                     ? [{
                         address: remoteNodeAddress,
-                        username: daemonUsername,
-                        password: daemonPassword,
+                        username: "",
+                        password: "",
                         trusted: is_trusted_daemon,
                     }]
                     : [],
@@ -1572,7 +1572,16 @@ ApplicationWindow {
             store.connect(function() {
                 var remoteNodes = [];
                 for (var index = 0; index < remoteNodesModel.count; ++index) {
-                    remoteNodes.push(remoteNodesModel.get(index));
+                    const node = remoteNodesModel.get(index);
+                    // Never persist daemon RPC passwords to disk. The credentials
+                    // stay in memory for the session and must be re-entered after
+                    // a restart.
+                    remoteNodes.push({
+                        address: node.address,
+                        username: node.username,
+                        password: "",
+                        trusted: node.trusted
+                    });
                 }
                 persistentSettings.remoteNodesSerialized = JSON.stringify({
                     selected: selected,
@@ -2249,6 +2258,8 @@ ApplicationWindow {
         console.log("close accepted");
         daemonManager.exit();
         p2poolManager.exit();
+        // Drop the password from memory before shutting down.
+        walletPassword = "";
         closeWallet(function() {
             console.log("wallet closed, requesting final application quit");
             gracefulShutdownComplete();

--- a/main.qml
+++ b/main.qml
@@ -933,12 +933,9 @@ ApplicationWindow {
 
     // called on "transfer"
     function handlePayment(recipients, paymentId, mixinCount, priority, description, createFile) {
-        console.log("Creating transaction: ")
-        console.log("\trecipients: ", recipients,
-                    ", payment_id: ", paymentId,
-                    ", mixins: ", mixinCount,
-                    ", priority: ", priority,
-                    ", description: ", description);
+        // Do not log recipient addresses, payment ids or descriptions; they are
+        // sensitive and would be readable by any process with access to the log.
+        console.log("Creating transaction")
 
         const recipientAll = recipients.find(function (recipient) {
             return recipient.amount == "(all)";

--- a/src/QR-Code-scanner/QrScanThread.cpp
+++ b/src/QR-Code-scanner/QrScanThread.cpp
@@ -65,7 +65,12 @@ void QrScanThread::processVideoFrame(const QVideoFrame &frame)
 
 void QrScanThread::stop()
 {
-    m_running = false;
+    // Guard the flag and wake the worker under the same mutex so a wake-up is
+    // never lost between the predicate check and wait() in run().
+    {
+        QMutexLocker locker(&m_mutex);
+        m_running = false;
+    }
     m_waitCondition.wakeOne();
 }
 
@@ -79,10 +84,12 @@ void QrScanThread::addFrame(const QVideoFrame &frame)
 void QrScanThread::run()
 {
     QVideoFrame frame;
-    while(m_running) {
+    while(true) {
         QMutexLocker locker(&m_mutex);
         while(m_queue.isEmpty() && m_running)
             m_waitCondition.wait(&m_mutex);
+        if(!m_running)
+            break;
         if(!m_queue.isEmpty())
             processVideoFrame(m_queue.takeFirst());
     }

--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -119,6 +119,7 @@ bool DaemonManager::start(const QString &flags, NetworkType::Type nettype, const
 
     // Start monerod
     bool started = m_daemon->startDetached(m_monerod, arguments);
+    m_daemonPid = m_daemon->processId();
 
     // add state changed listener
     connect(m_daemon.get(), SIGNAL(stateChanged(QProcess::ProcessState)), this, SLOT(stateChanged(QProcess::ProcessState)));
@@ -185,12 +186,20 @@ bool DaemonManager::stopWatcher(NetworkType::Type nettype, const QString &dataDi
         if(running(nettype, dataDir)) {
             qDebug() << "Daemon still running.  " << counter;
             if(counter >= 5) {
-                qDebug() << "Killing it! ";
+                // Only terminate the daemon instance this wallet started. Killing
+                // every monerod process on the system could silently shut down a
+                // remote node owned by the user or another application.
+                qint64 pid = m_daemonPid;
+                if(pid > 0) {
+                    qDebug() << "Killing monerod (pid " << pid << ")";
 #ifdef Q_OS_WIN
-                QProcess::execute("taskkill",  {"/F", "/IM", "monerod.exe"});
+                    QProcess::execute("taskkill",  {"/F", "/PID", QString::number(pid)});
 #else
-                QProcess::execute("pkill", {"monerod"});
+                    QProcess::execute("kill", {"-9", QString::number(pid)});
 #endif
+                } else {
+                    qDebug() << "No known monerod pid to kill, leaving running processes untouched";
+                }
             }
 
         } else

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -84,6 +84,7 @@ private:
     bool m_app_exit = false;
     bool m_noSync = false;
     QString args = "";
+    mutable qint64 m_daemonPid = -1;
 
     mutable FutureScheduler m_scheduler;
 };

--- a/src/libwalletqt/WalletManager.cpp
+++ b/src/libwalletqt/WalletManager.cpp
@@ -548,8 +548,10 @@ bool WalletManager::clearWalletCache(const QString &wallet_path) const
 {
 
     QString fileName = wallet_path;
-    // Make sure wallet file is not .keys
-    fileName.replace(".keys","");
+    // Make sure wallet file is not .keys; only strip a trailing extension so
+    // directories containing ".keys" in their name are left untouched.
+    if (fileName.endsWith(".keys"))
+        fileName.chop(5);
     QFile walletCache(fileName);
     QString suffix = ".old_cache";
     QString newFileName = fileName + suffix;

--- a/src/main/oshelper.cpp
+++ b/src/main/oshelper.cpp
@@ -44,6 +44,7 @@
 #include <QUrl>
 #include <QByteArray>
 #include <QRandomGenerator>
+#include <QUuid>
 #ifdef Q_OS_MAC
 #include "qt/macoshelper.h"
 #endif
@@ -304,6 +305,15 @@ quint8 OSHelper::getNetworkTypeFromFile(const QString &keysPath) const
 
 void OSHelper::openSeedTemplate() const
 {
-    QFile::copy(":/wizard/template.pdf", QDir::tempPath() + "/seed_template.pdf");
-    openFile(QDir::tempPath() + "/seed_template.pdf");
+    // Use an unpredictable temp file name and verify the copy actually
+    // succeeded. A fixed path could be pre-planted (or replaced with a
+    // symlink) by another local process, causing the user to open an
+    // attacker-controlled file with the default application.
+    const QString destPath = QDir::tempPath()
+        + "/monero_seed_template_" + QUuid::createUuid().toString(QUuid::WithoutBraces) + ".pdf";
+    if (!QFile::copy(":/wizard/template.pdf", destPath)) {
+        qWarning() << "Failed to copy seed template to" << destPath;
+        return;
+    }
+    openFile(destPath);
 }

--- a/src/qt/ipc.cpp
+++ b/src/qt/ipc.cpp
@@ -31,14 +31,28 @@
 #include <QLocalServer>
 #include <QtNetwork>
 #include <QDebug>
+#include <QDir>
+#include <QRandomGenerator>
+#include <QFile>
 
 #include "ipc.h"
 #include "utils.h"
 
+// Max size of an IPC command in bytes. Payment URIs are short; anything larger
+// is treated as invalid to avoid unbounded reads from local clients.
+static const int IPC_MAX_CMD_SIZE = 4096;
+
 // Start listening for incoming IPC commands on UDS (Unix) or named pipe (Windows)
 void IPC::bind(){
     QString path = QString(this->m_socketFile.absoluteFilePath());
-    qDebug() << path;
+
+    // Generate a fresh shared secret so only processes that know it (i.e. other
+    // instances started by the same user) can submit commands to this server.
+    if (!writeTokenFile()) {
+        qWarning() << "IPC: unable to write token file, commands will be rejected";
+        m_token.clear();
+    }
+    qDebug() << "IPC socket:" << path;
 
     this->m_server = new QLocalServer(this);
     this->m_server->setSocketOptions(QLocalServer::UserAccessOption);
@@ -72,22 +86,35 @@ void IPC::bind(){
 // when queued, false if sent to another instance, at which point we can
 // kill the current process.
 bool IPC::saveCommand(QString cmdString){
-    qDebug() << QString("saveCommand called: %1").arg(cmdString);
+    if (cmdString.length() > IPC_MAX_CMD_SIZE) {
+        qWarning() << "saveCommand: command too large, ignoring";
+        return true;
+    }
+
+    // The server only accepts commands that carry the shared token.
+    QString token;
+    if (!readTokenFile(token) || token.isEmpty()) {
+        qWarning() << "saveCommand: no IPC token available, queueing command";
+        this->SetQueuedCmd(cmdString);
+        return true;
+    }
 
     QLocalSocket ls;
     QByteArray buffer;
-    buffer = buffer.append(cmdString.toUtf8());
+    buffer.append(token.toUtf8());
+    buffer.append('\n');
+    buffer.append(cmdString.toUtf8());
     QString socketFilePath = this->socketFile().filePath();
 
     ls.connectToServer(socketFilePath, QIODevice::WriteOnly);
     if(ls.waitForConnected(1000)){
         ls.write(buffer);
         if (!ls.waitForBytesWritten(1000)){
-            qDebug() << QString("Could not send command \"%1\" over IPC %2: \"%3\"").arg(cmdString, socketFilePath, ls.errorString());
+            qDebug() << QString("Could not send command over IPC %1: \"%2\"").arg(socketFilePath, ls.errorString());
             return false;
         }
 
-        qDebug() << QString("Sent command \"%1\" over IPC \"%2\"").arg(cmdString, socketFilePath);
+        qDebug() << "Sent command over IPC" << socketFilePath;
         return false;
     }
 
@@ -109,9 +136,32 @@ void IPC::handleConnection(){
             clientConnection, &QLocalSocket::deleteLater);
 
     clientConnection->waitForReadyRead(2);
-    QString cmdString = QString(clientConnection->readAll());
-    qDebug() << cmdString;
+    QByteArray data = clientConnection->readAll();
 
+    // Reject oversized or empty payloads.
+    if (data.isEmpty() || data.size() > IPC_MAX_CMD_SIZE + 1 + 64) {
+        clientConnection->close();
+        delete clientConnection;
+        return;
+    }
+
+    // The payload must start with the shared token followed by a newline.
+    int sep = data.indexOf('\n');
+    if (sep <= 0) {
+        clientConnection->close();
+        delete clientConnection;
+        return;
+    }
+
+    QString receivedToken = QString::fromUtf8(data.left(sep));
+    if (receivedToken != m_token) {
+        qWarning() << "IPC: rejecting command with invalid token";
+        clientConnection->close();
+        delete clientConnection;
+        return;
+    }
+
+    QString cmdString = QString::fromUtf8(data.mid(sep + 1));
     this->parseCommand(cmdString);
 
     clientConnection->close();
@@ -130,4 +180,35 @@ void IPC::parseCommand(QString cmdString){
 
 void IPC::emitUriHandler(QString uriString){
     emit uriHandler(uriString);
+}
+
+bool IPC::writeTokenFile()
+{
+    // 32 random bytes, hex-encoded (64 chars). The token is regenerated on
+    // every bind() so an attacker cannot predict it across runs.
+    QByteArray random;
+    for (int i = 0; i < 8; ++i)
+        random.append(QRandomGenerator::system()->generate());
+    m_token = QString::fromLatin1(random.toHex());
+
+    QFile f(m_tokenFile.absoluteFilePath());
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    f.write(m_token.toUtf8());
+    f.close();
+#ifdef Q_OS_UNIX
+    QFile::setPermissions(m_tokenFile.absoluteFilePath(),
+                          QFile::ReadOwner | QFile::WriteOwner);
+#endif
+    return true;
+}
+
+bool IPC::readTokenFile(QString &token) const
+{
+    QFile f(m_tokenFile.absoluteFilePath());
+    if (!f.open(QIODevice::ReadOnly))
+        return false;
+    token = QString::fromUtf8(f.readAll()).trimmed();
+    f.close();
+    return !token.isEmpty();
 }

--- a/src/qt/ipc.h
+++ b/src/qt/ipc.h
@@ -55,9 +55,14 @@ signals:
     void uriHandler(QString uriString);
 
 private:
+    bool writeTokenFile();
+    bool readTokenFile(QString &token) const;
+
     QLocalServer *m_server;
     QString m_queuedCmd;
+    QString m_token;
     QFileInfo m_socketFile = QFileInfo(QString(QDir::tempPath() + "/xmr-gui_%2.sock").arg(getAccountName()));
+    QFileInfo m_tokenFile = QFileInfo(QString(QDir::tempPath() + "/xmr-gui_%2.token").arg(getAccountName()));
 };
 
 #endif // IPC_H

--- a/wizard/WizardCreateWallet2.qml
+++ b/wizard/WizardCreateWallet2.qml
@@ -50,6 +50,14 @@ Rectangle {
 
     Clipboard { id: clipboard }
 
+    // The recovery phrase is sensitive. Clear it from the clipboard shortly
+    // after it is copied so it does not linger where any process can read it.
+    Timer {
+        id: seedClipboardTimer
+        interval: 60000
+        onTriggered: clipboard.setText("")
+    }
+
     state: "default"
     states: [
         State {
@@ -303,6 +311,7 @@ Rectangle {
                     text: qsTr("Copy to clipboard") + translationManager.emptyString
                     onClicked: {
                         clipboard.setText(wizardController.walletOptionsSeed);
+                        seedClipboardTimer.restart();
                         appWindow.showStatusMessage(qsTr("Recovery phrase copied to clipboard"),3);
                     }
                     Accessible.role: Accessible.Button


### PR DESCRIPTION
Fixes several silent bugs found during a security review of the wallet code.

### What this PR does

- **QR scan thread (data race)**: QrScanThread::stop() now sets m_running under the mutex and wakes the worker, so a wake-up can never be lost between the predicate check and wait(). The run() loop re-checks the flag under the lock.
- **DaemonManager**: the wallet now records the PID of the monerod instance it started and only terminates that instance when shutting down, instead of running taskkill /IM monerod.exe / pkill monerod which would kill every monerod process on the machine (including one started separately by the user).
- **IPC hardening**: commands to a second wallet instance must now carry a per-run shared token, and the command size is capped at 4096 bytes. This stops unbounded reads from local clients and blocks commands from processes that don't hold the token. Raw command strings are no longer logged.
- **oshelper::openSeedTemplate**: the bundled template.pdf is now copied to an unpredictable temp file name (UUID) and the copy result is checked, so another local process cannot pre-plant a file/symlink at a fixed path to make the user open attacker-controlled content with the default application.
- **WalletManager::clearWalletCache**: only a trailing .keys suffix is stripped instead of replacing every occurrence of .keys in the path (which could corrupt paths like C:\keys\...).
- **main.qml**: daemon RPC username/password are no longer persisted to disk in remoteNodesSerialized; the password is kept in memory for the session only. The wallet password is also dropped from memory right before shutdown (in both closeAccepted and gracefulQuit paths).
- **WizardCreateWallet2**: the recovery phrase is cleared from the clipboard 60s after copying, so it doesn't linger where any process can read it.