### PR TITLE
tests: make QML test harness opt-in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: install dependencies
       run: HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi ninja openssl zmq libsodium unbound protobuf qt5 pkg-config
     - name: build
-      run: DEV_MODE=ON make release
+      run: DEV_MODE=ON QML_TESTS=ON make release
     - name: test qml
       run: build/release/bin/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui --test-qml
 
@@ -42,7 +42,7 @@ jobs:
     - name: install monero gui dependencies
       run: sudo apt -y install qtbase5-dev qtdeclarative5-dev qml-module-qtqml-models2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-xmllistmodel qml-module-qt-labs-settings qml-module-qt-labs-platform qml-module-qt-labs-folderlistmodel qml-module-qttest qttools5-dev-tools qml-module-qtquick-templates2 libqt5svg5-dev libgcrypt20-dev xvfb
     - name: build
-      run: DEV_MODE=ON make release
+      run: DEV_MODE=ON QML_TESTS=ON make release
     - name: test qml
       run: xvfb-run -a build/release/bin/monero-wallet-gui --test-qml
 
@@ -66,7 +66,7 @@ jobs:
         cp -f "$MSYSTEM_PREFIX/bin/qmake-qt5.exe" "$MSYSTEM_PREFIX/bin/qmake.exe"
         cp -f "$MSYSTEM_PREFIX/bin/windeployqt-qt5.exe" "$MSYSTEM_PREFIX/bin/windeployqt.exe"
     - name: build
-      run: DEV_MODE=ON make release-win64
+      run: DEV_MODE=ON QML_TESTS=ON make release-win64
     - name: deploy
       run: cmake --build . --target deploy
       working-directory: build/release
@@ -106,8 +106,8 @@ jobs:
     - name: deploy
       run: cmake --build . --target deploy
       working-directory: build
-    - name: test qml
-      run: build/bin/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui --test-qml
+    - name: check qml startup
+      run: build/bin/monero-wallet-gui.app/Contents/MacOS/monero-wallet-gui --check-qml
     - name: create .tar
       run: tar -cf monero-wallet-gui.tar monero-wallet-gui.app
       working-directory: build/bin
@@ -132,8 +132,8 @@ jobs:
       run: docker run --rm -v /home/runner/work/monero-gui/monero-gui:/monero-gui -w /monero-gui monero:build-env-linux sh -c 'make release-static'
     - name: sha256sum
       run: shasum -a256 /home/runner/work/monero-gui/monero-gui/build/release/bin/monero-wallet-gui
-    - name: test qml
-      run: xvfb-run -a /home/runner/work/monero-gui/monero-gui/build/release/bin/monero-wallet-gui --test-qml
+    - name: check qml startup
+      run: xvfb-run -a /home/runner/work/monero-gui/monero-gui/build/release/bin/monero-wallet-gui --check-qml
     - uses: actions/upload-artifact@v7
       with:
         name: ${{ github.job }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(WITH_SCANNER "Enable webcam QR scanner" OFF)
 option(WITH_DESKTOP_ENTRY "Ask to install desktop entry on first startup" ON)
 option(WITH_UPDATER "Regularly check for new updates" ON)
 option(DEV_MODE "Checkout latest monero master on build" OFF)
-cmake_dependent_option(QML_TESTS "Build QML tests" ON "NOT STATIC;NOT ANDROID;NOT IOS" OFF)
+cmake_dependent_option(QML_TESTS "Build QML tests" OFF "NOT STATIC;NOT ANDROID;NOT IOS" OFF)
 option(SKIP_OPTIONAL_MONERO_BINARIES "Don't build optional monero binaries" ON)
 
 if(DEV_MODE)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ANDROID_STANDALONE_TOOLCHAIN_PATH ?= /usr/local/toolchain
 MANUAL_SUBMODULES ?= OFF
+QML_TESTS ?= OFF
 
 dotgit=$(shell ls -d .git/config)
 ifeq ($(dotgit), .git/config)
@@ -25,42 +26,42 @@ ifeq ($(USE_SINGLE_BUILDDIR), OFF)
 endif
 
 default:
-	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release .. && cmake --build .
+	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release .. && cmake --build .
 debug:
-	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D CMAKE_BUILD_TYPE=Debug .. && cmake --build . --verbose
+	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D CMAKE_BUILD_TYPE=Debug .. && cmake --build . --verbose
 
 depends:
 	mkdir -p build/$(target)/release
-	cd build/$(target)/release && cmake -G Ninja -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D BUILD_TAG=$(tag) -D CMAKE_BUILD_TYPE=Release -D CMAKE_TOOLCHAIN_FILE=$(root)/$(target)/share/toolchain.cmake ../../.. && cmake --build .
+	cd build/$(target)/release && cmake -G Ninja -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D BUILD_TAG=$(tag) -D CMAKE_BUILD_TYPE=Release -D CMAKE_TOOLCHAIN_FILE=$(root)/$(target)/share/toolchain.cmake ../../.. && cmake --build .
 
 devmode:
-	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release .. && cmake --build .
+	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release .. && cmake --build .
 clean:
 	mkdir -p build && cd build && rm -rf *
 scanner:
-	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D WITH_SCANNER=ON -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release .. && cmake --build .
+	mkdir -p build && cd build && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D WITH_SCANNER=ON -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release .. && cmake --build .
 
 release:
-	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D CMAKE_BUILD_TYPE=Release $(topdir) && cmake --build .
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D CMAKE_BUILD_TYPE=Release $(topdir) && cmake --build .
 
 release-linux-armv8:
-	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -D ARCH="armv8-a" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="linux-armv8" $(topdir) && cmake --build .
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -D ARCH="armv8-a" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="linux-armv8" $(topdir) && cmake --build .
 
 release-linux-ppc64le:
-	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="ppc64le" -D CMAKE_BUILD_TYPE=Release $(topdir) && cmake --build .
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="ppc64le" -D CMAKE_BUILD_TYPE=Release $(topdir) && cmake --build .
 
 release-static:
-	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release $(topdir) && cmake --build .
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -G Ninja -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release $(topdir) && cmake --build .
 
 debug-static-win64:
-	mkdir -p $(builddir)/debug && cd $(builddir)/debug && cmake -D STATIC=ON -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Debug -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=$(topdir)/cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) -D MINGW=ON $(topdir) && cmake --build .
+	mkdir -p $(builddir)/debug && cd $(builddir)/debug && cmake -D STATIC=ON -G Ninja -D DEV_MODE=$(or ${DEV_MODE},ON) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Debug -D BUILD_TAG="win-x64" -D CMAKE_TOOLCHAIN_FILE=$(topdir)/cmake/64-bit-toolchain.cmake -D MSYS2_FOLDER=$(shell cd ${MINGW_PREFIX}/.. && pwd -W) -D MINGW=ON $(topdir) && cmake --build .
 
 debug-static-mac64:
 	mkdir -p $(builddir)/debug
-	cd $(builddir)/debug && cmake -G Ninja -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},ON) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Debug -D BUILD_TAG="mac-x64" $(topdir) && cmake --build .
+	cd $(builddir)/debug && cmake -G Ninja -D STATIC=ON -D DEV_MODE=$(or ${DEV_MODE},ON) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Debug -D BUILD_TAG="mac-x64" $(topdir) && cmake --build .
 
 release-static-win64:
-	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -D STATIC=ON -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" $(topdir) && cmake --build .
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -D STATIC=ON -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" $(topdir) && cmake --build .
 
 release-win64:
-	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -D STATIC=OFF -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" $(topdir) && cmake --build .
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake -D STATIC=OFF -G Ninja -D DEV_MODE=$(or ${DEV_MODE},OFF) -DQML_TESTS=${QML_TESTS} -DMANUAL_SUBMODULES=${MANUAL_SUBMODULES} -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=Release -D BUILD_TAG="win-x64" $(topdir) && cmake --build .

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -296,10 +296,10 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
     parser.addOption(disableCheckUpdatesOption);
     QCommandLineOption socksProxyOption("socks5-proxy", "Enable socks5 proxy. Used for remote node connection (advanced mode), updates downloading and fetching price sources.", "address:port");
     parser.addOption(socksProxyOption);
-    QCommandLineOption testQmlOption("test-qml");
-    testQmlOption.setFlags(QCommandLineOption::HiddenFromHelp);
+    QCommandLineOption checkQmlOption("check-qml");
+    checkQmlOption.setFlags(QCommandLineOption::HiddenFromHelp);
     parser.addOption(logPathOption);
-    parser.addOption(testQmlOption);
+    parser.addOption(checkQmlOption);
     parser.addHelpOption();
     parser.process(app);
 
@@ -557,7 +557,7 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
     }
 
     // QML loaded successfully.
-    if (parser.isSet(testQmlOption))
+    if (parser.isSet(checkQmlOption))
         return 0;
 
 #ifdef WITH_SCANNER


### PR DESCRIPTION
This avoids shipping release binaries with the test harness built in.