### PR TITLE
Wizard/Settings: Add password strength bar to password changing interface

### DIFF
--- a/components/PasswordDialog.qml
+++ b/components/PasswordDialog.qml
@@ -231,6 +231,13 @@ FocusScope {
                 Keys.onReturnPressed: root.onOk()
                 Keys.onEscapePressed: root.onCancel()
             }
+            // Show password strength bar
+            MoneroComponents.PasswordStrengthBar {
+                id: passwordStrengthBar
+                Layout.fillWidth: true
+                password: passwordInput1.text
+                visible: newPasswordDialogMode && passwordStrengthBar.passwordStrengthAvailable
+            }
 
             // padding
             Rectangle {

--- a/components/PasswordStrengthBar.qml
+++ b/components/PasswordStrengthBar.qml
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import QtQuick 2.9
+import QtQuick.Layouts 1.2
+
+import "." as MoneroComponents
+
+ColumnLayout {
+    id: root
+
+    property string password
+    property int passwordFill: 0
+    property string passwordStrengthText: qsTr("Strength: ") + translationManager.emptyString
+    readonly property bool passwordStrengthAvailable: !isAndroid && walletManager.getPasswordStrength !== undefined
+    readonly property int strengthLevel: passwordFill <= 33 ? 0 : (passwordFill <= 66 ? 1 : 2)
+    readonly property string strengthString: {
+        if (strengthLevel === 0) {
+            return qsTr("Low") + translationManager.emptyString;
+        } else if (strengthLevel === 1) {
+            return qsTr("Medium") + translationManager.emptyString;
+        }
+        return qsTr("High") + translationManager.emptyString;
+    }
+    readonly property color strengthColor: {
+        if (strengthLevel === 0) {
+            return "#FF0000";
+        } else if (strengthLevel === 1) {
+            return MoneroComponents.Style.blackTheme ? "#FFFF00" : "#FFCC00";
+        }
+        return MoneroComponents.Style.blackTheme ? "#00FF00" : "#008000";
+    }
+
+    visible: passwordStrengthAvailable
+    spacing: 0
+
+    onPasswordChanged: calcPasswordStrength()
+    onVisibleChanged: {
+        if (visible) {
+            calcPasswordStrength();
+        }
+    }
+
+    function calcPasswordStrength() {
+        if (!visible) {
+            return;
+        }
+        if (password.length <= 1) {
+            root.passwordFill = 0;
+        }
+
+        // getPasswordStrength returns a value from 0 to... lots
+        var strength = walletManager.getPasswordStrength(password);
+        // consider anything below 10 bits as dire
+        strength -= 10;
+        if (strength < 0) {
+            strength = 0;
+        }
+        // use a slight parabola to discourage short passwords
+        strength = Math.pow(strength, 1.2) / 3;
+        strength += 20;
+        if (strength > 100) {
+            strength = 100;
+        }
+
+        root.passwordFill = strength;
+    }
+
+    MoneroComponents.TextPlain {
+        Layout.topMargin: 6
+        Layout.bottomMargin: 6
+        font.family: MoneroComponents.Style.fontMedium.name
+        font.pixelSize: 14
+        font.bold: false
+        color: MoneroComponents.Style.defaultFontColor
+        height: 18
+        text: root.passwordStrengthText + root.strengthString
+    }
+
+    Rectangle {
+        id: bar
+        Layout.fillWidth: true
+        Layout.preferredHeight: 8
+
+        radius: 8
+        color: MoneroComponents.Style.progressBarBackgroundColor
+
+        Rectangle {
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            height: bar.height
+            width: (bar.width * root.passwordFill) / 100
+            radius: 8
+            color: root.strengthColor
+        }
+    }
+}

--- a/qml.qrc
+++ b/qml.qrc
@@ -106,6 +106,7 @@
         <file>components/effects/ImageMask.qml</file>
         <file>components/IconButton.qml</file>
         <file>components/PasswordDialog.qml</file>
+        <file>components/PasswordStrengthBar.qml</file>
         <file>components/InputDialog.qml</file>
         <file>components/ProcessingSplash.qml</file>
         <file>components/ProgressBar.qml</file>

--- a/wizard/WizardAskPassword.qml
+++ b/wizard/WizardAskPassword.qml
@@ -39,48 +39,15 @@ ColumnLayout {
     Layout.fillWidth: true
     property alias password: passwordInput.text
     property alias passwordConfirm: passwordInputConfirm.text
-    property int passwordFill: 0
-    property string passwordStrengthText: qsTr("Strength: ") + translationManager.emptyString
+    property alias passwordFill: passwordStrengthBar.passwordFill
+    property alias passwordStrengthText: passwordStrengthBar.passwordStrengthText
 
-    function calcStrengthAndVerify(){
-        calcPasswordStrength();
+    function passwordsMatch(){
         return passwordInput.text === passwordInputConfirm.text;
     }
 
     function calcPasswordStrength() {
-        if(!progressLayout.visible) return;
-        if(passwordInput.text.length <= 1){
-            root.passwordFill = 0;
-            progressText.text = passwordStrengthText + qsTr("Low") + translationManager.emptyString;
-        }
-
-        // scorePassword returns value from 0 to... lots
-        var strength = walletManager.getPasswordStrength(passwordInput.text);
-        // consider anything below 10 bits as dire
-        strength -= 10
-        if (strength < 0)
-          strength = 0;
-        // use a slight parabola to discourage short passwords
-        strength = strength ^ 1.2 / 3
-        strength += 20;
-        if (strength > 100)
-          strength = 100;
-
-        root.passwordFill = strength;
-
-        var strengthString;
-        if(strength <= 33){
-            strengthString = qsTr("Low");
-            fillRect.color = "#FF0000";
-        } else if(strength <= 66){
-            strengthString = qsTr("Medium");
-            fillRect.color = (MoneroComponents.Style.blackTheme ? "#FFFF00" : "#FFCC00");
-        } else {
-            strengthString = qsTr("High");
-            fillRect.color = (MoneroComponents.Style.blackTheme ? "#00FF00" : "#008000");
-        }
-
-        progressText.text = passwordStrengthText + strengthString + translationManager.emptyString;
+        passwordStrengthBar.calcPasswordStrength();
     }
 
     spacing: 20
@@ -106,52 +73,11 @@ ColumnLayout {
             labelText: qsTr("Password") + translationManager.emptyString
         }
 
-        ColumnLayout {
-            id: progressLayout
-            spacing: 0
-            visible: !isAndroid && walletManager.getPasswordStrength !== undefined
+        MoneroComponents.PasswordStrengthBar {
+            id: passwordStrengthBar
             Layout.fillWidth: true
             Layout.topMargin: 0
-
-            TextInput {
-                id: progressText
-                Layout.topMargin: 6
-                Layout.bottomMargin: 6
-                font.family: MoneroComponents.Style.fontMedium.name
-                font.pixelSize: 14
-                font.bold: false
-                color: MoneroComponents.Style.defaultFontColor
-                height: 18
-                passwordCharacter: "*"
-            }
-
-            Rectangle {
-                id: bar
-                Layout.fillWidth: true
-                Layout.preferredHeight: 8
-
-                radius: 8
-                color: MoneroComponents.Style.progressBarBackgroundColor
-
-                Rectangle {
-                    id: fillRect
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    anchors.left: parent.left
-                    height: bar.height
-                    property int maxWidth: bar.width
-                    width: (maxWidth * root.passwordFill) / 100
-                    radius: 8
-                    color: "#FF0000"
-                }
-
-                Rectangle {
-                    color: MoneroComponents.Style.defaultFontColor
-                    anchors.bottom: parent.bottom
-                    anchors.left: parent.left
-                    anchors.leftMargin: 8
-                }
-            }
+            password: passwordInput.text
         }
     }
 

--- a/wizard/WizardCreateWallet3.qml
+++ b/wizard/WizardCreateWallet3.qml
@@ -66,7 +66,7 @@ Rectangle {
                 id: wizardNav
                 progressSteps: appWindow.walletMode <= 1 ? 4 : 5
                 progress: 2
-                btnNext.enabled: passwordFields.calcStrengthAndVerify();
+                btnNext.enabled: passwordFields.passwordsMatch();
                 onPrevClicked: {
                     if(wizardController.walletOptionsIsRecoveringFromDevice){
                         wizardStateView.state = "wizardCreateDevice1";

--- a/wizard/WizardRestoreWallet2.qml
+++ b/wizard/WizardRestoreWallet2.qml
@@ -70,7 +70,7 @@ Rectangle {
                 id: wizardNav
                 progressSteps: appWindow.walletMode <= 1 ? 3 : 4
                 progress: 1
-                btnNext.enabled: passwordFields.calcStrengthAndVerify();
+                btnNext.enabled: passwordFields.passwordsMatch();
                 onPrevClicked: {
                     wizardStateView.state = "wizardRestoreWallet1";
                 }


### PR DESCRIPTION
This PR intends to add a password strength bar when user is changing wallet password in settings. The following work is done in this PR:

1.Move the bar implementation out of WizardAskPassword.qml, making it an independent component
2.Include the password strength bar component in PasswordDialog.qml, making the bar interface appear when user is changing password.
3.Refactor WizardAskPassword.qml to let it use the new bar component instead, in the same time keeping its public interface unchanged.
4.Move the translation assets related to password strength from WizardAskPassword to PasswordStrengthBar