### PR TITLE
qml: fix broken leading-zero stripping in amount fields

### DIFF
--- a/js/Utils.js
+++ b/js/Utils.js
@@ -116,6 +116,26 @@ function removeTrailingZeros(value) {
     return (value + '').replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
 }
 
+// Strips a redundant leading zero from an amount field as it's typed
+// (007 -> 7, 05 -> 5) and adjusts the cursor to stay in place. Also
+// turns a leading "." into "0." so the field doesn't start on a dot.
+// Takes the TextInput's current text/cursorPosition and returns the
+// corrected pair; the caller assigns both back to the field.
+function stripLeadingZeros(text, cursorPosition) {
+    const match = text.match(/^0+(\d.*)/);
+    if (match) {
+        const oldCursorPosition = cursorPosition;
+        text = match[1];
+        cursorPosition = Math.max(oldCursorPosition, 1) - 1;
+    } else if (text.indexOf('.') === 0) {
+        text = '0' + text;
+        if (text.length > 2) {
+            cursorPosition = 1;
+        }
+    }
+    return { text: text, cursorPosition: cursorPosition };
+}
+
 function parseDateStringOrRestoreHeightAsInteger(value) {
     // Parse date string or restore height as integer
     var restoreHeight = 0;

--- a/pages/Receive.qml
+++ b/pages/Receive.qml
@@ -44,6 +44,7 @@ import moneroComponents.TransactionHistoryModel 1.0
 import moneroComponents.Subaddress 1.0
 import moneroComponents.SubaddressModel 1.0
 import "../js/TxUtils.js" as TxUtils
+import "../js/Utils.js" as Utils
 
 Rectangle {
     id: pageReceive
@@ -262,17 +263,9 @@ Rectangle {
                     }
                     onTextEdited: {
                         text = text.trim().replace(",", ".");
-                        const match = text.match(/^0+(\d.*)/);
-                        if (match) {
-                            const cursorPosition = cursorPosition;
-                            text = match[1];
-                            cursorPosition = Math.max(cursorPosition, 1) - 1;
-                        } else if(text.indexOf('.') === 0){
-                            text = '0' + text;
-                            if (text.length > 2) {
-                                cursorPosition = 1;
-                            }
-                        }
+                        const corrected = Utils.stripLeadingZeros(text, cursorPosition);
+                        text = corrected.text;
+                        cursorPosition = corrected.cursorPosition;
                         if (amountToReceiveFiat.text == "") {
                             amountToReceiveXMR.text = "";
                         } else {
@@ -322,17 +315,9 @@ Rectangle {
                     }
                     onTextEdited: {
                         text = text.trim().replace(",", ".");
-                        const match = text.match(/^0+(\d.*)/);
-                        if (match) {
-                            const cursorPosition = cursorPosition;
-                            text = match[1];
-                            cursorPosition = Math.max(cursorPosition, 1) - 1;
-                        } else if(text.indexOf('.') === 0){
-                            text = '0' + text;
-                            if (text.length > 2) {
-                                cursorPosition = 1;
-                            }
-                        }
+                        const corrected = Utils.stripLeadingZeros(text, cursorPosition);
+                        text = corrected.text;
+                        cursorPosition = corrected.cursorPosition;
                         if (amountToReceiveXMR.text == "") {
                             amountToReceiveFiat.text = "";
                         } else {

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -505,17 +505,9 @@ Rectangle {
                                 text: amount
                                 onTextChanged: {
                                     text = text.trim().replace(",", ".");
-                                    const match = text.match(/^0+(\d.*)/);
-                                    if (match) {
-                                        const cursorPosition = cursorPosition;
-                                        text = match[1];
-                                        cursorPosition = Math.max(cursorPosition, 1) - 1;
-                                    } else if(text.indexOf('.') === 0){
-                                        text = '0' + text;
-                                        if (text.length > 2) {
-                                            cursorPosition = 1;
-                                        }
-                                    }
+                                    const corrected = Utils.stripLeadingZeros(text, cursorPosition);
+                                    text = corrected.text;
+                                    cursorPosition = corrected.cursorPosition;
                                     error = walletManager.amountFromString(text) > appWindow.getUnlockedBalance();
 
                                     amount = text;

--- a/pages/TxKey.qml
+++ b/pages/TxKey.qml
@@ -35,6 +35,7 @@ import "../components" as MoneroComponents
 import moneroComponents.Clipboard 1.0
 
 import "../js/TxUtils.js" as TxUtils
+import "../js/Utils.js" as Utils
 
 Rectangle {
     color: "transparent"
@@ -112,20 +113,12 @@ Rectangle {
                 enabled: getProofAddressLine.text.length === 0 && getProofTxIdLine.text.length === 0
                 onTextChanged: {
                     text = text.trim().replace(",", ".");
-                    const match = text.match(/^0+(\d.*)/);
-                    if (match) {
-                        const cursorPosition = cursorPosition;
-                        text = match[1];
-                        cursorPosition = Math.max(cursorPosition, 1) - 1;
-                        } else if(text.indexOf('.') === 0) {
-                            text = '0' + text;
-                            if (text.length > 2) {
-                                cursorPosition = 1;
-                            }
-                        }
-                        error = walletManager.amountFromString(text) > appWindow.getUnlockedBalance();
-                    }
-                    validator: RegExpValidator {
+                    const corrected = Utils.stripLeadingZeros(text, cursorPosition);
+                    text = corrected.text;
+                    cursorPosition = corrected.cursorPosition;
+                    error = walletManager.amountFromString(text) > appWindow.getUnlockedBalance();
+                }
+                validator: RegExpValidator {
                     regExp: /^\s*(\d{1,8})?([\.,]\d{1,12})?\s*$/
                 }
             }


### PR DESCRIPTION
The leading-zero branch in the amount input handlers declares:

```js
if (match) {
    const cursorPosition = cursorPosition;
    text = match[1];
    cursorPosition = Math.max(cursorPosition, 1) - 1;
}
```

The local `const` reuses the property name `cursorPosition` for the new
binding and for its own initializer. Under let/const scoping the
right-hand side resolves to the not-yet-initialized local binding
instead of the property on the item. The declaration throws. The block
never gets past that line. `text = match[1]` and the cursor position
update never run.

In practice this means typing a redundant leading zero followed by a
digit (007, 05, ...) into any of these fields does not get corrected.
The same exception fires again on every keystroke after that, as long
as the leading zero is still there.

Same block, same bug, in four places: the send amount field in
Transfer, both payment request amount fields in Receive, and the
reserve proof amount field in TxKey.

Fix: rename the local variable so it stops shadowing the property. The
rest of the logic is unchanged.

I have no build of the GUI to click through the actual pages. So I
isolated the exact code from the unpatched and patched handlers into a
standalone TestCase, not part of this diff, just local verification,
and ran it with qmltestrunner-qt5 against Qt 5.15.19:

```
QDEBUG : ...test_buggy_throws_on_leading_zero() qml: buggy() threw: true (ReferenceError: cursorPosition is not defined)
PASS   : ...test_buggy_throws_on_leading_zero()
PASS   : ...test_fixed_strips_leading_zero()
Totals: 4 passed, 0 failed, 0 skipped, 0 blacklisted, 11ms
```

Same result under Qt 6.11.1 qmltestrunner. qmllint is clean on all
three modified files before and after this change. Same output, none,
both times.
