### PR TITLE
DaemonManager: remove detached process state listener

### DIFF
--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -120,9 +120,6 @@ bool DaemonManager::start(const QString &flags, NetworkType::Type nettype, const
     // Start monerod
     bool started = m_daemon->startDetached(m_monerod, arguments);
 
-    // add state changed listener
-    connect(m_daemon.get(), SIGNAL(stateChanged(QProcess::ProcessState)), this, SLOT(stateChanged(QProcess::ProcessState)));
-
     if (!started) {
         qDebug() << "Daemon start error: " + m_daemon->errorString();
         emit daemonStartFailure(m_daemon->errorString());
@@ -199,14 +196,6 @@ bool DaemonManager::stopWatcher(NetworkType::Type nettype, const QString &dataDi
     return false;
 }
 
-
-void DaemonManager::stateChanged(QProcess::ProcessState state)
-{
-    qDebug() << "STATE CHANGED: " << state;
-    if (state == QProcess::NotRunning) {
-        emit daemonStopped();
-    }
-}
 
 void DaemonManager::printOutput()
 {

--- a/src/daemon/DaemonManager.h
+++ b/src/daemon/DaemonManager.h
@@ -75,7 +75,6 @@ signals:
 public slots:
     void printOutput();
     void printError();
-    void stateChanged(QProcess::ProcessState state);
 
 private:
     std::unique_ptr<QProcess> m_daemon;


### PR DESCRIPTION
`startDetached()` does not update the `QProcess` state, so this signal/slot pair can never fire. Remove the dead connection and slot.

Issue: #4686